### PR TITLE
Support building gomlx_xla.tar.gz on MacOS.

### DIFF
--- a/c/BUILD
+++ b/c/BUILD
@@ -24,13 +24,19 @@ genrule(
     name = "gomlx_xla_lib",
     srcs = [
         "//gomlx:libgomlx_xla.so",
+        "@gperftools//:libtcmalloc.a",
         # "//gomlx/aot:libgomlx_xla.so",
     ],
     outs = ["lib"],
     cmd = """
     mkdir "$@"
     ln $(location //gomlx:libgomlx_xla.so) "$@"
-  """,
+    GPERFTOOLS_LIB="$$(pwd)/$$(dirname $(location @gperftools//:libtcmalloc.a))"
+    if [ -d "$$GPERFTOOLS_LIB"/lib ]; then
+      GPERFTOOLS_LIB="$$GPERFTOOLS_LIB"/lib
+    fi
+    ln "$$GPERFTOOLS_LIB"/lib* "$@"
+    """,
 )
 
 # Tar packaging: notice we force date/time and ordering to be deterministic, to generate the
@@ -50,7 +56,15 @@ genrule(
         files="$${files} $$(basename $${ii})"
     done
     echo "$${files}"
-    tar --create --dereference --directory="$${tt}" \
+    TAR=tar
+    if [[ "$$OSTYPE" == "darwin"* ]]; then
+        if ! command -v gtar &> /dev/null; then
+            echo -e "\\033[0;31mgtar (gnu-tar) cannot not be found. gnu-tar can be installed using:\nbrew install gnu-tar"
+        exit
+        fi
+        TAR=gtar
+    fi
+    $$TAR --create --dereference --directory="$${tt}" \
         --sort=name --mtime="2023-04-03 00:00Z" --owner=0 --group=0 --numeric-owner --format=gnu \
         --gzip --file "$@" $${files}
     rm -rf "$${tt}"

--- a/c/WORKSPACE
+++ b/c/WORKSPACE
@@ -46,6 +46,20 @@ http_archive(
     ],
 )
 
+
+GPERFTOOLS_VERSION = "2.10"
+
+http_archive(
+    name = "gperftools",
+    strip_prefix = "gperftools-{version}".format(version = GPERFTOOLS_VERSION),
+    build_file = "//third_party:gperftools.BUILD",
+    sha256 = "83e3bfdd28b8bcf53222c3798d4d395d52dadbbae59e8730c4a6d31a9c3732d8",
+    urls = [
+    	  "https://github.com/gperftools/gperftools/releases/download/gperftools-{version}/gperftools-{version}.tar.gz".format(version = GPERFTOOLS_VERSION),
+    ],
+)
+
+
 #http_archive(
 #    name = "org_tensorflow",
 #    add_prefix = "tensorflow",

--- a/c/gomlx/BUILD
+++ b/c/gomlx/BUILD
@@ -89,7 +89,9 @@ cc_library(
     srcs = glob(["*.cpp"]),
     hdrs = glob(["*.h"]),
     linkopts = ["-shared"],
-    deps = [] + gomlx_jit_deps,
+    deps = [
+	    "@gperftools",
+    ] + gomlx_jit_deps,
     alwayslink = True,
 )
 

--- a/c/third_party/gperftools.BUILD
+++ b/c/third_party/gperftools.BUILD
@@ -1,0 +1,24 @@
+genrule(
+    name = "run_configure_make",
+    srcs = glob(["**"]),
+    outs = ["libtcmalloc.a"],
+    cmd = """
+    export OUT="$$(pwd)/$(@D)"
+    cd external/gperftools
+    ./configure --enable-shared
+    make -j
+    echo "Copying to $$OUT"
+    ls ./.libs/libtcmalloc.*
+    cp -fv ./.libs/libtcmalloc.* "$$OUT"
+    """,
+)
+
+cc_library(
+    name = "gperftools",
+    hdrs = [
+        "src/gperftools/malloc_extension.h",
+    ],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+    alwayslink = 1,
+)


### PR DESCRIPTION
Additional building steps:
1. download gperftools
2. compile it with configure and make
3. add the generated libraries to the tar file

Use gtar (gnu-tar) on MacOS (can be installed with homebrew)