### PR TITLE
Renaming to avoid collisions; Moved libtcmalloc.* libraries to under …

### DIFF
--- a/c/BUILD
+++ b/c/BUILD
@@ -31,11 +31,13 @@ genrule(
     cmd = """
     mkdir "$@"
     ln $(location //gomlx:libgomlx_xla.so) "$@"
+
+    mkdir "$@/gomlx"
     GPERFTOOLS_LIB="$$(pwd)/$$(dirname $(location @gperftools//:libtcmalloc.a))"
     if [ -d "$$GPERFTOOLS_LIB"/lib ]; then
       GPERFTOOLS_LIB="$$GPERFTOOLS_LIB"/lib
     fi
-    ln "$$GPERFTOOLS_LIB"/lib* "$@"
+    ln "$$GPERFTOOLS_LIB"/lib* "$@/gomlx"
     """,
 )
 

--- a/c/WORKSPACE
+++ b/c/WORKSPACE
@@ -46,9 +46,8 @@ http_archive(
     ],
 )
 
-
+# gperftools with tcmalloc.
 GPERFTOOLS_VERSION = "2.10"
-
 http_archive(
     name = "gperftools",
     strip_prefix = "gperftools-{version}".format(version = GPERFTOOLS_VERSION),
@@ -58,17 +57,6 @@ http_archive(
     	  "https://github.com/gperftools/gperftools/releases/download/gperftools-{version}/gperftools-{version}.tar.gz".format(version = GPERFTOOLS_VERSION),
     ],
 )
-
-
-#http_archive(
-#    name = "org_tensorflow",
-#    add_prefix = "tensorflow",
-#    sha256 = "af0584df1a4e28763c32c218b39f8c4f3784fabb6a8859b00c02d743864dc191",
-#    strip_prefix = "tensorflow-2.12.0",
-#    urls = [
-#        "https://github.com/tensorflow/tensorflow/archive/v2.12.0.zip",
-#    ],
-#)
 
 # Create @tsl repository.
 load("@xla//third_party:repo.bzl", "tf_vendored")

--- a/c/gomlx/BUILD
+++ b/c/gomlx/BUILD
@@ -56,7 +56,7 @@ gomlx_jit_deps = [
     "@xla//xla/stream_executor:rocm_platform",
 ])
 
-# Minimal set of dependencies needed to run inference in a AOT compiled model.
+# Minimal set of dependencies needed to run inference in an Ahead-Of-Time (AOT) compiled model.
 gomlx_aot_deps = [
     "@com_google_absl//absl/types:span",
     "@com_google_absl//absl/types:optional",
@@ -89,24 +89,24 @@ cc_library(
     srcs = glob(["*.cpp"]),
     hdrs = glob(["*.h"]),
     linkopts = ["-shared"],
-    deps = [
-	    "@gperftools",
-    ] + gomlx_jit_deps,
+    deps = gomlx_jit_deps + [
+        "@gperftools",
+    ],
     alwayslink = True,
 )
 
 cc_binary(
     name = "libgomlx_xla.so",
-    linkopts = ["-shared"],
+    linkopts = ["-shared", "-ltcmalloc"],
     # Setting linkshared=1 and linkstatic=1 should try to link everything (except system libraries) statically
     # but generate a dynamically linked library -- needed to link it to other languages, Go in this case.
     # At least that's what I understood from reading the docs in
     # https://bazel.build/reference/be/c-cpp#cc_binary.linkshared
     linkshared = 1,
     linkstatic = 1,
-    deps = [
+    deps = gomlx_jit_deps + [
         ":gomlx",
-    ] + gomlx_jit_deps,
+    ]
 )
 
 cc_library(
@@ -128,7 +128,9 @@ cc_library(
         "status.h",
     ],
     linkopts = ["-shared"],
-    deps = [] + gomlx_aot_deps,
+    deps = [
+        "@gperftools",
+    ] + gomlx_aot_deps,
     alwayslink = True,
 )
 

--- a/c/third_party/gperftools.BUILD
+++ b/c/third_party/gperftools.BUILD
@@ -1,5 +1,7 @@
+# Runs ./configure and ./make -- gperftools doesn't support Bazel.
+# See more in https://github.com/gperftools/gperftools/issues/800
 genrule(
-    name = "run_configure_make",
+    name = "gperftools_run_configure_make",
     srcs = glob(["**"]),
     outs = ["libtcmalloc.a"],
     cmd = """
@@ -13,10 +15,12 @@ genrule(
     """,
 )
 
+# This rule exposes the header files used by GoMLX.
 cc_library(
     name = "gperftools",
     hdrs = [
         "src/gperftools/malloc_extension.h",
+        "src/gperftools/heap-checker.h",
     ],
     includes = ["src"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
To make sure installing `gomlx_xla.tar.gz`  won't overwrite some pre-installed `libtcmalloc`.

See #23 ; CC: @tdegris 