### PR TITLE
C++ deps work arounds

### DIFF
--- a/c/gomlx/BUILD
+++ b/c/gomlx/BUILD
@@ -5,13 +5,14 @@ load("@tsl//tsl:tsl.bzl", "if_cuda_or_rocm")
 
 # Dependencies needed for Just-In-Time (JIT) compilation: what we use for training.
 gomlx_jit_deps = [
+    # "@xla//xla/mlir/utils:error_util", Temporarily replaced by:
+    "//third_party/xla_mlir:error_util",
     "@com_google_absl//absl/types:span",
     "@com_google_absl//absl/types:optional",
     "@com_google_absl//absl/base:log_severity",
     "@xla//xla:comparison_util",
     "@xla//xla:literal",
     "@xla//xla:shape_util",
-    "@xla//xla/mlir/utils:error_util",
     "@xla//xla:status",
     "@xla//xla:statusor",
     "@xla//xla:types",

--- a/c/gomlx/aot_compile.cpp
+++ b/c/gomlx/aot_compile.cpp
@@ -53,7 +53,6 @@
 #include "xla/execution_options_util.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/literal.h"
-#include "xla/mlir/utils/error_util.h"
 #include "xla/mlir_hlo/mhlo/transforms/passes.h"
 #include "xla/service/compiler.h"
 #include "xla/service/cpu/cpu_compiler.h"
@@ -70,6 +69,10 @@
 #include "xla/translate/hlo_to_mhlo/hlo_to_mlir_hlo.h"
 #include "xla/types.h"
 #include "xla/xla_data.pb.h"
+
+// Temporarily replacing:
+// #include "xla/mlir/utils/error_util.h"
+#include "third_party/xla_mlir/error_util.h"
 
 using namespace std;
 
@@ -104,7 +107,7 @@ xla::StatusOr<mlir::ModuleOp> ConvertXlaComputationToStableHLOImplementation(
     return status;
   }
 
-  mlir::BaseScopedDiagnosticHandler diagnostic(&context); // Error collector.
+  mlir::TmpBaseScopedDiagnosticHandler diagnostic(&context); // Error collector.
   if (!mlir::verify(module).succeeded()) {
     return tsl::FromAbslStatus(diagnostic.ConsumeStatus());
   }
@@ -182,7 +185,7 @@ StatusOr UnserializeStableHLO(VectorData *serialized) {
   StatusOr r{0, 0};
   std::unique_ptr<StableHLOHolder> holder(new StableHLOHolder());
   holder->context.reset(new mlir::MLIRContext());
-  mlir::BaseScopedDiagnosticHandler diagnostic(
+  mlir::TmpBaseScopedDiagnosticHandler diagnostic(
       holder->context.get()); // Error collector.
   mlir::OwningOpRef<mlir::ModuleOp> module =
       mlir::stablehlo::deserializePortableArtifact(

--- a/c/gomlx/literal.cpp
+++ b/c/gomlx/literal.cpp
@@ -109,8 +109,8 @@ Literal *MakeLiteralTuple(Literal **elements, int num_elements) {
     literals.push_back(elements[ii]->literal);
   }
   free(elements);
-  return XlaLiteralToLiteral(
-      new xla::Literal(std::move(xla::LiteralUtil::MakeTuple(literals))));
+  auto tuple = xla::LiteralUtil::MakeTuple(literals);
+  return XlaLiteralToLiteral(new xla::Literal(std::move(tuple)));
 }
 
 void XlaLiteralRefreshData(Literal *literal) {

--- a/c/third_party/xla_mlir/BUILD
+++ b/c/third_party/xla_mlir/BUILD
@@ -1,0 +1,15 @@
+load("@tsl//tsl:tsl.default.bzl", "get_compatible_with_portable")
+load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
+
+cc_library(
+    name = "error_util",
+    srcs = ["error_util.cc"],
+    hdrs = ["error_util.h"],
+    #    compatible_with = get_compatible_with_portable(),
+    deps = [
+        "@com_google_absl//absl/status",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@tsl//tsl/platform:errors",
+    ],
+)

--- a/c/third_party/xla_mlir/README.md
+++ b/c/third_party/xla_mlir/README.md
@@ -1,0 +1,4 @@
+Since in some platforms where GoMLX the `xla/mlir/utils` directory is not available,
+we include the file here.
+
+Hopefully this is a temporary solution.

--- a/c/third_party/xla_mlir/error_util.cc
+++ b/c/third_party/xla_mlir/error_util.cc
@@ -1,0 +1,87 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// #include "xla/mlir/utils/error_util.h"
+#include "third_party/xla_mlir/error_util.h"
+
+#include <string>
+#include <string_view>
+
+#include "tsl/platform/errors.h"
+#include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/IR/Diagnostics.h"  // from @llvm-project
+
+namespace mlir {
+TmpBaseScopedDiagnosticHandler::TmpBaseScopedDiagnosticHandler(MLIRContext* context,
+                                                         bool propagate,
+                                                         bool filter_stack)
+    : SourceMgrDiagnosticHandler(source_mgr_, context, diag_stream_),
+      diag_stream_(diag_str_),
+      propagate_(propagate) {}
+
+TmpBaseScopedDiagnosticHandler::~TmpBaseScopedDiagnosticHandler() {
+  // Verify errors were consumed and re-register old handler.
+  bool all_errors_produced_were_consumed = ok();
+  DCHECK(all_errors_produced_were_consumed) << "Error status not consumed:\n"
+                                            << diag_str_;
+}
+
+bool TmpBaseScopedDiagnosticHandler::ok() const { return diag_str_.empty(); }
+
+absl::Status TmpBaseScopedDiagnosticHandler::ConsumeStatus() {
+  if (ok()) return absl::OkStatus();
+
+  // TODO(jpienaar) This should be combining status with one previously built
+  // up.
+  absl::Status s = absl::UnknownError(diag_str_);
+  diag_str_.clear();
+  return s;
+}
+
+absl::Status TmpBaseScopedDiagnosticHandler::Combine(absl::Status status) {
+  if (status.ok()) return ConsumeStatus();
+
+  // status is not-OK here, so if there was no diagnostics reported
+  // additionally then return this error.
+  if (ok()) return status;
+
+  // Append the diagnostics reported to the status. This repeats the behavior of
+  // TensorFlow's AppendToMessage without the additional formatting inserted
+  // there.
+  std::string str_status_message(status.message());
+  status = absl::Status(status.code(), str_status_message + diag_str_);
+  diag_str_.clear();
+
+  return status;
+}
+
+LogicalResult TmpBaseScopedDiagnosticHandler::handler(Diagnostic* diag) {
+  size_t current_diag_str_size_ = diag_str_.size();
+
+  // Emit the diagnostic and flush the stream.
+  emitDiagnostic(*diag);
+  diag_stream_.flush();
+
+  // Emit non-errors to VLOG instead of the internal status.
+  if (diag->getSeverity() != DiagnosticSeverity::Error) {
+    VLOG(1) << diag_str_.substr(current_diag_str_size_);
+    diag_str_.resize(current_diag_str_size_);
+  }
+
+  // Return failure to signal propagation if necessary.
+  return failure(propagate_);
+}
+
+}  // namespace gomlx_mlir

--- a/c/third_party/xla_mlir/error_util.h
+++ b/c/third_party/xla_mlir/error_util.h
@@ -1,0 +1,79 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Renamed as we made a local copy of error_util.c into GoMLX.
+//
+// --> It also required s/BaseScopedDiagnosticHandler/TmpBaseScopedDiagnosticHandler
+//     for some obscure C++ reason -- useless GCC output.
+//#ifndef XLA_MLIR_UTILS_ERROR_UTIL_H_
+//#define XLA_MLIR_UTILS_ERROR_UTIL_H_
+#ifndef THIRD_PARTY_XLA_MLIR_ERROR_UTIL_H_
+#define THIRD_PARTY_XLA_MLIR_ERROR_UTIL_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/Diagnostics.h"  // from @llvm-project
+#include "mlir/IR/Location.h"  // from @llvm-project
+#include "mlir/IR/MLIRContext.h"  // from @llvm-project
+
+// Error utilities for MLIR when interacting with code using Status returns.
+// Temporarily renamed namespace to gomlx_mlir.
+namespace mlir {
+// Diagnostic handler that collects all the diagnostics reported and can
+// produce a Status to return to callers. This is for the case where MLIR
+// functions are called from a function that will return a Status: MLIR code
+// still uses the default error reporting, and the final return function can
+// return the Status constructed from the diagnostics collected.
+class TmpBaseScopedDiagnosticHandler : public SourceMgrDiagnosticHandler {
+ public:
+  explicit TmpBaseScopedDiagnosticHandler(MLIRContext* context,
+                                       bool propagate = false,
+                                       bool filter_stack = false);
+  // On destruction error consumption is verified.
+  ~TmpBaseScopedDiagnosticHandler();
+  // Returns whether any errors were reported.
+  bool ok() const;
+
+  // Returns Status corresponding to the diagnostics reported. This consumes
+  // the diagnostics reported and returns a Status of type Unknown. It is
+  // required to consume the error status, if there is one, before destroying
+  // the object.
+  absl::Status ConsumeStatus();
+
+  // Returns the combination of the passed in status and consumed diagnostics.
+  // This consumes the diagnostics reported and either appends the diagnostics
+  // to the error message of 'status' (if 'status' is already an error state),
+  // or returns an Unknown status (if diagnostics reported), otherwise OK.
+  absl::Status Combine(absl::Status status);
+
+ protected:
+  LogicalResult handler(Diagnostic* diag);
+
+  // String stream to assemble the final error message.
+  std::string diag_str_;
+  llvm::raw_string_ostream diag_stream_;
+
+  // A SourceMgr to use for the base handler class.
+  llvm::SourceMgr source_mgr_;
+
+  // Whether to propagate diagnostics to the old diagnostic handler.
+  bool propagate_;
+};
+}  // namespace mlir
+
+#endif  // XLA_MLIR_UTILS_ERROR_UTIL_H_

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 * Workaround small C++ copy elision limitation from clang.
+* Temporarily copied `xla/mlir/utils` library to `third-party/xla_mlir`, since it is not available in all XLA distributions.
 
 ## v0.7.2 - 2023/10/27
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GoMLX changelog
 
+## Next
+
+* Workaround small C++ copy elision limitation from clang.
+
 ## v0.7.2 - 2023/10/27
 
 * Fixed C/C++ mismatching malloc/new/new[] and free/delete/delete[].


### PR DESCRIPTION
* Workaround small C++ copy elision limitation from clang.
* Temporarily copied `xla/mlir/utils` library to `third-party/xla_mlir`, since it is not available in all XLA distributions.
