### PR TITLE
Fixes on Tensor.DonateBuffer and Tensor.MaterializeOnDevices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Package `graph`:
   * Added `ExecOnce` and `ExecOnceN` 
   * Added `CumSum`
+* Package `tensors`:
+  * Fixed race condition `Tensor.DonateBuffer`.
+  * Fixed unnecessary copying of tensor data in `Tensor.MaterializeOnDevices`
 * Small fixes to documentation.
 
 ## 0.11.0 BREAKING CHANGE: Multi-Backend support; Added XLA/PJRT support (with gopjrt); meaningful speed ups; No more C code (all goes through gopjrt) 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -481,7 +481,16 @@ func (g *Graph) RunWithBuffers(inputs []backends.Buffer, donate []bool) (outputs
 	if len(donate) != numParams {
 		exceptions.Panicf("graph %q takes %d donate values for the input parameters, but %d were given to RunWithBuffers()", g.name, numParams, len(donate))
 	}
-	results := g.executable.Execute(inputs, donate)
+	var start time.Time
+	var results []backends.Buffer
+	if klog.V(1).Enabled() {
+		start = time.Now()
+		results = g.executable.Execute(inputs, donate)
+		elapsed := time.Since(start)
+		klog.V(1).Infof("Graph.RunWithBuffers: %s elapsed", elapsed)
+	} else {
+		results = g.executable.Execute(inputs, donate)
+	}
 	for ii, wasDonated := range donate {
 		if wasDonated {
 			g.backend.BufferFinalize(inputs[ii])

--- a/types/tensors/tensor.go
+++ b/types/tensors/tensor.go
@@ -162,7 +162,11 @@ func (t *Tensor) FinalizeAll() {
 	// Get the list of local and device tensors to finalize.
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.lockedFinalizeAll()
+}
 
+// lockedFinalizeAll is FinalizeAll but must be called with the tensor already locked.
+func (t *Tensor) lockedFinalizeAll() {
 	if t == nil {
 		t.mu.Unlock()
 		return


### PR DESCRIPTION
* Package `tensors`
  * Fixed race condition `Tensor.DonateBuffer`.
  * Fixed unnecessary copying of tensor data in `Tensor.MaterializeOnDevices`