### PR TITLE
* `graph.Scalar()` is now generic, and takes as input any non-complex…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 * Added `Shape.Dim(axis)` as a shortcut, where `axis` can use negative values.
+* `graph.Scalar()` is now generic, and takes as input any non-complex number type, for improved convenience.
 
 ## v0.11.3 - 2023/08/29
 

--- a/graph/ops_util.go
+++ b/graph/ops_util.go
@@ -26,8 +26,12 @@ import (
 // This file contains derived practical calculations that often used.
 
 // Scalar returns a constant scalar with the given value.
-func Scalar(g *Graph, dtype dtypes.DType, value float64) *Node {
-	return g.getScalarConst(dtype, value)
+//
+// The value is first converted to float64 to serve as index to a cache and later converted to the requested dtype.
+// This may lose bits of precision to very large integers.
+// If you are worried with any of these conversions, use Const instead.
+func Scalar[N dtypes.NumberNotComplex](g *Graph, dtype dtypes.DType, value N) *Node {
+	return g.getScalarConst(dtype, float64(value))
 }
 
 // FillScalar creates a Node with a value with the given shape, filled with the given value.

--- a/graph/ops_util_test.go
+++ b/graph/ops_util_test.go
@@ -10,6 +10,25 @@ import (
 	"testing"
 )
 
+func TestScalar(t *testing.T) {
+	graphtest.RunTestGraphFn(t, "EinsumMatrixMul",
+		func(g *Graph) (inputs, outputs []*Node) {
+			inputs = []*Node{
+				Scalar(g, dtypes.Float32, uint8(3)),
+				Scalar(g, dtypes.Float64, int16(-2)),
+				Scalar(g, dtypes.Int64, float32(7)),
+				Scalar(g, dtypes.Uint8, float64(3)),
+			}
+			outputs = inputs
+			return
+		}, []any{
+			float32(3),
+			float64(-2),
+			int64(7),
+			uint8(3),
+		}, -1)
+}
+
 func TestEinsum(t *testing.T) {
 	graphtest.RunTestGraphFn(t, "EinsumMatrixMul",
 		func(g *Graph) (inputs, outputs []*Node) {


### PR DESCRIPTION
… number type, for improved convenience.