### PR TITLE
Node Aliases

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,9 @@
   * More unit tests.
   * Aliases nodes: allow setting aliases to nodes, and to retrieve them by those aliases. Useful for layers
     or models to export intermediary nodes by their aliases. They are prefixed by scope. New methods are:
-    `Node.SetAlias`, `Graph.GetNodeByAlias`, `Graph.PushAliasScope`, `Graph.PopAliasScope` and `Graph.IterAliasedNodes`.
+    `Node.WithAlias`, `Node.GetAlias`, `Graph.GetNodeByAlias`, `Graph.PushAliasScope`, `Graph.PopAliasScope` 
+    and `Graph.IterAliasedNodes`.
+  * Added optional aliases nodes for `inceptionv3` model.
 
 # v0.16.1 - 🎄 2024/12/19 🎄 MatMul fixes
 * MatMul fixed for some edge shape configuration and greatly accelerated in some cases.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,24 +3,30 @@
 # Next
 
 * Added "Flow Matching" examples/demo.
-* Added `layers.DropBlock`, a type of dropout for images.
-* Added `layers.DropPath` and `layers.DropPathFromContext`, a type of dropout used in Residual connections, to drop full paths.
+* Package `layers`:
+  * Added `layers.DropBlock`, a type of dropout for images.
+  * Added `layers.DropPath` and `layers.DropPathFromContext`, a type of dropout used in Residual connections, to drop full paths.
+  * `layers.LayerNormalization`:
+    * up-scale precision by default if input is a Float16 or BFloat16. Low-precision
+      lead to NaNs when reducing values for normalization. Added also a hyperparameter to configure normalization DType.
 * Added `Context.RandomBenoulli` to sample from a Bernoulli (binary) distribution.
 * Correctly pretty-print Float16 and BFloat16 tensors.
-* Fixed nanlogger for Float16 and BFloat16; Also, it first prints other logged tensors, before failing with a NaN.
 * Several fixes and small improvements to command-line tool `gomlx_checkpoint`.
-* `nanlogger`:
+* Package `nanlogger`:
   * Store only the stack-trace, and trim the stack into the nanlogger package.
   * Does not exit, simply report the NanLogger. User can define a handler, if they want the training to exit.
   * Use `IsFinite` to check for NaN and Infs: but we loose the type of NaN that happened.  
-* `layers.LayerNormalization`: 
-  * up-scale precision by default if input is a Float16 or BFloat16. Low-precision
-    lead to NaNs when reducing values for normalization. Added also a hyperparameter to configure normalization DType.
+  * Fixed nanlogger for Float16 and BFloat16; Also, it first prints other logged tensors, before failing with a NaN.
 * Package `losses`: 
   * Added `ParamLoss`: hyperparameter to define the loss, and many constant values.
   * Added `LossFromContext`, using `ParamLoss` hyperparameter. 
   * Added `MakeHuberLossFromContext`
   * Added experimental `MakeAdaptivePowerLoss` and `MakeAdaptivePowerLossFromContext`
+* Package `graph`:
+  * More unit tests.
+  * Aliases nodes: allow setting aliases to nodes, and to retrieve them by those aliases. Useful for layers
+    or models to export intermediary nodes by their aliases. They are prefixed by scope. New methods are:
+    `Node.SetAlias`, `Graph.GetNodeByAlias`, `Graph.PushAliasScope`, `Graph.PopAliasScope` and `Graph.IterAliasedNodes`.
 
 # v0.16.1 - 🎄 2024/12/19 🎄 MatMul fixes
 * MatMul fixed for some edge shape configuration and greatly accelerated in some cases.

--- a/graph/node.go
+++ b/graph/node.go
@@ -55,6 +55,9 @@ type Node struct {
 	// inputs need to be
 	inputs NodeInputs
 
+	// alias is a name by which the Node be referred in the Graph.
+	alias string
+
 	// logMessage is set if node is marked for logging.
 	logMessage string
 

--- a/graph/node.go
+++ b/graph/node.go
@@ -202,10 +202,13 @@ func (n *Node) String() (str string) {
 	if n.graph == nil || !n.graph.IsValid() {
 		return "Node(invalid graph)"
 	}
+	if n.alias != "" {
+		str = fmt.Sprintf("[%q] ", n.alias)
+	}
 	if n.Type() == NodeTypeInvalid {
-		str = "Invalid(?)"
+		str += "Invalid(?)"
 	} else {
-		str = n.inputs.String()
+		str += n.inputs.String()
 	}
 
 	parts := []string{str}

--- a/graph/node_aliases.go
+++ b/graph/node_aliases.go
@@ -51,6 +51,12 @@ func (n *Node) WithAlias(alias string) *Node {
 	return n
 }
 
+// GetAlias returns the alias (with the absolute path) of the current node, if one was registered
+// with Node.WithAlias, otherwise returns "".
+func (n *Node) GetAlias() string {
+	return n.alias
+}
+
 // AliasScopeSeparator is the string used to join the individual alias scope parts as well as
 // the alias itself. So if the scope is currently ["a", "b"] and an alias "output" is created,
 // it will be renamed "/a/b/output".

--- a/graph/node_aliases.go
+++ b/graph/node_aliases.go
@@ -1,0 +1,117 @@
+package graph
+
+import (
+	"fmt"
+	"github.com/gomlx/exceptions"
+	"iter"
+	"strings"
+)
+
+// PushAliasScope pushes another scope to the current alias scope for new aliases.
+//
+// For instance, for an image model, one may want to push a scope per layer, and create
+// an alias "output" to the node with the output of the layer. The different scope helps
+// differentiate the different "output" aliases nodes.
+//
+// Notice this is orthogonal to the context.Context scope used for variables.
+// That's because for instance, one may reuse a model multiple times for different inputs (e.g.: triplet loss
+// will use the same model for the "anchor", "positive" and "negative" examples, or a style transfer model
+// will use the same embedding model for the "source", "style" and "target" images), so the variables context
+// scope is the same, but we want a different alias scope, so we can access the outputs per layer of each
+// type of the example separately.
+//
+// Each call to Graph.PushAliasScope should be matched by a call to Graph.PopAliasScope, usually using defer.
+func (g *Graph) PushAliasScope(scope string) {
+	g.aliasScope = append(g.aliasScope, scope)
+}
+
+// PopAliasScope removes the scope previously pushed with PushAliasScope.
+//
+// It panics if there are no scopes pushed.
+func (g *Graph) PopAliasScope() {
+	if len(g.aliasScope) == 0 {
+		exceptions.Panicf("no scopes pushed when calling Graph.PopAliasScope")
+	}
+	g.aliasScope = g.aliasScope[:len(g.aliasScope)-1]
+}
+
+// WithAlias sets an alias in the Graph for the node.
+// It allows it to be retrieved with Graph.GetNodeByAlias.
+//
+// The alias is automatically prefixed with the Graph current "alias scope", see Graph.PushAliasScope and
+// Graph.PopAliasScope. Except if the alias starts with AliasScopeSeparator ("/"), in which case it is
+// assumed to be given with an "absolute scope path".
+//
+// It returns the Node itself, to allow cascading method calling.
+//
+// It panics if the exact same alias already exists.
+func (n *Node) WithAlias(alias string) *Node {
+	n.Graph().insertNodeAlias(n, alias)
+	return n
+}
+
+// AliasScopeSeparator is the string used to join the individual alias scope parts as well as
+// the alias itself. So if the scope is currently ["a", "b"] and an alias "output" is created,
+// it will be renamed "/a/b/output".
+const AliasScopeSeparator = "/"
+
+// absoluteAlias returns an alias with an absolute path, by prepending the current scope.
+//
+// If alias is absolute (starts with "/") it is not changed.
+func (g *Graph) absoluteAlias(alias string) string {
+	if strings.HasPrefix(alias, AliasScopeSeparator) {
+		return alias
+	}
+	// Prepend alias with current scope.
+	if len(g.aliasScope) == 0 {
+		return fmt.Sprintf("%s%s", AliasScopeSeparator, alias)
+	}
+	return fmt.Sprintf("%s%s%s%s",
+		AliasScopeSeparator, strings.Join(g.aliasScope, AliasScopeSeparator), AliasScopeSeparator, alias)
+}
+
+// insertNodeAlias will prepend the given alias with the current scope (separated by "/") and
+func (g *Graph) insertNodeAlias(n *Node, alias string) {
+	alias = g.absoluteAlias(alias)
+	if _, found := g.aliasToNode[alias]; found {
+		exceptions.Panicf("alias already exists in Node.WithAlias(%q) -- they must be unique within the scope (path) they are defined",
+			alias)
+	}
+	n.alias = alias
+	g.aliasToNode[alias] = n
+}
+
+// GetNodeByAlias returns a node with the given alias or nil if it didn't find it.
+//
+// If the search alias has an absolute scope (path), meaning if it starts with AliasScopeSeparator,
+// it is searched as is. If not, it is prefixed with the current scope before searching.
+//
+// See Node.WithAlias to create node aliases, and Graph.PushAliasScope and Graph.PopAliasScope to
+// manipulate the scope of the aliases created.
+func (g *Graph) GetNodeByAlias(alias string) *Node {
+	alias = g.absoluteAlias(alias)
+	return g.aliasToNode[alias]
+}
+
+// IterAliasedNodes provides an iterator over all aliased nodes. It yields pairs (alias, node).
+func (g *Graph) IterAliasedNodes() iter.Seq2[string, *Node] {
+	items := make([]struct {
+		Alias string
+		Node  *Node
+	}, 0, len(g.aliasToNode))
+	for alias, node := range g.aliasToNode {
+		items = append(items, struct {
+			Alias string
+			Node  *Node
+		}{Alias: alias, Node: node})
+	}
+	return func(yield func(string, *Node) bool) {
+		for _, pair := range items {
+			next := yield(pair.Alias, pair.Node)
+			if !next {
+				return
+			}
+		}
+		return
+	}
+}

--- a/graph/node_aliases.go
+++ b/graph/node_aliases.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/gomlx/exceptions"
 	"iter"
+	"slices"
 	"strings"
 )
 
@@ -94,17 +95,19 @@ func (g *Graph) GetNodeByAlias(alias string) *Node {
 }
 
 // IterAliasedNodes provides an iterator over all aliased nodes. It yields pairs (alias, node).
+// The aliases are sorted before iteration.
 func (g *Graph) IterAliasedNodes() iter.Seq2[string, *Node] {
-	items := make([]struct {
+	type Item struct {
 		Alias string
 		Node  *Node
-	}, 0, len(g.aliasToNode))
-	for alias, node := range g.aliasToNode {
-		items = append(items, struct {
-			Alias string
-			Node  *Node
-		}{Alias: alias, Node: node})
 	}
+	items := make([]Item, 0, len(g.aliasToNode))
+	for alias, node := range g.aliasToNode {
+		items = append(items, Item{alias, node})
+	}
+	slices.SortFunc(items, func(a, b Item) int {
+		return strings.Compare(a.Alias, b.Alias)
+	})
 	return func(yield func(string, *Node) bool) {
 		for _, pair := range items {
 			next := yield(pair.Alias, pair.Node)

--- a/graph/node_aliases_test.go
+++ b/graph/node_aliases_test.go
@@ -1,0 +1,54 @@
+package graph_test
+
+import (
+	"fmt"
+	. "github.com/gomlx/gomlx/graph"
+	"github.com/gomlx/gomlx/graph/graphtest"
+	"github.com/gomlx/gomlx/types"
+	"github.com/gomlx/gopjrt/dtypes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeAliases(t *testing.T) {
+	backend := graphtest.BuildTestBackend()
+	g := NewGraph(backend, "Graph With Aliases")
+
+	// Create some nodes
+	n1 := ScalarZero(g, dtypes.Float32)
+	n2 := ScalarOne(g, dtypes.Float32)
+
+	// Test adding aliases
+	n1.WithAlias("n1")
+	n2.WithAlias("n2")
+
+	assert.Equal(t, n1, g.GetNodeByAlias("n1"))
+	assert.Equal(t, n2, g.GetNodeByAlias("n2"))
+	assert.Nil(t, g.GetNodeByAlias("n3"), "Node with alias 'n3' should not exist yet")
+
+	// Test alias scopes
+	g.PushAliasScope("scope1")
+	n3 := Add(n1, n2)
+	n3.WithAlias("n3")
+	assert.Equal(t, n3, g.GetNodeByAlias("/scope1/n3"))
+	assert.Equal(t, n3, g.GetNodeByAlias("n3"))
+	assert.Nil(t, g.GetNodeByAlias("n1"))         // "n1" doesn't exist in this scope.
+	assert.True(t, n1 == g.GetNodeByAlias("/n1")) // But it still exists in the global scope.
+
+	// Test IterAliasedNodes:
+	aliases := types.MakeSet[string]()
+	for alias, node := range g.IterAliasedNodes() {
+		fmt.Printf("\tGraph[%q] = %s\n", alias, node)
+		aliases.Insert(alias)
+	}
+	assert.Len(t, aliases, 3)
+	assert.True(t, aliases.Has("/n1"))
+	assert.True(t, aliases.Has("/n2"))
+	assert.True(t, aliases.Has("/scope1/n3"))
+
+	// Test popping alias scope
+	g.PopAliasScope()
+	assert.Equal(t, n3, g.GetNodeByAlias("/scope1/n3")) // "/scope1/n3" still exists.
+	assert.True(t, g.GetNodeByAlias("n3") == nil)       // But it is now on a different context.
+}


### PR DESCRIPTION
  * Aliases nodes: allow setting aliases to nodes, and to retrieve them by those aliases. Useful for layers
    or models to export intermediary nodes by their aliases. They are prefixed by scope. New methods are:
    `Node.WithAlias`, `Node.GetAlias`, `Graph.GetNodeByAlias`, `Graph.PushAliasScope`, `Graph.PopAliasScope` 
    and `Graph.IterAliasedNodes`.
  * Added optional aliases nodes for `inceptionv3` model.
