### PR TITLE
Mnist - Notebook

### DIFF
--- a/examples/mnist/classifier/classifier.go
+++ b/examples/mnist/classifier/classifier.go
@@ -1,4 +1,4 @@
-// Package classifier is a MNIST classifier.
+// Package classifier is a MNIST-based digit classifier.
 // It loads a pre-trained model and offers a Classify method that will classify any image,
 // by first resizing it to the model's input size.
 //

--- a/examples/mnist/classifier/classifier.go
+++ b/examples/mnist/classifier/classifier.go
@@ -1,0 +1,89 @@
+// Package classifier is a Cifar-10 classifier.
+// It loads a pre-trained model and offers a Classify method that will classify any image,
+// by first resizing it to the model's input size.
+//
+// To use it, create a Classifier with New(), and then simply call its Classify method with a 32x32 image.
+//
+// This is an example of how to serve a model for inference.
+package classifier
+
+import (
+	"image"
+
+	"github.com/gomlx/exceptions"
+	"github.com/gomlx/gomlx/backends"
+	"github.com/gomlx/gomlx/examples/mnist"
+	"github.com/gomlx/gomlx/graph"
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/gomlx/gomlx/ml/context/checkpoints"
+	"github.com/gomlx/gomlx/types/tensors"
+	"github.com/gomlx/gomlx/types/tensors/images"
+	"github.com/gomlx/gopjrt/dtypes"
+	"github.com/pkg/errors"
+)
+
+// Classifier holds the MNIST model compiled.
+// It will use XLA with GPU if available or CPU by default. But the backend can be configured with GOMLX_BACKEND.
+type Classifier struct {
+	// backend is created with defaults, which uses GOMLX_BACKEND if it is set.
+	backend backends.Backend
+
+	// ctx with the model's weights.
+	ctx *context.Context
+
+	// exec is used to execute the model with a context.
+	exec *context.Exec
+}
+
+// New creates a new Classifier object that can be used to classify images using a MNIST model.
+func New(checkpointDir string) (*Classifier, error) {
+	c := &Classifier{
+		backend: backends.New(),
+		ctx:     context.New(),
+	}
+
+	// Notice all hyperparameters are read from the checkpoint as well, so it will be build the
+	// same model.
+	// We don't need to keep the checkpoint handler around, since we are not going to use it to save.
+	_, err := checkpoints.Load(c.ctx).
+		Dir(checkpointDir).
+		Done()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed while loading MNIST model from %q", checkpointDir)
+	}
+	c.ctx = c.ctx.Reuse() // Mark it to reuse variables: it will be an error to create a new variable -- for extra sanity checking.
+
+	modelType := context.GetParamOr(c.ctx, "model", "")
+	modelFn, ok := mnist.Models[modelType]
+	if !ok {
+		return nil, errors.WithMessagef(err, "cannot build model from checkpoint %q, invalid model type %s", checkpointDir, modelType)
+	}
+
+	// Create model executor.
+	c.exec = context.NewExec(c.backend, c.ctx.In("model"), func(ctx *context.Context, image *graph.Node) (choice *graph.Node) {
+		// We take the first result from the modelFn -- it returns a slice.
+		image = graph.ExpandAxes(image, 0) // Create a batch dimension of size 1.
+		logits := modelFn(ctx, nil, []*graph.Node{image})[0]
+		// Take the class with highest logit value.
+		choice = graph.ArgMax(logits, -1, dtypes.Int32)
+		// Remove batch dimension.
+		choice = graph.Reshape(choice) // No dimensions given, means a scalar.
+		return
+	})
+	return c, nil
+}
+
+// Classify takes a 28x28 image and returns a MNIST classification according to the models.
+// The returned class is from 0 to 9.
+//
+// TODO: resize image to 32x32, used by the model.
+func (c *Classifier) Classify(img image.Image) (int32, error) {
+	input := images.ToTensor(dtypes.Float32).Single(img)
+	var outputs []*tensors.Tensor
+	err := exceptions.TryCatch[error](func() { outputs = c.exec.Call(input) })
+	if err != nil {
+		return 0, err
+	}
+	classID := tensors.ToScalar[int32](outputs[0]) // Convert tensor to Go value.
+	return classID, nil
+}

--- a/examples/mnist/dataset.go
+++ b/examples/mnist/dataset.go
@@ -47,6 +47,7 @@ const (
 	TestLabelsFilename  = "t10k-labels-idx1-ubyte.gz"
 	Width               = 28
 	Height              = 28
+	Depth               = 3
 	NumClasses          = 10
 	TrainExamples       = 60000
 	TestExamples        = 10000

--- a/examples/mnist/demo/demo.go
+++ b/examples/mnist/demo/demo.go
@@ -34,8 +34,6 @@ import (
 var (
 	flagTrain      = flag.Bool("train", true, "Flag to train")
 	flagDownload   = flag.Bool("download", false, "Flag to download")
-	flagModel      = flag.String("model", "linear", "Model function")
-	flagLoss       = flag.String("loss", "cross-entropy", "Loss function")
 	flagDataDir    = flag.String("data", "~/tmp/mnist", "Directory to cache downloaded dataset.")
 	flagCheckpoint = flag.String("checkpoint", "", "Checkpoint directory from/to where to load/save the trained model. Path is relative to --data.")
 )
@@ -51,7 +49,7 @@ func main() {
 		klog.Infof("Data downloaded in %s", *flagDataDir)
 	}
 	if *flagTrain {
-		must.M(mnist.TrainModel(ctx, *flagDataDir, *flagCheckpoint, *flagModel, *flagLoss, paramsSet))
+		must.M(mnist.TrainModel(ctx, *flagDataDir, *flagCheckpoint, paramsSet))
 	}
 	if !*flagDownload && !*flagTrain {
 		klog.Info("exit: usage -download and/or -train, optional -data")

--- a/examples/mnist/demo/demo.go
+++ b/examples/mnist/demo/demo.go
@@ -31,6 +31,8 @@ import (
 	_ "github.com/gomlx/gomlx/backends/xla"
 )
 
+// Example usage:  go run demo.go -train -checkpoint=cnn -set="model=cnn;loss=triplet;triplet_loss_mining_strategy=hard;triplet_loss_margin=0.1" 
+
 var (
 	flagTrain      = flag.Bool("train", true, "Flag to train")
 	flagDownload   = flag.Bool("download", false, "Flag to download")

--- a/examples/mnist/demo/demo.go
+++ b/examples/mnist/demo/demo.go
@@ -31,12 +31,12 @@ import (
 	_ "github.com/gomlx/gomlx/backends/xla"
 )
 
-// Example usage:  go run demo.go -train -checkpoint=cnn -set="model=cnn;loss=triplet;triplet_loss_mining_strategy=hard;triplet_loss_margin=0.1" 
+// Example usage:  go run demo.go -train -checkpoint=cnn_triplet_hard_01 -set="model=cnn;loss=triplet;triplet_loss_mining_strategy=hard;triplet_loss_margin=0.1"
 
 var (
 	flagTrain      = flag.Bool("train", true, "Flag to train")
 	flagDownload   = flag.Bool("download", false, "Flag to download")
-	flagDataDir    = flag.String("data", "~/tmp/mnist", "Directory to cache downloaded dataset.")
+	flagDataDir    = flag.String("data", "~/work/mnist", "Directory to cache downloaded dataset.")
 	flagCheckpoint = flag.String("checkpoint", "", "Checkpoint directory from/to where to load/save the trained model. Path is relative to --data.")
 )
 

--- a/examples/mnist/mnist.ipynb
+++ b/examples/mnist/mnist.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -142,16 +142,16 @@
      "data": {
       "text/html": [
        "<table><tr>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABzklEQVR4nNyVMcviMBiADz2VqFsbdRTBgkoR3PwBLtbFWbq5uYjoH3ATBNFB0OlEHF38Aw4ZBaU4iJOOFamDBF1McmCglA+xd19798H3THlj8vj2zdvU8+Mf8C2lxWKRMUYI6XQ6Pp/PhT8vl8sYY0LI44ksyy5IN5vN4/FwU1qtVjHGphQhBABwZMxkMrfbjSfIpe12+/2Wn+9/9nq9iqIEAgEeejweSilCyJHU7/eXSiXGGA8ppeb4DTYtdb/fu92udQZjbBiGrdcGAIAsy/P5nNd0vV47zZQnu91uY7EYD1erldM0OZIknU4nQsj1ek2n0+5IK5UKbylN0/5k/evTFwRBVVVBEBBCEMJer8fnp9Pp51Or1+vWbjeZzWaJROIzxkgkstvtXkoJIZfLZTAYNJvNUCj0F9JsNkueRKPR5XJJLPCrzxrqul6r1T7chC9aCkLInoiieDwe+Xi/32uaxt8oE0qpKIr9fr/RaFgNLw4qGAzywWKxiMfjjDHDMBRFORwOhUIBQqiqaj6fD4fD5pZUKmXz+ACA8XhsFvF8PrdarQ9rksnkcDicTCa/nuRyOfuySpKk6zqXjkYj+w3/ga/+mn5H6e8AAAD//ypsSsmQzB9KAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB6UlEQVR4nOyVr6siURTH7503GLwIlrFYTCZFLWaT3TBhwvwH/sKixWgSDYLFIAgKChYxaLCoRQSzigjiBJVhBHHAET264bKzb5flvafjLizsJ10unM/9Hg4zh0F/gP/SvyXFGDudzlQqdTweb9+53+/T6TSTyTz5FM/z8A5Jklqt1nq9BoDT6ZTL5Z6RJhIJAJjP54IgOBwOjuMQQhzHxWIxABgMBh+X/779/X6PEGJZdjwer1YrWZYRQrIsVyoVVVUVRXkmKcuyy+USABqNxvt7URQVRbHZbM9IEUJWq7XX610ul2w2+/b2Ri8FQdhut+RnMMaPqSVJAoB2u22xWAghgiBomqYP8HA4TCYTlmUfk4bDYVpfKBTq9bqu63Q60WjU5XI9pqNgjMvlsu7SNK3ZbHIc93C6X/D5fLpUFMWvlHz+mfI8r5/dbrehgBSMca1WAwBZlmn7wWDQqJQQQhu32+39fh8AhsPhy6SRSMTv9+92u/P5HI/HDUkxxsVikbZvNpvz+TwAjEYjk8lkyKtPP5lMiqJIz16v94OSz6c/m82q1SpCKJ1OE0JUVTWU8cfLDLNYLADger3SpKVSyVBShNDtdguFQpvNRv93MMyL9pDH4+l2uzRpIBB4jfTr/Dsr+lsAAAD//3+5LEbYr36zAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([8])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABhUlEQVR4nOyVsarCMBSGQ+hkFy2KmwgVC4KDk7vgC7g5KW5OTj6DGXyGTplc3Bx0kryCgkocBYWAQbfAqRcMiKi17b2Vu/hNoSf5zp+0oRh9gK/0K/WpYVwsFskVIYR35XK56MFqtSKEWJYVrWG73YYgBoPB80LjTcx6va7HUsrxeDyZTO4nEEJs244Ws9Vq3eI0m82HaqVSkVL6JfVlu90CwPF4bDQapmnel1Kp1HQ61f0cx4kgPZ/PALBYLJ5LnU5HGymlGL941b5nqpQyDIMx9vDcsqxer6fHs9nM87wISV+CMXZdV8ccDofJZPKvRoRQPp/Xxvl8nk6nYzAihJbLJQBwzjOZTDxG27aVUgAwGo1CLSiXy+8nFAoFzjkAnE6narUaSlqr1d5PuN2Ffr8fyhhIIpHQpymEePlh/gbGmI4ZduOBOI5zOBwAYL/fG4bvZYmAaZqUUgDY7XbdbjcGI0KoVCrpjbuuG37VR34nAWSz2c1ms16vc7ncP7S/5ycAAP//TbzwnBdu+2kAAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([7])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACK0lEQVR4nOyVy2viUBTGL9NpSwuhkFJoodAWmlIodFG6TUgh7SoU8YGo+NroSvwnBJeCW0FQXAiCK9GFiIhmoSAug4Ki+NwFMaDmgbO4cJFhHOM4XQzMtzo5ud8v300Oud/AF+g/9B+Bft9pNYZh7+/vLy8vl5eXbrcb9W9vb/v9/m5Pvri4uLq60uv1qqoqv1K5XD46OtqB6Pf7BUGAZgidz+fBYNDlcvE8D/uhUGjdsnH7p6enDMPYbLbr62sMw2BzsVg4nU5RFJvNpsfjwXEcAJBMJmOx2PZ0Dw8PkUhkfYMcxy2XS0mSDAYDSZKFQgH2J5OJyWTaTjw/Px+NRghXKpVYliUIQhRFVVW73S66NR6PKYraTjw8PIxGoygFy7InJycAAJ/Ph94pUiaT2U4EAHx8fCCPxWJBfYZharWaRujPH+r19RUWXq83nU7D2uFwnJ2d3d3dra+sVqt2u11T0kAgAFN0Op1GozGdTnO5nCzL6yOlKMpwOHx6etJEBADQNM1xnLpBq9UKcnU6nVYiFEVR2WxWEITBmiRJQknD4fBuRKTn52dUf35+zmYzCI3H4wRB/CEU6fHxEc3mYDAwm837EgEA9XodzRBN01osv/v14ThutVrv7+/hZT6fb7fb+2YkSRJlTCQSBwcH+xLf3t6KxSIk8jx/c3Oj3bvxOJFlmSRJWFcqlV6vt29MAIDRaGy1WoqipFKp4+Pjv0DcU19ymv4IAAD//0Son78ABw7NAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([9])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAByElEQVR4nNyVz8spURjHH7eLUGOjLJUsZmFjOSVLFpL8BdSxkp0s7KdslVJWs7awoCjZ2SkKG2OhWElCpqZGnuPcek+p632vH925dXs/u3PmzOd8T53nOT/gH/CdpFartVgsyrJsGAZjjFKqKMrjX34+cOVyOb/fHwgEYrEYn7xer4wxSZLeTw/g9XrL5TL+zm63o5QioqqqbxtFUVwul1x0OBxGH6TT6WAw+KL0i+MnEgmfz6eqaq1WGw6H4/H47Vyfsdls4XDY4/F8/sSTdjodE7bhEEK4NJPJmCZdrVaU0l6vJwiCOUZCyOVyoZTm8/mni1+tKKfTabFYdF2v1+t/nfADSZI0TaOUNptNc4wAsFgsEPF0OplmjEajx+MREQuFgjnGUCi03+8RcbPZOBwOc6SKovB6fSvmH7sUAKRSqWQyCQDdbrdard7mXS5XJBK5DQeDga7rr0qz2Sy/55PJhNtLpRJjzG63i6J4W9ZoNAghhmE8yS8IQqvV0jTtrvvxMr1jPp+73e7nSWVZjsfjjzdut9vr9RoAKpXK3W37Wjqbze6G2+12Op0iYr/fH41GAHA+nxHxyZFN5Ds90f+L9FcAAAD//08ME1mBZRmYAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABBklEQVR4nOyVMWqEUBCG52XzBAXBQrQVrSzF3sLCO3gCz2Fv4S0sbLzAO4FeQbG1FWyCxsA+IqR6s5sJ2+Sr/mLmm19EfIM/4F+KZRiGtm0pj9u2PU3Ttm1RFCmHsU3f7+i6bpommfTjDgD4vk8mDYJA6rIsI5MCAGMMOfmA9DxPeikelJQxluc58WVN0z6/qeuaXpokiXIe9fhFUciwLMs4jr8uCeA4Tt/3smbXdZgVddMwDOM4llkIQSP1PO/K8zxjpGqaprneEuccs6Joyjl3XVdmIcRxHAQ1Lcu6aqZpitx64DNd1/XZbj+53W5VVe37XpalYRg00ud49d/0xdKvAAAA//+9OmZ0PsqwdAAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([1])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABQUlEQVR4nOTVoY7CQBAG4LnjFAlBLA7W8gCA4AkQOCQKgeAtwGBROBKeAccToEgqarZJq1b0AZptsmZm95LWXS6FNlNxuV93vsy0091PaCH/HO00qJFSPp/PwWDweDycczyNnE4nLDIajXhEAEjTlB8lIkRUSvX7fR5xv99774loPp/ziMfj0RhDREopIQSDKISIoggR8zxfrVYMIgBcr9fy+9xuNx5RSklFsiybTqfVD3+9iW63W+89AFwulyAIGNpcr9flGiHibDZjEMfjsda6RA+HQ6fT5M/+mfP5TETOOWvtZDJhEHu9XhiGiGit3e12DCIAbDab8lVqrd+venGeLpfLBq28WKmPIgBwv98b6L9ECKG1LsevVVg1frfbHQ6HABDHcS20anxjTJIk3vvFYlELbSV/54puBf0OAAD//2hLpMiDLXAUAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([1])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABqElEQVR4nNyUv4rqQBSHT/6IiE2CGhJQG7EQ9AHUVixsJVXIS6iPYCHYasDWRuyChdgHbiHYWGhh6VRqI4gghMktZGWMmWDc3SL7lZM53/nlJDMs/AJ/QBqPxw3DwASn00mWZVEUP+/W6XTsZzDGtm1blpXNZv1rOdqDSqVSq9XIFYZhHMfJZDLFYvFwOORyuev1erlcAiRtNBrr9fo1KYmmacGS7na7/X6PEPr3RbVadRyH3HO73Var1fl8DhDWRbvd7vf7rrDT6VRRlM+lACCKoqZpw+GQ9JZKpW9J7+i67i8Nz4nigxZEo1FBEDiOe/wJiUSCZVmM8WMPQyuWJMnzs5bL5cFg4FpUFOV4PPplSSaT9Xp9NBp5HlNPVFWl6mKxmK7rvV7Ps9JHOplMSM/T68uyjBCitXQNDgDm8/lmswGAbrdLvQQMwyD7m6bZarW2261nUtM0C4WC3xzvuMqWy+V4PEYIvUpns9lbRgBQVZU2NVK6WCzy+fxbRgCIRCLNZtNfallWOp1+13iH53laXkmSUqmUIAjBjD9FeC6U8Ej/BwAA//+db9W84gMxHAAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABlUlEQVR4nNyVL4sCURTFHyr+H5RJgsUilkmDRSwGweAnMGmxKgg2xTjZpJgMotg02EQwiEmTiNoFi8rAQ3nh3llwloVdWEdm3sLiaXM498eZucN7NvIHemNotVpFxNlsxq1CJBI5n88AUCgUuEG32y0AlEolp9PJh5jP5xFRURRuREJIp9NhjEmSxI0oSRJjrF6vcyMSQmq12nw+fzH80i/l8XhyudxisbBW7LvS6TQAyLL8Yt5umPB6ve122+fziaIoy/Jms7ndblZrRqNRfIhSqmkapTSTybhcricjxt80m81qD00mk1QqNRwOR6NRpVKx1LTVah2Px0QiIYqi7vT7fVVVBUEw3zQWi51Op+VyeblcdOdwOPj9frv9130YQAOBQDKZ/GGGQqHdbmd+XcFgEBHX6/WXE4/Hr9druVx+MmX8+vqWPtM2W7FYdLvd+/3eZE1CiCAIqqquViv9UVEUAGg0GuaJuprN5v1+H4/Hg8EAEbvdLoejLxwOT6dTeKjX6zkcDqtEc/oft+l7QT8CAAD//zG/qs3n8n/uAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([6])</figcaption></figure></td>\n",
-       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACRUlEQVR4nOyVv0vrUBSA02dQCGaVRAQ30UkkS50EHePgEBEJmkFFHRy6OcUsbmZwMPkXzJoMIoIuHYSQCC6KTgaD2CFLSkvLObkPGuwrvqS/wOXxvuly77lfTs7hJL+oH+C/NBdd1+/u7mzbdl2XEGLb9sHBAU3Twz9tb28PEeGL9lrTtCGNKysrtVrN9/2tra3iFxcXF6lXVdVhpNfX1wDAsmzn5tjY2P7+PgA0m01RFAczHh8fI+LZ2VnmqWmaSZK8v79PT0/nGTIatbCwQAjheT7zwuHhISGE47idnZ0BpPf391EUjY+P5915fX2lKGp5eZlhmLyYDCYmJkZGRvJO5+bm0o5NTU0NIO0Oy7IPDw9d6j7ARE1OTqaLOI5fXl5Ii8zIbuPBMIwoihsbGzzPFwoFjuM+Pj583z86Ouo/lT/MzMyUSqUwDP+eKAAIgiCOYwCYnZ3t16goShiGiBgEgWEYpRYURa2urhqGEUVRkiSI+Pz83G+jFEV5e3v7/Pw8Pz/PDFhaWmpn/fT01C50N3RdB4DLy8u8AMMwELHcAgAeHx975yvLMgB4nvdt8FNUVW00GogoSdL6+npa60qlsru728NrWRYiuq7b+Wo0TWuahi0EQUg3BUFIq4+Isix3kxaLxdvbWwCoVqvb29uKoliW5ThOWkfTNDuDGYY5PT2VJGl+fr5HsouLi57nfftIl8vltbW10dHRHpcpqpB3wLLsyckJIWRzc9NxnKurq5ubm3q93tP4U/wbv+ih+R0AAP//61Ri370ayqkAAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB7ElEQVR4nOyVvcuqUBzHT5akRdCtRXqDgqDBCAoJl9aoMYT2hoYgGhrabS2I+g8aCiJwbGxsihaJJtcIdCgTsfB04RHi0vXxPna9w4XnO53zO56PX38viIB/oG+o8/JYH+M4Xi6Xn1uKolKplLGuVCooihYKhcPhYO+drVYLfi5BEEiStEdMJpO32+0FxHFcvV7/8SGfz2ePCAAIBoO73c5gbbdbmqYjkQiC/F0ZvF7vZrOBEGqals/nv37RbXGWzWb7/T4AAEJ4PB5LpVI6nZZl+XK5QAjfsYmi6Hw+N61Pp9PxeP7QNuYiSfJJUVVVFEVJklRVNSKDwcDttvpKK6iu68vl8tk3JEmez+enX9vQeDw+m816vd5LvFqtiqJoZDkUCtnmfqbhcGiYpSjK9IF3mu7xeLwsHJAgCBBCRVEymYwzxEAgcDqdIISLxcIZIgBgtVoZCS0Wizau4Tgei8V+jxMEMRqN7vc7hHA6nWIYZgPabDZlWW40GsYWQZBEItHtdiVJMjzyPB8Ohy0IJtOWy+X8fn+73cYwDMfxWq1G0zQAwOVyXa/X8XjMsqymaTZsAgAYhtF1/ddh13VdURSWZaPR6FcIJvO73+9vHyIIguM4nucnkwnDMOv1WpZlewYd1P/zi/4ZAAD//yBwNKHwvKstAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([5])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABvklEQVR4nOyVQesxQRzHx7YlrZScNsnNJuUoJSVWuVlyU97AlrtylVcgJy9ASW1ycFC25MSFUiibA8mNjW3ZGc9ha/snemYfnoP6f0/b1PfTZ/a3s0OA/5Bf6JdAyXfKTqczGAwCAA6HA4RwuVyagHq9Xp7nLRaLsRKLxWiatlqtLpcLAKAoyv1+FwQhn8/jGkWjUQghepHT6bTZbOr1eiKRwDW12Wy5XO6npqIosiwDAJrNZqvV2u12+/3+fD7jOpIkWa1WdSNN00ajUTabZRgGt/80mUzG2OZisaAoCqeF+0nNZjOO4zD3+BdoIBDQH/x+/3A4bLfbkUjE4XBgqjwPRVHlcnk6nf4ctyiKPp/vLa6eZDJZqVS63a6qqgih1Wr1AaiRVCqFEIIQxuNxc02322232x8WCYJgWXYwGCCEbrdbKBQyQeQ47nq9iqJoDCQcDvM83+/39XeqqmqxWDSnqZfH43GhUGg0GpIkaZpmTOlyudRqNZqmzUEnk8mrY77dbo0Dbi6lUumBdTwe5/N5Op32eDw4hCc/FEEQGIZhWVaW5U6ns16ve72eJEn/IvjBfM8d9T3QPwEAAP//aN8bJQ8bnm4AAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([5])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB/UlEQVR4nOyVO6vqTBSGR5MYQRsLMSgKtumVdAqC/8DCzoDg7QdoY6mSxs5GsBM7wcYmpYKNF/ASBRUsAinEJtEiXqIf7IFB1O9o9jm7OZynGma963GZTBIj+AH+ST+CpulqtXq9Xm+3W7PZ/DM/Xi6XtTtyudzvGovF4vF4vJc2Gg0cx79vdLvdyLjZbJC32+0yDPNN43w+h5bRaBQMBmVZRl5RFHV7jUZjrVaD/aqqxuNxAEAoFGq328jb6XSsVqsOaTqdRs31eh3t4zjO8zwqzWazT41+v/98PqNOj8dzX8UwDM0rSRJN0x9Jk8kkMmYyGQzDHgIWiwXdt1gs9t5ot9vH4zFsWC6XBEG8jK3Xa03TFEUJh8PvpYlEAhr3+73X630OUBSVSqUOh4OmaTzPvzcCAARBgNJKpfIykM/nYUAQBKfT+VB98VQwDONwOOB6Mpk8BwwGA7zEw+GQ4zhJkt6PybIsnGK32/l8vucASZKapvX7fZvN9l4HEUURSler1f1+JBIZDAbyF6VSyWw2/5/hxd8nSRIuOI6Di8ViQRCEy+UymUwAgPEXqqp+OiYAYLvdwkl7vV4gECgUCpfLBe7IstxqtSiK0qGDTKdT7RWKorAsq1sHiUajp9Ppwcjz/Ecn/BegcwrJZrP6XkU/wd/3idbFfwEAAP//gheU1AZqMMsAAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([0])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABn0lEQVR4nOyVParyQBSGJ3+IIDaDoIiIqVII4h8p4gKsRCGFRXqXIIi1W7CwslRwA2otRhA3IGIXCxVJtBDG4weGjytewdHJLS7cp0pOch5ewskZHv0Af1LvEdgVPM+rqprL5dbrNSGEyRWPxxVFqVarpmnCjV6v5z4SKRW1Wk2WZfe6WCz6fL5YLOb3+xFCHMddr9fxePxeTFVVCSHwjdFo1G63k8kkxlgQvr4k99IoimIgEKhUKoVCYblc7vf7zWYzm80sy3oj1wOKohwOh2w2S9/yeqR0XQ8Gg6lU6vNcD2CMz+fzdrvFGNN3vUhqGIYkSZ1OZ7fbMSf8DwDYth2NRj0zulIA6Ha7kiR5Js1kMo1GAwAMw/BM6qLr+nQ6pX+faktZluU4DkOq2xg9VDRNA4BIJEJpeJJ0MpmUSqX7SjqdXiwWTP+laZq2bScSCfdWlmXHcfr9/udGhFC5XAaA1WrVbDbr9fp8Pj+dTpqmMUkFQRgOh/crrtVqvWV4vvpCoVA+nw+Hwwih4/E4GAwulwtTUnZ+zxH9LwAA///pYrXWIo6MJwAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([5])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB+klEQVR4nOyVP2jiYBjGw13apnyFTqUYIy4OimYQFHETQQVnR53U3U3cBScdBREEVyUQZwddXAV1CESCoksMQUGCGXw/ctCASHp/cq0HHe43Kc+bH8/7fZB8I/4B/6VfUlosFjHGs9nsFn3eKBQKuq4DAMdxf/EYRVGCIEyn03Q6bYncbrckSQBQr9efnp7sGhFC/X4f3qhUKteR0+kURREA9vs9wzB2jSzLLpdL09hutx8eHq7TZrOJMQaAfD5v1xiJRFRVNQwDY9xqtX6a6rrO8/zj46MtYygUkmUZAA6HQ7Vavbu7u04pippMJgDA87wtHUmS0WhUURRza0EQnp+fLTPmKWuaFg6HbUkTiQRcgTFer9c+n+8ykMlkTqfT+3v7HePx2CIFAFmWk8kkQRAej+d4PAJAqVSy3Ns13y3/GYZ5fX3dbrexWKzT6dA07fV6EULZbBYAAoFAKpUSRTGXy2GM7Ta1gBBqNBrmvpfi3W73gzpL/fl8fpGez2dZlmu12q/mSTtSRVFUVTV/cxy3Wq1omu71ep9qGo/HzfVFUUQIfcp1YbfbYYxHoxHLsnbm//w+dblc9/f3hmEMBoPFYnGDjiRJDodDAJAk6eXl5QZGgiD8fr95muVy+TZGgiAcDsdms9E0LRgM3kz6Mb7q1/Q9PwIAAP//Cl4sR+1mWj8AAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([4])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABgElEQVR4nOzVoYsCQRgF8FVkZAURDKJJ2LiCm+ymBUE0aVVsBrFY/RM0GQQxGsVu1GywCYIoGFZF2+6sOL69MNxx3JVj77Mc99Ju+c038xgmqLwg/+hfRXO53Gg0Wq1W+/2+Vqv9bvFgMBqNTqdT13XxHtd1Z7NZKBTyI6ZSqX6/j0/Z7XaXy0V+RyIRP2i9Xv/gbrfb+XweDAa2bQPgnKuq+nVbP6c9zxuPx+l0OpFIZLNZVVUdx6lWq5xzP5MahtFsNpPJpPztdDpCCNu2i8WiH+57yuWyZVkAer0eARcIBPL5/PV6BXA4HDRNI0AzmYzs6ng86rpOIJqmKYQAIIQwTZNA1HX9dDoBeD6fpVKJQNQ0bb1eA3g8HoVCgUBkjM3ncwCWZTUaDQJRUZThcCibabVaNOJkMuGcA2i32zRipVKR4mKxiMfjBKJhGPf7HcByuYzFYjQzOo4jy6GZkTG22WzkzSE7ynA4vN1uOefdbpcxRoOS5CWv6VsAAAD//7QO57jApVHUAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([7])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACCUlEQVR4nOyVQasxbxjG5+CcTp1OTWc6nSEmUsqGspNYUHa+geXYGDUrqUkpSxsLsVDDrBQL+QKaksGKUhYKRZnIbhZqZnrGfzE16Y+ayXkXb73XSvf93D/X03XPjAn6A/oH/X1Z9B/FMCwWi/n9/mQyudvtUBTtdDoWiyWdTkMQJAgCDMPG/jwQCPA8rygKeCCWZQ07LZVKPz8/6u9ut2uz2RaLxfWBfr9vwOPHxwdN07IsAwAEQUgkEiaT6fX11QDiVhRFaXckSfIplqpcLrfdblViq9VCUVTPlPlR4+XlJZPJFAqF7+9vtTIYDDwej9Pp3Gw2siwbNvj19dVsNm8j1tKvVquGFygYDIqieI3jeb7X663Xa63SbreNQXEc14Ynk0k+n1f3CUGQSCRyOp0AAKPRyBgUgiCCIEiSvJsMx3GXy0VRlHg8bph7VxiGDYdD9RLZbPZ3oJVK5Xw+AwBms5nD4dA1YzabcRx3uVx3u9FodLlcqjZrtZpeI8ViEQDAcdztg2i1WtWumh5BEHqh0+kUAHA4HN7f36/rdrudYRhtT0OhkF4iBEGpVEodOx6PDMO43W4YhimKms/n6vJLkjQej9/e3gxAPz8/G43Go5fmfr+v1+sGcJp8Ph9N05Ik/Y+4Wq30xv1IXq+XZVme50VRLJfL4XAYQZCniE/q7/lE/xcAAP//y9BqqLuUZ/EAAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([5])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB9klEQVR4nOyVMa8pQRTHZ9/SrGxMWAqbaEShEmFb/UShUaLQbEOvUGiUColCNj6BBAkq5X4DCrIRhcomBCEhEnZersndt3mWd9fzipfcXzU5zvmfv5k5sz/AP+Bb9P3Y7kMQwm63G4/HAQDtdhsA4PV6McadTkeW5dFo9Eofn883n88vBq7XK1moqtpsNmOx2HMF+j50OBycTifP85tPttsty7I0TTMME4lEksnkbDbTNG2z2bziWieTyZTLZaPry+VSq9U4jvsrXUKhUDBuS7/fv88xOahHCILAcVypVDIGp9OpNVGEUD6fBwBQFIUxjkajHMeRNUlIJBKyLH/d1geKovx2+vq6Xq+TfpZBCF1vYIyvn2CMA4HAK3IEhmECN3K53H6/150OBgOPx/O6ro4oimQiyN9Pp9NvEAUABINBXXS9XpM5fgOpVErf31arZaFSEASE0KNfyVwRLCiqqvqkIJvNnk4na6IIoT8W6Pf3UQJ1HyoWi5VKBQAwmUwkSdInqtfrLRaLcDg8HA7JO0LTJo+cuajdbvf7/Yqi/Eq6iS6Xy+PxCCF0u90kbrOZT7lJK03Tdrsdz/Pn81nTNAghRX30ZlnW5XI5HA6StlqtqtXqV50agRDq91wUxVAoRFw3Gg1Jksbj8fPyd/L/fKJ/BgAA//+6TEgy5TBZaQAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([3])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB0UlEQVR4nOyVscviMBjGy6GLIG6ChXZwcHDTzVHESUT7B6iDiyDoorP617jIDTqLSEVx0EUiKKhY2kFw0EIJCl9zYLiXnu0njXfH3fA9U3jz5JfnDWn6jfsL+oIyqNFoXK9X0zSbzeYf2DyRSOi6/vFT9/sdIRQOh9/E+Xy+Xq9HA378qna7/Q4xm81ut1uKsEMxxrlcjo0Yj8dlWQaEaZrD4XC1Wlm5s9mMgRgIBObzOSw+Ho+pVMrj8WQyGcMwoK4oilui3+/vdruw8nA4RCIRmK3VasBlgEqSBMTz+VwqlZ4M0IQj1GMveb1eOP7T6ZRMJjebjds4n6lYLEJMhJCj53VSB2maZj6kaVo0GrUbJEmiBkKIqqp2g0P75CGO4xRFWa/XjhtTAyFkOp26SqqqKm0tn887GqxXrVAo2A2vHhRBEOxFURR5nqfj/X7f7/fZkuq6Xi6Xn2Y7nQ7ErFarrogcxw0GA7jbu90uFovROs/z9XodYwzQz87HWePxGFYahvH9IYSQ9auXZTkUCjFARVFcLpdPbxIhBMaTyYSNSCUIwmKxuN1uVijG+HK5tFqtYDDITARVKhWAjkajdDr9Pus39R/8Tf8l9EcAAAD//4cZySzhRkXoAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([0])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACBUlEQVR4nOzVvWvqXBzA8ZP0gUIIbYZCO7RLKU3WUgopnZpJEBczOETdnBz0PwiugpsuOvmyKNHBSRcddMzuIIjvEoQQwSCR/I4PKL2Ee3tBe3Ppcr9bwsknCTk/QqK/0Hej4XB4t9stFoubmxt3bi6KIuzDGLMs64IoSZKmaQAwmUxkWb64uPhT8enpSdM0jHGxWLy6unLhGRFCjUYDAEaj0f39vTuiJEmbzcayrEgk4o6IEJrNZgCQSqVcEwOBgG3bhmG8vr66IzIMs1wuASAUCrkjIoQ4jgMAVVVJ0qWpI0myUCgAgCiKzvMEQdzd3cViMVVVc7mcx+M5AX1/f8f7nBPJ83w+n8cY/xit4XD48PBwAgoAlmVdX18jhM7OzhKJhK7rAKDrejabTSaTnU4HAEql0mlovV4/HEajUQAwDMO5t97e3gCg3+8fiwqCgDHu9Xo0TSOEptPper0WBMG5xuv1/g7971N0t+/x8ZGm6cvLS4ZhKpVKq9Vyrnl+fkYINZvNXy//fLt0u11FUQiCyGQyfr+foiiCIJwLKIried40TUVRjnv5fSzLjsfjw1cGgPl8HgwGX15eEEI+n69Wq2GMq9XqCeKh8/PzeDy+Wq3wR9vt1jRN27YBYDAYnLCfforjuHQ63W634aNyuSzL8u3t7RfFr/Xdf9N/6JH9HwAA//+NMBl1Mhf0mwAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([6])</figcaption></figure></td>\n",
        "</tr></table>\n"
       ]
      },
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -258,13 +258,16 @@
       "\t\"/l1_regularization\": (float64) 0\n",
       "\t\"/l2_regularization\": (float64) 0\n",
       "\t\"/learning_rate\": (float64) 0.0001\n",
-      "\t\"/loss\": (string) cross-entropy\n",
+      "\t\"/loss\": (string) sparse_cross_logits\n",
       "\t\"/model\": (string) 'cnn'\n",
       "\t\"/nan_logger\": (bool) false\n",
       "\t\"/num_checkpoints\": (int) 3\n",
       "\t\"/optimizer\": (string) adamw\n",
       "\t\"/plots\": (bool) false\n",
       "\t\"/train_steps\": (int) 10\n",
+      "\t\"/triplet_loss_margin\": (float64) 0.5\n",
+      "\t\"/triplet_loss_mining_strategy\": (string) Hard\n",
+      "\t\"/triplet_loss_pairwise_distance_metric\": (string) L2\n",
       "Parameters set (-set): [\"batch_size\" \"model\" \"train_steps\"]\n",
       "\t\"/activation\": (string) relu\n",
       "\t\"/adam_dtype\": (string) \n",
@@ -278,13 +281,16 @@
       "\t\"/l1_regularization\": (float64) 0\n",
       "\t\"/l2_regularization\": (float64) 0\n",
       "\t\"/learning_rate\": (float64) 0.0001\n",
-      "\t\"/loss\": (string) cross-entropy\n",
+      "\t\"/loss\": (string) sparse_cross_logits\n",
       "\t\"/model\": (string) 'cnn'\n",
       "\t\"/nan_logger\": (bool) false\n",
       "\t\"/num_checkpoints\": (int) 3\n",
       "\t\"/optimizer\": (string) adamw\n",
       "\t\"/plots\": (bool) false\n",
-      "\t\"/train_steps\": (int) 10\n"
+      "\t\"/train_steps\": (int) 10\n",
+      "\t\"/triplet_loss_margin\": (float64) 0.5\n",
+      "\t\"/triplet_loss_mining_strategy\": (string) Hard\n",
+      "\t\"/triplet_loss_pairwise_distance_metric\": (string) L2\n"
      ]
     }
    ],
@@ -300,8 +306,6 @@
     ")\n",
     "\n",
     "var (\n",
-    "    // ValidModels is the list of model types supported.\n",
-    "    ValidModels = []string{\"linear\", \"cnn\"}\n",
     "\tflagEval      = flag.Bool(\"eval\", true, \"Whether to evaluate the model on the validation data in the end.\")\n",
     ")\n",
     "\n",
@@ -315,6 +319,7 @@
     "\tctx.SetParams(map[string]any{\n",
     "\t\t// Model type to use\n",
     "\t\t\"model\":           \"linear\",\n",
+    "\t\t\"loss\":            \"sparse_cross_logits\",\n",
     "\t\t\"num_checkpoints\": 3,\n",
     "\t\t\"train_steps\":     4000,\n",
     "\n",
@@ -349,6 +354,11 @@
     "\t\t// CNN\n",
     "\t\t\"cnn_dropout_rate\":  0.5,\n",
     "\t\t\"cnn_normalization\": \"layer\", // \"layer\" or \"batch\".\n",
+    "\n",
+    "\t\t// Triplet\n",
+    "\t\tlosses.ParamTripletLossPairwiseDistanceMetric: \"L2\",\n",
+    "\t\tlosses.ParamTripletLossMiningStrategy:         \"Hard\",\n",
+    "\t\tlosses.ParamTripletLossMargin:                 0.5,\n",
     "\t})\n",
     "\treturn ctx\n",
     "}\n",
@@ -362,7 +372,7 @@
     "\n",
     "// Let's test that we can set hyperparameters by setting it in the \"-set\" flag:\n",
     "%% -set=\"batch_size=17;model='cnn';train_steps=10\"\n",
-    "fmt.Printf(\"Model types: %q\\n\", ValidModels)\n",
+    "fmt.Printf(\"Models: %q\\n\", mnist.ModelList)\n",
     "ctx, parametersSet := ContextFromSettings()\n",
     "fmt.Printf(\"Parameters set (-set): %q\\n\", parametersSet)\n",
     "fmt.Println(commandline.SprintContextSettings(ctx))"
@@ -385,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -447,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -460,12 +470,17 @@
     },
     {
      "data": {
-      "text/html": [
-       "<div id=\"dade4a5f\"></div>"
-      ]
+      "text/html": []
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training (4000 steps):    0% [........................................] (32 steps/s) [0s:2m5s] [step=35] [loss+=1.925] [~loss+=2.137] [~loss=2.137] [~acc=28.62%]         "
+     ]
     },
     {
      "data": {
@@ -478,17 +493,167 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t- restarting from global step 4000\n",
-      "\t - target train_steps=4000 already reached. To train further, set a number additional to current global step.\n",
+      "Training (4000 steps):  100% [========================================] (134 steps/s) [step=3999] [loss+=0.321] [~loss+=0.289] [~loss=0.289] [~acc=91.98%]        ]         \n",
+      "\n",
+      "\t- saving checkpoint@4000\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p><b>Metric: accuracy</b></p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"8e4530de\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script charset=\"UTF-8\">\n",
+       "(() => {\n",
+       "\tconst src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\";\n",
+       "\tvar runJSFn = function(module) {\n",
+       "\t\t\n",
+       "\tif (!module) {\n",
+       "\t\tmodule = window.Plotly;\n",
+       "\t}\n",
+       "\tlet data = JSON.parse('{\"data\":[{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.18803030252456665,0.2344202846288681,0.2890090048313141,0.35854947566986084,0.4308333992958069,0.49690482020378113,0.558836817741394,0.6246775984764099,0.6867244243621826,0.7390128970146179,0.7840120196342468,0.8172426223754883,0.8420642614364624,0.8603987097740173,0.8723210096359253,0.8823381662368774,0.8888523578643799,0.8962824940681458,0.9005602598190308,0.9055622816085815,0.9097958207130432,0.9133420586585999,0.9163161516189575,0.9198712706565857,0.9198431372642517]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.2305999994277954,0.32339999079704285,0.4457166790962219,0.5792166590690613,0.6696333289146423,0.7269166707992554,0.7630167007446289,0.7925500273704529,0.8116500377655029,0.8279666900634766,0.8444333672523499,0.8550500273704529,0.8645833134651184,0.8727499842643738,0.8804000020027161,0.8869500160217285,0.8929666876792908,0.8981333374977112,0.9032833576202393,0.9075166583061218,0.9110833406448364,0.9143000245094299,0.9173166751861572,0.9200000166893005,0.9206333160400391]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.22830000519752502,0.31710001826286316,0.4425000250339508,0.5811000466346741,0.6732000112533569,0.7326000332832336,0.7692000269889832,0.7987000346183777,0.8215000629425049,0.8393000364303589,0.853100061416626,0.8655000329017639,0.8746000528335571,0.8839000463485718,0.8896000385284424,0.8955000638961792,0.900700032711029,0.9044000506401062,0.9087000489234924,0.9113000631332397,0.9142000675201416,0.9158000349998474,0.9183000326156616,0.9200000166893005,0.9208000302314758]}],\"layout\":{\"legend\":{},\"title\":{\"text\":\"accuracy\"},\"xaxis\":{\"showgrid\":true,\"type\":\"log\"},\"yaxis\":{\"showgrid\":true,\"type\":\"log\"}}}');\n",
+       "\tmodule.newPlot('8e4530de', data);\n",
+       "\n",
+       "\t}\n",
+       "\t\n",
+       "    if (typeof requirejs === \"function\") {\n",
+       "        // Use RequireJS to load module.\n",
+       "\t\tlet srcWithoutExtension = src.substring(0, src.lastIndexOf(\".js\"));\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': srcWithoutExtension\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(plotly) {\n",
+       "            runJSFn(plotly)\n",
+       "        });\n",
+       "        return\n",
+       "    }\n",
+       "\n",
+       "\tvar currentScripts = document.head.getElementsByTagName(\"script\");\n",
+       "\tfor (const idx in currentScripts) {\n",
+       "\t\tlet script = currentScripts[idx];\n",
+       "\t\tif (script.src == src) {\n",
+       "\t\t\trunJSFn(null);\n",
+       "\t\t\treturn;\n",
+       "\t\t}\n",
+       "\t}\n",
+       "\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\n",
+       "\tscript.charset = \"utf-8\";\n",
+       "\t\n",
+       "\tscript.src = src;\n",
+       "\tscript.onload = script.onreadystatechange = function () { runJSFn(null); };\n",
+       "\tdocument.head.appendChild(script);\t\n",
+       "})();\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p><b>Metric: loss</b></p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"6219d01a\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script charset=\"UTF-8\">\n",
+       "(() => {\n",
+       "\tconst src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\";\n",
+       "\tvar runJSFn = function(module) {\n",
+       "\t\t\n",
+       "\tif (!module) {\n",
+       "\t\tmodule = window.Plotly;\n",
+       "\t}\n",
+       "\tlet data = JSON.parse('{\"data\":[{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Batch Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.242750644683838,2.0831222534179688,1.9293919801712036,1.7319185733795166,1.5714173316955566,1.3857063055038452,1.2374286651611328,1.0803089141845703,0.9555859565734863,0.8855295777320862,0.7828711271286011,0.6793928146362305,0.6259808540344238,0.5266555547714233,0.520197331905365,0.4463309943675995,0.4451720416545868,0.38713833689689636,0.3446575403213501,0.332558810710907,0.34101662039756775,0.29675543308258057,0.3295268714427948,0.27425843477249146,0.32147932052612305]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.3120200634002686,2.2213363647460938,2.131723642349243,2.033026695251465,1.925816535949707,1.8146777153015137,1.6848138570785522,1.525039792060852,1.3436931371688843,1.162893295288086,0.9920595288276672,0.8415334820747375,0.7171860933303833,0.6185946464538574,0.5453207492828369,0.4858480393886566,0.44258978962898254,0.40505319833755493,0.37823113799095154,0.3549397885799408,0.33447906374931335,0.31722182035446167,0.3032344579696655,0.29096442461013794,0.28866538405418396]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.3120200634002686,2.2213363647460938,2.131723642349243,2.033026695251465,1.925816535949707,1.8146777153015137,1.6848138570785522,1.525039792060852,1.3436931371688843,1.162893295288086,0.9920595288276672,0.8415334820747375,0.7171860933303833,0.6185946464538574,0.5453207492828369,0.4858480393886566,0.44258978962898254,0.40505319833755493,0.37823113799095154,0.3549397885799408,0.33447906374931335,0.31722182035446167,0.3032344579696655,0.29096442461013794,0.28866538405418396]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2173426151275635,2.0621337890625,1.9004777669906616,1.7263919115066528,1.553458333015442,1.3827018737792969,1.2216707468032837,1.0748977661132812,0.9471924304962158,0.8376462459564209,0.744358479976654,0.6653969287872314,0.5990288853645325,0.5432859659194946,0.4956851899623871,0.4556851089000702,0.4217076599597931,0.3927658200263977,0.3682361841201782,0.3470945954322815,0.3290477991104126,0.31355389952659607,0.30034705996513367,0.2891567349433899,0.28626495599746704]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2173426151275635,2.0621337890625,1.9004777669906616,1.7263919115066528,1.553458333015442,1.3827018737792969,1.2216707468032837,1.0748977661132812,0.9471924304962158,0.8376462459564209,0.744358479976654,0.6653969287872314,0.5990288853645325,0.5432859659194946,0.4956851899623871,0.4556851089000702,0.4217076599597931,0.3927658200263977,0.3682361841201782,0.3470945954322815,0.3290477991104126,0.31355389952659607,0.30034705996513367,0.2891567349433899,0.28626495599746704]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2289540767669678,2.070373058319092,1.9051034450531006,1.7273848056793213,1.5506057739257812,1.3758571147918701,1.2114927768707275,1.0618422031402588,0.931283712387085,0.8200049996376038,0.7262523770332336,0.6464847922325134,0.5799047350883484,0.5243610143661499,0.477105051279068,0.4378643333911896,0.4051312208175659,0.37746894359588623,0.35410669445991516,0.3349500298500061,0.3182392716407776,0.3054843544960022,0.2944055497646332,0.2854694426059723,0.28384408354759216]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2289540767669678,2.070373058319092,1.9051034450531006,1.7273848056793213,1.5506057739257812,1.3758571147918701,1.2114927768707275,1.0618422031402588,0.931283712387085,0.8200049996376038,0.7262523770332336,0.6464847922325134,0.5799047350883484,0.5243610143661499,0.477105051279068,0.4378643333911896,0.4051312208175659,0.37746894359588623,0.35410669445991516,0.3349500298500061,0.3182392716407776,0.3054843544960022,0.2944055497646332,0.2854694426059723,0.28384408354759216]}],\"layout\":{\"legend\":{},\"title\":{\"text\":\"loss\"},\"xaxis\":{\"showgrid\":true,\"type\":\"log\"},\"yaxis\":{\"showgrid\":true,\"type\":\"log\"}}}');\n",
+       "\tmodule.newPlot('6219d01a', data);\n",
+       "\n",
+       "\t}\n",
+       "\t\n",
+       "    if (typeof requirejs === \"function\") {\n",
+       "        // Use RequireJS to load module.\n",
+       "\t\tlet srcWithoutExtension = src.substring(0, src.lastIndexOf(\".js\"));\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': srcWithoutExtension\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(plotly) {\n",
+       "            runJSFn(plotly)\n",
+       "        });\n",
+       "        return\n",
+       "    }\n",
+       "\n",
+       "\tvar currentScripts = document.head.getElementsByTagName(\"script\");\n",
+       "\tfor (const idx in currentScripts) {\n",
+       "\t\tlet script = currentScripts[idx];\n",
+       "\t\tif (script.src == src) {\n",
+       "\t\t\trunJSFn(null);\n",
+       "\t\t\treturn;\n",
+       "\t\t}\n",
+       "\t}\n",
+       "\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\n",
+       "\tscript.charset = \"utf-8\";\n",
+       "\t\n",
+       "\tscript.src = src;\n",
+       "\tscript.onload = script.onreadystatechange = function () { runJSFn(null); };\n",
+       "\tdocument.head.appendChild(script);\t\n",
+       "})();\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t- trained to step 4000, median train step: 3267 microseconds\n",
       "\n",
       "Results on train:\n",
-      "\tMean Loss+Regularization (#loss+): 0.288\n",
-      "\tMean Loss (#loss): 0.288\n",
-      "\tMean Accuracy (#acc): 92.04%\n",
+      "\tMean Loss+Regularization (#loss+): 0.286\n",
+      "\tMean Loss (#loss): 0.286\n",
+      "\tMean Accuracy (#acc): 92.06%\n",
       "Results on test:\n",
       "\tMean Loss+Regularization (#loss+): 0.284\n",
       "\tMean Loss (#loss): 0.284\n",
-      "\tMean Accuracy (#acc): 92.14%\n",
+      "\tMean Accuracy (#acc): 92.08%\n",
       "\n"
      ]
     }
@@ -520,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -624,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -647,12 +812,17 @@
     },
     {
      "data": {
-      "text/html": [
-       "<div id=\"cf014ec5\"></div>"
-      ]
+      "text/html": []
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training (4000 steps):    0% [........................................] (16 steps/s) [1s:4m5s] [step=35] [loss+=2.001] [~loss+=3.331] [~loss=3.331] [~acc=22.52%]         "
+     ]
     },
     {
      "data": {
@@ -665,23 +835,392 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t- restarting from global step 4000\n",
-      "\t - target train_steps=4000 already reached. To train further, set a number additional to current global step.\n",
+      "Training (4000 steps):  100% [========================================] (71 steps/s) [step=3999] [loss+=0.028] [~loss+=0.035] [~loss=0.035] [~acc=98.85%]        ]          \n",
+      "\n",
+      "\t- saving checkpoint@4000\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p><b>Metric: accuracy</b></p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"637535bb\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script charset=\"UTF-8\">\n",
+       "(() => {\n",
+       "\tconst src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\";\n",
+       "\tvar runJSFn = function(module) {\n",
+       "\t\t\n",
+       "\tif (!module) {\n",
+       "\t\tmodule = window.Plotly;\n",
+       "\t}\n",
+       "\tlet data = JSON.parse('{\"data\":[{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.12409090250730515,0.1627536118030548,0.22977477312088013,0.3064197599887848,0.38324323296546936,0.4595067799091339,0.5373380184173584,0.6207820773124695,0.7005358934402466,0.7718029022216797,0.8295319080352783,0.8747650384902954,0.907522439956665,0.927790641784668,0.9426401257514954,0.952543318271637,0.9607671499252319,0.9667502045631409,0.9713452458381653,0.9756587743759155,0.9792490601539612,0.9827476143836975,0.9850558042526245,0.9877312779426575,0.9884975552558899]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.26249998807907104,0.5195333361625671,0.7083166837692261,0.799916684627533,0.8562999963760376,0.8895000219345093,0.9136833548545837,0.9293833374977112,0.942300021648407,0.9505666494369507,0.9588333368301392,0.9647499918937683,0.9698666930198669,0.9743666648864746,0.9778167009353638,0.9807833433151245,0.9833333492279053,0.9851999878883362,0.9873666763305664,0.9892666935920715,0.9909833669662476,0.992733359336853,0.9941999912261963,0.9955999851226807,0.9957000017166138]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.25690001249313354,0.5208000540733337,0.7104000449180603,0.803100049495697,0.8621000647544861,0.8970000147819519,0.9205000400543213,0.9353000521659851,0.9483000636100769,0.9539000391960144,0.9623000621795654,0.9676000475883484,0.9709000587463379,0.9750000238418579,0.9780000448226929,0.9798000454902649,0.9818000197410583,0.9825000762939453,0.9847000241279602,0.9865000247955322,0.9871000647544861,0.9877000451087952,0.9889000654220581,0.9903000593185425,0.9895000457763672]}],\"layout\":{\"legend\":{},\"title\":{\"text\":\"accuracy\"},\"xaxis\":{\"showgrid\":true,\"type\":\"log\"},\"yaxis\":{\"showgrid\":true,\"type\":\"log\"}}}');\n",
+       "\tmodule.newPlot('637535bb', data);\n",
+       "\n",
+       "\t}\n",
+       "\t\n",
+       "    if (typeof requirejs === \"function\") {\n",
+       "        // Use RequireJS to load module.\n",
+       "\t\tlet srcWithoutExtension = src.substring(0, src.lastIndexOf(\".js\"));\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': srcWithoutExtension\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(plotly) {\n",
+       "            runJSFn(plotly)\n",
+       "        });\n",
+       "        return\n",
+       "    }\n",
+       "\n",
+       "\tvar currentScripts = document.head.getElementsByTagName(\"script\");\n",
+       "\tfor (const idx in currentScripts) {\n",
+       "\t\tlet script = currentScripts[idx];\n",
+       "\t\tif (script.src == src) {\n",
+       "\t\t\trunJSFn(null);\n",
+       "\t\t\treturn;\n",
+       "\t\t}\n",
+       "\t}\n",
+       "\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\n",
+       "\tscript.charset = \"utf-8\";\n",
+       "\t\n",
+       "\tscript.src = src;\n",
+       "\tscript.onload = script.onreadystatechange = function () { runJSFn(null); };\n",
+       "\tdocument.head.appendChild(script);\t\n",
+       "})();\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p><b>Metric: loss</b></p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"dd79257a\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script charset=\"UTF-8\">\n",
+       "(() => {\n",
+       "\tconst src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\";\n",
+       "\tvar runJSFn = function(module) {\n",
+       "\t\t\n",
+       "\tif (!module) {\n",
+       "\t\tmodule = window.Plotly;\n",
+       "\t}\n",
+       "\tlet data = JSON.parse('{\"data\":[{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Batch Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[3.8298325538635254,2.684189558029175,2.157374143600464,1.570107340812683,1.2134819030761719,0.9696266651153564,0.6999115943908691,0.519900918006897,0.439585417509079,0.3976902961730957,0.3945767283439636,0.25771185755729675,0.21356944739818573,0.1787734478712082,0.13796697556972504,0.12060899287462234,0.08764876425266266,0.08083140105009079,0.06875628232955933,0.09862811118364334,0.06189776957035065,0.09568135440349579,0.028441276401281357,0.04254184663295746,0.028382498770952225]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[4.420759201049805,3.8440346717834473,3.2988903522491455,2.832308292388916,2.431940793991089,2.0868313312530518,1.7545318603515625,1.411542296409607,1.096258282661438,0.821063220500946,0.6021521091461182,0.4334585666656494,0.3172509968280792,0.24585428833961487,0.1929909884929657,0.15659788250923157,0.12971241772174835,0.11019685864448547,0.0931941568851471,0.0793602243065834,0.06700577586889267,0.0566834881901741,0.04704773426055908,0.03729463368654251,0.03535936400294304]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[4.420759201049805,3.8440346717834473,3.2988903522491455,2.832308292388916,2.431940793991089,2.0868313312530518,1.7545318603515625,1.411542296409607,1.096258282661438,0.821063220500946,0.6021521091461182,0.4334585666656494,0.3172509968280792,0.24585428833961487,0.1929909884929657,0.15659788250923157,0.12971241772174835,0.11019685864448547,0.0931941568851471,0.0793602243065834,0.06700577586889267,0.0566834881901741,0.04704773426055908,0.03729463368654251,0.03535936400294304]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2657573223114014,1.4392365217208862,0.9422882795333862,0.6431862115859985,0.4605896472930908,0.3475801944732666,0.27524957060813904,0.2249326854944229,0.1836419403553009,0.15763628482818604,0.13189318776130676,0.1133541390299797,0.09789863973855972,0.08432299643754959,0.07296032458543777,0.0634613037109375,0.05532548949122429,0.0479479543864727,0.04167185351252556,0.03469136729836464,0.02934635803103447,0.02338333986699581,0.019141292199492455,0.014537913724780083,0.014069993980228901]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2657573223114014,1.4392365217208862,0.9422882795333862,0.6431862115859985,0.4605896472930908,0.3475801944732666,0.27524957060813904,0.2249326854944229,0.1836419403553009,0.15763628482818604,0.13189318776130676,0.1133541390299797,0.09789863973855972,0.08432299643754959,0.07296032458543777,0.0634613037109375,0.05532548949122429,0.0479479543864727,0.04167185351252556,0.03469136729836464,0.02934635803103447,0.02338333986699581,0.019141292199492455,0.014537913724780083,0.014069993980228901]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2830333709716797,1.4444785118103027,0.9375590085983276,0.6308770775794983,0.44249123334884644,0.3287162482738495,0.2570558488368988,0.2079705446958542,0.1678205132484436,0.1424146145582199,0.1198345497250557,0.10221412032842636,0.08929438889026642,0.07806108891963959,0.06664089858531952,0.06013409048318863,0.05467929318547249,0.04905519261956215,0.04488399997353554,0.0392930693924427,0.03686310723423958,0.03205966576933861,0.03050234541296959,0.027867136523127556,0.03002404235303402]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[2.2830333709716797,1.4444785118103027,0.9375590085983276,0.6308770775794983,0.44249123334884644,0.3287162482738495,0.2570558488368988,0.2079705446958542,0.1678205132484436,0.1424146145582199,0.1198345497250557,0.10221412032842636,0.08929438889026642,0.07806108891963959,0.06664089858531952,0.06013409048318863,0.05467929318547249,0.04905519261956215,0.04488399997353554,0.0392930693924427,0.03686310723423958,0.03205966576933861,0.03050234541296959,0.027867136523127556,0.03002404235303402]}],\"layout\":{\"legend\":{},\"title\":{\"text\":\"loss\"},\"xaxis\":{\"showgrid\":true,\"type\":\"log\"},\"yaxis\":{\"showgrid\":true,\"type\":\"log\"}}}');\n",
+       "\tmodule.newPlot('dd79257a', data);\n",
+       "\n",
+       "\t}\n",
+       "\t\n",
+       "    if (typeof requirejs === \"function\") {\n",
+       "        // Use RequireJS to load module.\n",
+       "\t\tlet srcWithoutExtension = src.substring(0, src.lastIndexOf(\".js\"));\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': srcWithoutExtension\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(plotly) {\n",
+       "            runJSFn(plotly)\n",
+       "        });\n",
+       "        return\n",
+       "    }\n",
+       "\n",
+       "\tvar currentScripts = document.head.getElementsByTagName(\"script\");\n",
+       "\tfor (const idx in currentScripts) {\n",
+       "\t\tlet script = currentScripts[idx];\n",
+       "\t\tif (script.src == src) {\n",
+       "\t\t\trunJSFn(null);\n",
+       "\t\t\treturn;\n",
+       "\t\t}\n",
+       "\t}\n",
+       "\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\n",
+       "\tscript.charset = \"utf-8\";\n",
+       "\t\n",
+       "\tscript.src = src;\n",
+       "\tscript.onload = script.onreadystatechange = function () { runJSFn(null); };\n",
+       "\tdocument.head.appendChild(script);\t\n",
+       "})();\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t- trained to step 4000, median train step: 10415 microseconds\n",
       "\n",
       "Results on train:\n",
-      "\tMean Loss+Regularization (#loss+): 0.013\n",
-      "\tMean Loss (#loss): 0.013\n",
-      "\tMean Accuracy (#acc): 99.59%\n",
+      "\tMean Loss+Regularization (#loss+): 0.014\n",
+      "\tMean Loss (#loss): 0.014\n",
+      "\tMean Accuracy (#acc): 99.57%\n",
       "Results on test:\n",
-      "\tMean Loss+Regularization (#loss+): 0.028\n",
-      "\tMean Loss (#loss): 0.028\n",
-      "\tMean Accuracy (#acc): 99.06%\n",
+      "\tMean Loss+Regularization (#loss+): 0.030\n",
+      "\tMean Loss (#loss): 0.030\n",
+      "\tMean Accuracy (#acc): 98.95%\n",
       "\n"
      ]
     }
    ],
    "source": [
     "%% --checkpoint=cnn --set=\"model=cnn;train_steps=4000;plots=true\"\n",
+    "trainModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CNN Model Training with Triplet Loss\n",
+    "\n",
+    "Let's train the CNN using triplet loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training cnn model:\n",
+      "\t- checkpoint in /home/rener/work/mnist/cnn_triplet\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training (4000 steps):    0% [........................................] (6 steps/s) [4s:10m10s] [step=35] [loss+=0.541] [~loss+=0.612] [~loss=0.612] [~acc=9.83%]         "
+     ]
+    },
+    {
+     "data": {
+      "text/html": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training (4000 steps):   45% [=================>......................] (51 steps/s) [59s:42s] [step=1807] [loss+=0.329] [~loss+=0.334] [~loss=0.334] [~acc=15.73%]         \n",
+      "\t- saving checkpoint@1809\n",
+      "Training (4000 steps):  100% [========================================] (36 steps/s) [step=3999] [loss+=0.316] [~loss+=0.318] [~loss=0.318] [~acc=20.09%]        2%]         \n",
+      "\n",
+      "\t- saving checkpoint@4000\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p><b>Metric: accuracy</b></p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"3628dc3e\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script charset=\"UTF-8\">\n",
+       "(() => {\n",
+       "\tconst src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\";\n",
+       "\tvar runJSFn = function(module) {\n",
+       "\t\t\n",
+       "\tif (!module) {\n",
+       "\t\tmodule = window.Plotly;\n",
+       "\t}\n",
+       "\tlet data = JSON.parse('{\"data\":[{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.12545454502105713,0.1090579703450203,0.09756755828857422,0.0925000011920929,0.09213965386152267,0.09530612826347351,0.10081230103969574,0.1013774499297142,0.10441573709249496,0.10521069914102554,0.10901299118995667,0.11057387292385101,0.11127966642379761,0.11062858998775482,0.11149653047323227,0.11368957906961441,0.1196933165192604,0.12687166035175323,0.1393318772315979,0.15762583911418915,0.180546835064888,0.19437533617019653,0.20152559876441956,0.20216502249240875,0.20091305673122406]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.14464999735355377,0.03841666877269745,0.05900000035762787,0.06763333082199097,0.09378333389759064,0.10331666469573975,0.10965000092983246,0.10743333399295807,0.10241666436195374,0.11696666479110718,0.11438333243131638,0.1156499981880188,0.11438333243131638,0.11654999852180481,0.1148499995470047,0.11910000443458557,0.1357833296060562,0.13680000603199005,0.15396666526794434,0.1657000035047531,0.19484999775886536,0.20283333957195282,0.20368333160877228,0.19671666622161865,0.1898166686296463]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Accuracy\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.15470001101493835,0.037400003522634506,0.05820000171661377,0.06640000641345978,0.09070000797510147,0.09810000658035278,0.10510000586509705,0.10600000619888306,0.09970000386238098,0.11490000784397125,0.11430000513792038,0.11680000275373459,0.1169000044465065,0.11660000681877136,0.11550000309944153,0.11960000544786453,0.13860000669956207,0.13760000467300415,0.1534000039100647,0.16690000891685486,0.19510000944137573,0.20190000534057617,0.20340001583099365,0.19620001316070557,0.19120000302791595]}],\"layout\":{\"legend\":{},\"title\":{\"text\":\"accuracy\"},\"xaxis\":{\"showgrid\":true,\"type\":\"log\"},\"yaxis\":{\"showgrid\":true,\"type\":\"log\"}}}');\n",
+       "\tmodule.newPlot('3628dc3e', data);\n",
+       "\n",
+       "\t}\n",
+       "\t\n",
+       "    if (typeof requirejs === \"function\") {\n",
+       "        // Use RequireJS to load module.\n",
+       "\t\tlet srcWithoutExtension = src.substring(0, src.lastIndexOf(\".js\"));\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': srcWithoutExtension\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(plotly) {\n",
+       "            runJSFn(plotly)\n",
+       "        });\n",
+       "        return\n",
+       "    }\n",
+       "\n",
+       "\tvar currentScripts = document.head.getElementsByTagName(\"script\");\n",
+       "\tfor (const idx in currentScripts) {\n",
+       "\t\tlet script = currentScripts[idx];\n",
+       "\t\tif (script.src == src) {\n",
+       "\t\t\trunJSFn(null);\n",
+       "\t\t\treturn;\n",
+       "\t\t}\n",
+       "\t}\n",
+       "\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\n",
+       "\tscript.charset = \"utf-8\";\n",
+       "\t\n",
+       "\tscript.src = src;\n",
+       "\tscript.onload = script.onreadystatechange = function () { runJSFn(null); };\n",
+       "\tdocument.head.appendChild(script);\t\n",
+       "})();\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p><b>Metric: loss</b></p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"5bfdc512\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script charset=\"UTF-8\">\n",
+       "(() => {\n",
+       "\tconst src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\";\n",
+       "\tvar runJSFn = function(module) {\n",
+       "\t\t\n",
+       "\tif (!module) {\n",
+       "\t\tmodule = window.Plotly;\n",
+       "\t}\n",
+       "\tlet data = JSON.parse('{\"data\":[{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Batch Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.6440713405609131,0.5722668766975403,0.5483899116516113,0.49549931287765503,0.47092121839523315,0.45330125093460083,0.4292662739753723,0.4089389741420746,0.3987719416618347,0.3878205716609955,0.37362155318260193,0.3659020960330963,0.3716032803058624,0.36011064052581787,0.3519861400127411,0.34948399662971497,0.34356793761253357,0.3385467529296875,0.3409159779548645,0.33368879556655884,0.32981958985328674,0.32515987753868103,0.32021304965019226,0.3172653913497925,0.31573352217674255]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.6703252792358398,0.6405837535858154,0.6099338531494141,0.5805230736732483,0.5562132596969604,0.534018337726593,0.5102975368499756,0.48420432209968567,0.4581245183944702,0.4332716763019562,0.4112738370895386,0.39338281750679016,0.379173219203949,0.3685249090194702,0.36030465364456177,0.35394054651260376,0.3479679822921753,0.3426474332809448,0.33806923031806946,0.33355584740638733,0.32926619052886963,0.3252028822898865,0.3219218850135803,0.3189409673213959,0.3181019723415375]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Train: Moving Average Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.6703252792358398,0.6405837535858154,0.6099338531494141,0.5805230736732483,0.5562132596969604,0.534018337726593,0.5102975368499756,0.48420432209968567,0.4581245183944702,0.4332716763019562,0.4112738370895386,0.39338281750679016,0.379173219203949,0.3685249090194702,0.36030465364456177,0.35394054651260376,0.3479679822921753,0.3426474332809448,0.33806923031806946,0.33355584740638733,0.32926619052886963,0.3252028822898865,0.3219218850135803,0.3189409673213959,0.3181019723415375]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.5921525359153748,0.4995710253715515,0.47140589356422424,0.4494246542453766,0.4278237819671631,0.4089750647544861,0.393915057182312,0.3823387026786804,0.37324830889701843,0.3651495575904846,0.3585117757320404,0.3528130352497101,0.3481290936470032,0.3438303470611572,0.34011533856391907,0.33670929074287415,0.3329242467880249,0.3295123279094696,0.3260350227355957,0.322793185710907,0.319099485874176,0.3161572217941284,0.3135090470314026,0.3109006881713867,0.31047987937927246]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on train: Mean Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.5921525359153748,0.4995710253715515,0.47140589356422424,0.4494246542453766,0.4278237819671631,0.4089750647544861,0.393915057182312,0.3823387026786804,0.37324830889701843,0.3651495575904846,0.3585117757320404,0.3528130352497101,0.3481290936470032,0.3438303470611572,0.34011533856391907,0.33670929074287415,0.3329242467880249,0.3295123279094696,0.3260350227355957,0.322793185710907,0.319099485874176,0.3161572217941284,0.3135090470314026,0.3109006881713867,0.31047987937927246]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Loss+Regularization\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.5883098840713501,0.49272584915161133,0.46542277932167053,0.444530189037323,0.4238693416118622,0.40569761395454407,0.39081141352653503,0.37911778688430786,0.3702659010887146,0.362199604511261,0.35559847950935364,0.35019779205322266,0.345754474401474,0.341685026884079,0.3381304144859314,0.3350205719470978,0.3315841555595398,0.3283120393753052,0.32515043020248413,0.32232367992401123,0.31881797313690186,0.3161730170249939,0.3136442303657532,0.31123051047325134,0.3109862208366394]},{\"type\":\"scatter\",\"line\":{\"shape\":\"linear\"},\"mode\":\"lines+markers\",\"name\":\"Eval on test: Mean Loss\",\"x\":[10,22,36,53,73,97,126,161,203,253,313,385,471,574,698,847,1026,1241,1499,1809,2181,2627,3162,3804,4000],\"y\":[0.5883098840713501,0.49272584915161133,0.46542277932167053,0.444530189037323,0.4238693416118622,0.40569761395454407,0.39081141352653503,0.37911778688430786,0.3702659010887146,0.362199604511261,0.35559847950935364,0.35019779205322266,0.345754474401474,0.341685026884079,0.3381304144859314,0.3350205719470978,0.3315841555595398,0.3283120393753052,0.32515043020248413,0.32232367992401123,0.31881797313690186,0.3161730170249939,0.3136442303657532,0.31123051047325134,0.3109862208366394]}],\"layout\":{\"legend\":{},\"title\":{\"text\":\"loss\"},\"xaxis\":{\"showgrid\":true,\"type\":\"log\"},\"yaxis\":{\"showgrid\":true,\"type\":\"log\"}}}');\n",
+       "\tmodule.newPlot('5bfdc512', data);\n",
+       "\n",
+       "\t}\n",
+       "\t\n",
+       "    if (typeof requirejs === \"function\") {\n",
+       "        // Use RequireJS to load module.\n",
+       "\t\tlet srcWithoutExtension = src.substring(0, src.lastIndexOf(\".js\"));\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': srcWithoutExtension\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(plotly) {\n",
+       "            runJSFn(plotly)\n",
+       "        });\n",
+       "        return\n",
+       "    }\n",
+       "\n",
+       "\tvar currentScripts = document.head.getElementsByTagName(\"script\");\n",
+       "\tfor (const idx in currentScripts) {\n",
+       "\t\tlet script = currentScripts[idx];\n",
+       "\t\tif (script.src == src) {\n",
+       "\t\t\trunJSFn(null);\n",
+       "\t\t\treturn;\n",
+       "\t\t}\n",
+       "\t}\n",
+       "\n",
+       "\tvar script = document.createElement(\"script\");\n",
+       "\n",
+       "\tscript.charset = \"utf-8\";\n",
+       "\t\n",
+       "\tscript.src = src;\n",
+       "\tscript.onload = script.onreadystatechange = function () { runJSFn(null); };\n",
+       "\tdocument.head.appendChild(script);\t\n",
+       "})();\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t- trained to step 4000, median train step: 17454 microseconds\n",
+      "\n",
+      "Results on train:\n",
+      "\tMean Loss+Regularization (#loss+): 0.310\n",
+      "\tMean Loss (#loss): 0.310\n",
+      "\tMean Accuracy (#acc): 18.98%\n",
+      "Results on test:\n",
+      "\tMean Loss+Regularization (#loss+): 0.311\n",
+      "\tMean Loss (#loss): 0.311\n",
+      "\tMean Accuracy (#acc): 19.12%\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%% --checkpoint=cnn_triplet --set=\"model=cnn;loss=triplet;triplet_loss_mining_strategy=all;triplet_loss_pairwise_distance_metric=cosine;triplet_loss_margin=-1.0;train_steps=4000;plots=true\"\n",
     "trainModel()"
    ]
   },
@@ -699,100 +1238,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<p>Image: (28 x 28)</p>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAACXBIWXMAAAsTAAALEwEAmpwYAAAC+0lEQVRIia2VO0szQRSGz+6O5uKCkChWIgYEQUUjCYKlhZZWBiwsbFKIf0FSKKI2/gQhIGrAC4JBUgQEi+C1UAzYC24Es0ajk53ZGYvBEPf2+aGn2j0z85x9z2VW0nXdNE2EEOccfmeSJFFKm5ub0evrq6qqfwjFGEuVSkVVVUmSfkkUxjmvVCoyY4xS+idEAKCUcs5lWZb/ilg3VKvVAoHAP/fpur69vQ0AIlGcc4TQ9PR0S0uLA9Q0TQ+Wpmm5XI5SenBwcHh4aFm9vr5eW1tz4L68vBiGwZ0sm82OjY05BqsnLZVKNR4xDKNcLsuMMbfPLBQK+XxePA8ODo6Ojo6MjAwPD/v9flENAMhkMg7yPZopmUxijD8+Pjo6OqampgKBAGOMMZbP5+fn5zHGiqKMj487nHx6enKT72alUsnv9wNAKBTK5XLO8v+rqwzDWFpawhgDQCwWi0ajDvJ9Ph9jTFGUn+DS6fTR0dHJyYnw9Pf3t7W1OUC9R75UKl1cXMiyXKvV0un03t6e8Le2tiYSiUQi4XzMraVM01xfXx8aGoKvhm+0lZUVx3SLnCKMcTAYtAdjjC0uLj4/PwOAXc3j46OHPknTtFAohBCyQ3d2dnZ3d3t6etrb2ymlwWBQ1/X9/f2rq6ve3t7z83NVVS2nCCHVahV0XfdoKYyxxSPGIRqNvr29ucn3migA8Pl8Fk9nZ6fQ4TE1zlefiGn3X15ezszMAIA9Xd+ghBBLzM3NzXg8XiwWLVtvb28nJycLhQIAmKbZ1NTkBrUGXF1dXVhYIIQcHx9TSt/f3xFClNJsNru1tfXw8AAA8Xg8lUp5QK19OjExIfxdXV19fX2RSCQSiYg8AoCiKLOzs/f3926FFYWyVv/u7m5ubs4eOxwOJ5PJ09NTN9w3qH2iCCEbGxviHxOLxZaXl8/OzorFYrVa9SbWoZKmaeFw2H6h3NzclMvl7u7uuvafmGh+5NYcAwMDP2dZTJZlmRBSf2eM8a9J55w3vgqP22rj0ieuZu0WF49iIgAAAABJRU5ErkJggg=="
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025/02/14 02:29:03 Must not error: requested variable \"weights\" in scope \"/model/model/000_conv/conv\" with Context.Reuse set, but variable does not exist\n",
-      "github.com/gomlx/exceptions.Panicf\n",
-      "\t/home/rener/.local/go/pkg/mod/github.com/gomlx/exceptions@v0.0.3/exceptions.go:92\n",
-      "github.com/gomlx/gomlx/ml/context.(*Context).VariableWithShape\n",
-      "\t/home/rener/dev/gomlx/ml/context/context.go:772\n",
-      "github.com/gomlx/gomlx/ml/layers.(*ConvBuilder).Done\n",
-      "\t/home/rener/dev/gomlx/ml/layers/convolution.go:285\n",
-      "github.com/gomlx/gomlx/examples/mnist.CnnEmbeddings\n",
-      "\t/home/rener/dev/gomlx/examples/mnist/model.go:72\n",
-      "github.com/gomlx/gomlx/examples/mnist.CnnModelGraph\n",
-      "\t/home/rener/dev/gomlx/examples/mnist/model.go:46\n",
-      "github.com/gomlx/gomlx/examples/mnist/classifier.New.func1\n",
-      "\t/home/rener/dev/gomlx/examples/mnist/classifier/classifier.go:66\n",
-      "reflect.Value.call\n",
-      "\t/usr/local/go/src/reflect/value.go:581\n",
-      "reflect.Value.Call\n",
-      "\t/usr/local/go/src/reflect/value.go:365\n",
-      "github.com/gomlx/gomlx/ml/context.(*Exec).buildGraphFn.func1\n",
-      "\t/home/rener/dev/gomlx/ml/context/exec.go:312\n",
-      "reflect.Value.call\n",
-      "\t/usr/local/go/src/reflect/value.go:581\n",
-      "reflect.Value.Call\n",
-      "\t/usr/local/go/src/reflect/value.go:365\n",
-      "github.com/gomlx/gomlx/graph.(*Exec).createAndCacheGraph\n",
-      "\t/home/rener/dev/gomlx/graph/exec.go:536\n",
-      "github.com/gomlx/gomlx/graph.(*Exec).findOrCreateGraph\n",
-      "\t/home/rener/dev/gomlx/graph/exec.go:595\n",
-      "github.com/gomlx/gomlx/graph.(*Exec).compileAndExecute\n",
-      "\t/home/rener/dev/gomlx/graph/exec.go:436\n",
-      "github.com/gomlx/gomlx/graph.(*Exec).CallWithGraph\n",
-      "\t/home/rener/dev/gomlx/graph/exec.go:386\n",
-      "github.com/gomlx/gomlx/ml/context.(*Exec).CallWithGraph\n",
-      "\t/home/rener/dev/gomlx/ml/context/exec.go:541\n",
-      "github.com/gomlx/gomlx/ml/context.(*Exec).Call\n",
-      "\t/home/rener/dev/gomlx/ml/context/exec.go:527\n",
-      "github.com/gomlx/gomlx/examples/mnist/classifier.(*Classifier).Classify.func1\n",
-      "\t/home/rener/dev/gomlx/examples/mnist/classifier/classifier.go:83\n",
-      "github.com/gomlx/exceptions.TryCatch[...]\n",
-      "\t/home/rener/.local/go/pkg/mod/github.com/gomlx/exceptions@v0.0.3/exceptions.go:85\n",
-      "github.com/gomlx/gomlx/examples/mnist/classifier.(*Classifier).Classify\n",
-      "\t/home/rener/dev/gomlx/examples/mnist/classifier/classifier.go:83\n",
-      "main.main\n",
-      "\t \u001b[7m[[ Cell [21] Line 22 ]]\u001b[0m /tmp/gonb_eb357154/main.go:247\n",
-      "runtime.main\n",
-      "\t/usr/local/go/src/runtime/proc.go:283\n",
-      "runtime.goexit\n",
-      "\t/usr/local/go/src/runtime/asm_amd64.s:1700\n",
-      "Panicking ...\n",
-      "\n",
-      "panic: requested variable \"weights\" in scope \"/model/model/000_conv/conv\" with Context.Reuse set, but variable does not exist\n",
-      "\n",
-      "goroutine 1 [running]:\n",
-      "github.com/janpfeifer/must.init.func1({0xeb6a00, 0xc000165050})\n",
-      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:13 +0xd3\n",
-      "github.com/janpfeifer/must.M1[...](...)\n",
-      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:41\n",
-      "main.main()\n",
-      "\t \u001b[7m[[ Cell [21] Line 22 ]]\u001b[0m /tmp/gonb_eb357154/main.go:247 +0x4a2\n",
-      "panic: requested variable \"weights\" in scope \"/model/model/000_conv/conv\" with Context.Reuse set, but variable does not exist\n",
-      "\n",
-      "goroutine 1 [running]:\n",
-      "github.com/janpfeifer/must.init.func1({0xeb6a00, 0xc000165050})\n",
-      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:13 +0xd3\n",
-      "github.com/janpfeifer/must.M1[...](...)\n",
-      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:41\n",
-      "main.main()\n",
-      "\t \u001b[7m[[ Cell [21] Line 22 ]]\u001b[0m /tmp/gonb_eb357154/main.go:247 +0x4a2\n",
-      "exit status 2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import (\n",
     "    \"encoding/base64\"\n",

--- a/examples/mnist/mnist.ipynb
+++ b/examples/mnist/mnist.ipynb
@@ -1,0 +1,841 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MNIST\n",
+    "\n",
+    "MNIST is a simple computer vision dataset that consists of images of handwritten digits.\n",
+    "\n",
+    "Some examples:\n",
+    "\n",
+    "![MNIST digits sample](https://github.com/user-attachments/assets/996c11e0-47f9-4b21-8e23-3867b8942e64)\n",
+    "\n",
+    "It also includes labels for each image, which we use to train our example models.\n",
+    "\n",
+    "## The `mnist` library\n",
+    "\n",
+    "This package includes the following functionality:\n",
+    "\n",
+    "  - Download the dataset from [storage.googleapis.com/cvdf-datasets/mnist](https://storage.googleapis.com/cvdf-datasets/mnist),\n",
+    "  - Create a `Dataset` object to iterate over it, use for training and evaluation.\n",
+    "  - A linear and a CNN model demo.\n",
+    "  - A command-line demo (in the `demo` sub-directory).\n",
+    "\n",
+    "This notebook serves as documentation and example for the [github.com/gomlx/gomlx/examples/mnist](https://github.com/gomlx/gomlx/examples/mnist) library, and the demo code in one piece can be seen in [.../examples/mnist/demo/](https://github.com/gomlx/gomlx/tree/main/examples/mnist/demo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment Set Up\n",
+    "\n",
+    "Let's set up `go.mod` to use the local copy of GoMLX, so it can be developed jointly the dataset code with the model. That's often how data pre-processing and model code is developed together with experimentation.\n",
+    "\n",
+    "If you are not changing code, feel free to simply skip this cell. Or if you used a different directory for you projects, change it below.\n",
+    "\n",
+    "Notice the directory `${HOME}/Projects/gomlx` is where the GoMLX code is copied by default in [its Docker](https://hub.docker.com/repository/docker/janpfeifer/gomlx_jupyterlab/general)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t- Added replace rule for module \"github.com/gomlx/gomlx\" to local directory \"/home/rener/dev/gomlx\".\n"
+     ]
+    }
+   ],
+   "source": [
+    "!*rm -f go.work && go work init && go work use . \"${HOME}/dev/gomlx\"\n",
+    "%goworkfix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Preparation\n",
+    "\n",
+    "### Downloading data files\n",
+    "\n",
+    "To download to the local directory, simply do the following. Notice if it's already downloaded in the given `--data` directory, it returns immediately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import (\n",
+    "    \"github.com/gomlx/gomlx/examples/mnist\"\n",
+    "    \"github.com/gomlx/gomlx/ml/data\"\n",
+    "    \"github.com/janpfeifer/must\"\n",
+    ")\n",
+    "\n",
+    "var flagDataDir = flag.String(\"data\", \"~/work/mnist\", \"Directory to cache downloaded and generated dataset files.\")\n",
+    "\n",
+    "func AssertDownloaded() {\n",
+    "    *flagDataDir = data.ReplaceTildeInDir(*flagDataDir)\n",
+    "    if !data.FileExists(*flagDataDir) {\n",
+    "        must.M(os.MkdirAll(*flagDataDir, 0777))\n",
+    "    }\n",
+    "\n",
+    "   must.M(mnist.Download(*flagDataDir))\n",
+    "}\n",
+    "\n",
+    "%%\n",
+    "AssertDownloaded()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 12M\n",
+      "-rw-r--r-- 1 rener rener 1.6M Feb 13 23:43 t10k-images-idx3-ubyte.gz\n",
+      "-rw-r--r-- 1 rener rener 4.5K Feb 13 23:43 t10k-labels-idx1-ubyte.gz\n",
+      "-rw-r--r-- 1 rener rener 9.5M Feb 13 23:43 train-images-idx3-ubyte.gz\n",
+      "-rw-r--r-- 1 rener rener  29K Feb 13 23:43 train-labels-idx1-ubyte.gz\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -lh ~/work/mnist/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sample some images\n",
+    "The `mnist.NewDataset` creates a `data.InMemoryDataset` that can be used both for training, evaluation, or just to sample a few examples, which we do below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p>Samples MNIST</p>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table><tr>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABzklEQVR4nNyVMcviMBiADz2VqFsbdRTBgkoR3PwBLtbFWbq5uYjoH3ATBNFB0OlEHF38Aw4ZBaU4iJOOFamDBF1McmCglA+xd19798H3THlj8vj2zdvU8+Mf8C2lxWKRMUYI6XQ6Pp/PhT8vl8sYY0LI44ksyy5IN5vN4/FwU1qtVjHGphQhBABwZMxkMrfbjSfIpe12+/2Wn+9/9nq9iqIEAgEeejweSilCyJHU7/eXSiXGGA8ppeb4DTYtdb/fu92udQZjbBiGrdcGAIAsy/P5nNd0vV47zZQnu91uY7EYD1erldM0OZIknU4nQsj1ek2n0+5IK5UKbylN0/5k/evTFwRBVVVBEBBCEMJer8fnp9Pp51Or1+vWbjeZzWaJROIzxkgkstvtXkoJIZfLZTAYNJvNUCj0F9JsNkueRKPR5XJJLPCrzxrqul6r1T7chC9aCkLInoiieDwe+Xi/32uaxt8oE0qpKIr9fr/RaFgNLw4qGAzywWKxiMfjjDHDMBRFORwOhUIBQqiqaj6fD4fD5pZUKmXz+ACA8XhsFvF8PrdarQ9rksnkcDicTCa/nuRyOfuySpKk6zqXjkYj+w3/ga/+mn5H6e8AAAD//ypsSsmQzB9KAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAB6UlEQVR4nOyVr6siURTH7503GLwIlrFYTCZFLWaT3TBhwvwH/sKixWgSDYLFIAgKChYxaLCoRQSzigjiBJVhBHHAET264bKzb5flvafjLizsJ10unM/9Hg4zh0F/gP/SvyXFGDudzlQqdTweb9+53+/T6TSTyTz5FM/z8A5Jklqt1nq9BoDT6ZTL5Z6RJhIJAJjP54IgOBwOjuMQQhzHxWIxABgMBh+X/779/X6PEGJZdjwer1YrWZYRQrIsVyoVVVUVRXkmKcuyy+USABqNxvt7URQVRbHZbM9IEUJWq7XX610ul2w2+/b2Ri8FQdhut+RnMMaPqSVJAoB2u22xWAghgiBomqYP8HA4TCYTlmUfk4bDYVpfKBTq9bqu63Q60WjU5XI9pqNgjMvlsu7SNK3ZbHIc93C6X/D5fLpUFMWvlHz+mfI8r5/dbrehgBSMca1WAwBZlmn7wWDQqJQQQhu32+39fh8AhsPhy6SRSMTv9+92u/P5HI/HDUkxxsVikbZvNpvz+TwAjEYjk8lkyKtPP5lMiqJIz16v94OSz6c/m82q1SpCKJ1OE0JUVTWU8cfLDLNYLADger3SpKVSyVBShNDtdguFQpvNRv93MMyL9pDH4+l2uzRpIBB4jfTr/Dsr+lsAAAD//3+5LEbYr36zAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([8])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABhUlEQVR4nOyVsarCMBSGQ+hkFy2KmwgVC4KDk7vgC7g5KW5OTj6DGXyGTplc3Bx0kryCgkocBYWAQbfAqRcMiKi17b2Vu/hNoSf5zp+0oRh9gK/0K/WpYVwsFskVIYR35XK56MFqtSKEWJYVrWG73YYgBoPB80LjTcx6va7HUsrxeDyZTO4nEEJs244Ws9Vq3eI0m82HaqVSkVL6JfVlu90CwPF4bDQapmnel1Kp1HQ61f0cx4kgPZ/PALBYLJ5LnU5HGymlGL941b5nqpQyDIMx9vDcsqxer6fHs9nM87wISV+CMXZdV8ccDofJZPKvRoRQPp/Xxvl8nk6nYzAihJbLJQBwzjOZTDxG27aVUgAwGo1CLSiXy+8nFAoFzjkAnE6narUaSlqr1d5PuN2Ffr8fyhhIIpHQpymEePlh/gbGmI4ZduOBOI5zOBwAYL/fG4bvZYmAaZqUUgDY7XbdbjcGI0KoVCrpjbuuG37VR34nAWSz2c1ms16vc7ncP7S/5ycAAP//TbzwnBdu+2kAAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([7])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACK0lEQVR4nOyVy2viUBTGL9NpSwuhkFJoodAWmlIodFG6TUgh7SoU8YGo+NroSvwnBJeCW0FQXAiCK9GFiIhmoSAug4Ki+NwFMaDmgbO4cJFhHOM4XQzMtzo5ud8v300Oud/AF+g/9B+Bft9pNYZh7+/vLy8vl5eXbrcb9W9vb/v9/m5Pvri4uLq60uv1qqoqv1K5XD46OtqB6Pf7BUGAZgidz+fBYNDlcvE8D/uhUGjdsnH7p6enDMPYbLbr62sMw2BzsVg4nU5RFJvNpsfjwXEcAJBMJmOx2PZ0Dw8PkUhkfYMcxy2XS0mSDAYDSZKFQgH2J5OJyWTaTjw/Px+NRghXKpVYliUIQhRFVVW73S66NR6PKYraTjw8PIxGoygFy7InJycAAJ/Ph94pUiaT2U4EAHx8fCCPxWJBfYZharWaRujPH+r19RUWXq83nU7D2uFwnJ2d3d3dra+sVqt2u11T0kAgAFN0Op1GozGdTnO5nCzL6yOlKMpwOHx6etJEBADQNM1xnLpBq9UKcnU6nVYiFEVR2WxWEITBmiRJQknD4fBuRKTn52dUf35+zmYzCI3H4wRB/CEU6fHxEc3mYDAwm837EgEA9XodzRBN01osv/v14ThutVrv7+/hZT6fb7fb+2YkSRJlTCQSBwcH+xLf3t6KxSIk8jx/c3Oj3bvxOJFlmSRJWFcqlV6vt29MAIDRaGy1WoqipFKp4+Pjv0DcU19ymv4IAAD//0Son78ABw7NAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([9])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAByElEQVR4nNyVz8spURjHH7eLUGOjLJUsZmFjOSVLFpL8BdSxkp0s7KdslVJWs7awoCjZ2SkKG2OhWElCpqZGnuPcek+p632vH925dXs/u3PmzOd8T53nOT/gH/CdpFartVgsyrJsGAZjjFKqKMrjX34+cOVyOb/fHwgEYrEYn7xer4wxSZLeTw/g9XrL5TL+zm63o5QioqqqbxtFUVwul1x0OBxGH6TT6WAw+KL0i+MnEgmfz6eqaq1WGw6H4/H47Vyfsdls4XDY4/F8/sSTdjodE7bhEEK4NJPJmCZdrVaU0l6vJwiCOUZCyOVyoZTm8/mni1+tKKfTabFYdF2v1+t/nfADSZI0TaOUNptNc4wAsFgsEPF0OplmjEajx+MREQuFgjnGUCi03+8RcbPZOBwOc6SKovB6fSvmH7sUAKRSqWQyCQDdbrdard7mXS5XJBK5DQeDga7rr0qz2Sy/55PJhNtLpRJjzG63i6J4W9ZoNAghhmE8yS8IQqvV0jTtrvvxMr1jPp+73e7nSWVZjsfjjzdut9vr9RoAKpXK3W37Wjqbze6G2+12Op0iYr/fH41GAHA+nxHxyZFN5Ds90f+L9FcAAAD//08ME1mBZRmYAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABBklEQVR4nOyVMWqEUBCG52XzBAXBQrQVrSzF3sLCO3gCz2Fv4S0sbLzAO4FeQbG1FWyCxsA+IqR6s5sJ2+Sr/mLmm19EfIM/4F+KZRiGtm0pj9u2PU3Ttm1RFCmHsU3f7+i6bpommfTjDgD4vk8mDYJA6rIsI5MCAGMMOfmA9DxPeikelJQxluc58WVN0z6/qeuaXpokiXIe9fhFUciwLMs4jr8uCeA4Tt/3smbXdZgVddMwDOM4llkIQSP1PO/K8zxjpGqaprneEuccs6Joyjl3XVdmIcRxHAQ1Lcu6aqZpitx64DNd1/XZbj+53W5VVe37XpalYRg00ud49d/0xdKvAAAA//+9OmZ0PsqwdAAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([1])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABQUlEQVR4nOTVoY7CQBAG4LnjFAlBLA7W8gCA4AkQOCQKgeAtwGBROBKeAccToEgqarZJq1b0AZptsmZm95LWXS6FNlNxuV93vsy0091PaCH/HO00qJFSPp/PwWDweDycczyNnE4nLDIajXhEAEjTlB8lIkRUSvX7fR5xv99774loPp/ziMfj0RhDREopIQSDKISIoggR8zxfrVYMIgBcr9fy+9xuNx5RSklFsiybTqfVD3+9iW63W+89AFwulyAIGNpcr9flGiHibDZjEMfjsda6RA+HQ6fT5M/+mfP5TETOOWvtZDJhEHu9XhiGiGit3e12DCIAbDab8lVqrd+venGeLpfLBq28WKmPIgBwv98b6L9ECKG1LsevVVg1frfbHQ6HABDHcS20anxjTJIk3vvFYlELbSV/54puBf0OAAD//2hLpMiDLXAUAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([1])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABqElEQVR4nNyUv4rqQBSHT/6IiE2CGhJQG7EQ9AHUVixsJVXIS6iPYCHYasDWRuyChdgHbiHYWGhh6VRqI4gghMktZGWMmWDc3SL7lZM53/nlJDMs/AJ/QBqPxw3DwASn00mWZVEUP+/W6XTsZzDGtm1blpXNZv1rOdqDSqVSq9XIFYZhHMfJZDLFYvFwOORyuev1erlcAiRtNBrr9fo1KYmmacGS7na7/X6PEPr3RbVadRyH3HO73Var1fl8DhDWRbvd7vf7rrDT6VRRlM+lACCKoqZpw+GQ9JZKpW9J7+i67i8Nz4nigxZEo1FBEDiOe/wJiUSCZVmM8WMPQyuWJMnzs5bL5cFg4FpUFOV4PPplSSaT9Xp9NBp5HlNPVFWl6mKxmK7rvV7Ps9JHOplMSM/T68uyjBCitXQNDgDm8/lmswGAbrdLvQQMwyD7m6bZarW2261nUtM0C4WC3xzvuMqWy+V4PEYIvUpns9lbRgBQVZU2NVK6WCzy+fxbRgCIRCLNZtNfallWOp1+13iH53laXkmSUqmUIAjBjD9FeC6U8Ej/BwAA//+db9W84gMxHAAAAABJRU5ErkJggg==\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABlUlEQVR4nNyVL4sCURTFHyr+H5RJgsUilkmDRSwGweAnMGmxKgg2xTjZpJgMotg02EQwiEmTiNoFi8rAQ3nh3llwloVdWEdm3sLiaXM498eZucN7NvIHemNotVpFxNlsxq1CJBI5n88AUCgUuEG32y0AlEolp9PJh5jP5xFRURRuREJIp9NhjEmSxI0oSRJjrF6vcyMSQmq12nw+fzH80i/l8XhyudxisbBW7LvS6TQAyLL8Yt5umPB6ve122+fziaIoy/Jms7ndblZrRqNRfIhSqmkapTSTybhcricjxt80m81qD00mk1QqNRwOR6NRpVKx1LTVah2Px0QiIYqi7vT7fVVVBUEw3zQWi51Op+VyeblcdOdwOPj9frv9130YQAOBQDKZ/GGGQqHdbmd+XcFgEBHX6/WXE4/Hr9druVx+MmX8+vqWPtM2W7FYdLvd+/3eZE1CiCAIqqquViv9UVEUAGg0GuaJuprN5v1+H4/Hg8EAEbvdLoejLxwOT6dTeKjX6zkcDqtEc/oft+l7QT8CAAD//zG/qs3n8n/uAAAAAElFTkSuQmCC\"><figcaption style=\"text-align: center;\">([6])</figcaption></figure></td>\n",
+       "<td><figure style=\"padding:4px;text-align: center;\"><img width=\"56\" height=\"56\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACRUlEQVR4nOyVv0vrUBSA02dQCGaVRAQ30UkkS50EHePgEBEJmkFFHRy6OcUsbmZwMPkXzJoMIoIuHYSQCC6KTgaD2CFLSkvLObkPGuwrvqS/wOXxvuly77lfTs7hJL+oH+C/NBdd1+/u7mzbdl2XEGLb9sHBAU3Twz9tb28PEeGL9lrTtCGNKysrtVrN9/2tra3iFxcXF6lXVdVhpNfX1wDAsmzn5tjY2P7+PgA0m01RFAczHh8fI+LZ2VnmqWmaSZK8v79PT0/nGTIatbCwQAjheT7zwuHhISGE47idnZ0BpPf391EUjY+P5915fX2lKGp5eZlhmLyYDCYmJkZGRvJO5+bm0o5NTU0NIO0Oy7IPDw9d6j7ARE1OTqaLOI5fXl5Ii8zIbuPBMIwoihsbGzzPFwoFjuM+Pj583z86Ouo/lT/MzMyUSqUwDP+eKAAIgiCOYwCYnZ3t16goShiGiBgEgWEYpRYURa2urhqGEUVRkiSI+Pz83G+jFEV5e3v7/Pw8Pz/PDFhaWmpn/fT01C50N3RdB4DLy8u8AMMwELHcAgAeHx975yvLMgB4nvdt8FNUVW00GogoSdL6+npa60qlsru728NrWRYiuq7b+Wo0TWuahi0EQUg3BUFIq4+Isix3kxaLxdvbWwCoVqvb29uKoliW5ThOWkfTNDuDGYY5PT2VJGl+fr5HsouLi57nfftIl8vltbW10dHRHpcpqpB3wLLsyckJIWRzc9NxnKurq5ubm3q93tP4U/wbv+ih+R0AAP//61Ri370ayqkAAAAASUVORK5CYII=\"><figcaption style=\"text-align: center;\">([2])</figcaption></figure></td>\n",
+       "</tr></table>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import (\n",
+    "    \"fmt\"\n",
+    "    \"strings\"\n",
+    "\t\"strconv\"\n",
+    "    \"github.com/gomlx/gopjrt/dtypes\"\n",
+    "    \"github.com/gomlx/gomlx/backends\"\n",
+    "    \"github.com/gomlx/gomlx/examples/mnist\"\n",
+    "    \"github.com/gomlx/gomlx/types/shapes\"\n",
+    "    \"github.com/gomlx/gomlx/types/tensors/images\"\n",
+    "    \"github.com/janpfeifer/gonb/gonbui\"\n",
+    "\n",
+    "    _ \"github.com/gomlx/gomlx/backends/xla\"\n",
+    ")\n",
+    "\n",
+    "var (\n",
+    "    // Model DType, used everywhere.\n",
+    "    DType = dtypes.Float32\n",
+    ")\n",
+    "\n",
+    "// sampleToNotebook generates a sample of MNIST in a GoNB Jupyter Notebook.\n",
+    "func sampleToNotebook() {\n",
+    "    // Load data into tensors.\n",
+    "    backend := backends.New()\n",
+    "    if ds, err := mnist.NewDataset(backend, \"Samples MNIST\", *flagDataDir, \"train\", DType); err != nil {\n",
+    "        fmt.Printf(\"mnist.NewDataset: %v\", err)\n",
+    "    } else {\n",
+    "        ds.Shuffle()\n",
+    "        sampleImages(ds, 10)\n",
+    "    }\n",
+    "   \n",
+    "}\n",
+    "\n",
+    "// sampleTable generates and outputs one html table of samples, sampling rows x cols from the images/labels provided.\n",
+    "func sampleImages(ds train.Dataset, numImages int) {\n",
+    "    gonbui.DisplayHTML(fmt.Sprintf(\"<p>%s</p>\\n\", ds.Name()))\n",
+    "    \n",
+    "    parts := make([]string, 0, numImages+5) // Leave last part empty.\n",
+    "    parts = append(parts, \"<table><tr>\")\n",
+    "    for ii := 0; ii < numImages; ii++ {\n",
+    "        _, inputs, labels := must.M3(ds.Yield())\n",
+    "        imgTensor := inputs[0]\n",
+    "        img := images.ToImage().Single(imgTensor)\n",
+    "        label := labels[0].Value().([]int8)\n",
+    "    \n",
+    "        imgSrc := must.M1(gonbui.EmbedImageAsPNGSrc(img))\n",
+    "        size := imgTensor.Shape().Dimensions[0]\n",
+    "        parts = append(\n",
+    "            parts, \n",
+    "            fmt.Sprintf(`<td><figure style=\"padding:4px;text-align: center;\"><img width=\"%d\" height=\"%d\" src=\"%s\">` + \n",
+    "                        `<figcaption style=\"text-align: center;\">(%d)</figcaption></figure></td>`, \n",
+    "                        size*2, size*2, imgSrc, label),\n",
+    "        )\n",
+    "    }\n",
+    "    parts = append(parts, \"</tr></table>\", \"\")\n",
+    "    gonbui.DisplayHTML(strings.Join(parts, \"\\n\"))\n",
+    "}\n",
+    "\n",
+    "%%\n",
+    "AssertDownloaded()\n",
+    "sampleToNotebook()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training on MNIST\n",
+    "\n",
+    "### Models Support\n",
+    "\n",
+    "1. `flagModel` defines the model type, out of `validModels` options.\n",
+    "1. `createDefaultContext` creates a context and set the default values for the MNIST models. \n",
+    "1. `contextFromSettings` uses `createDefaultContext` and incorporate changes passed by the `-set` flag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model types: [\"linear\" \"cnn\"]\n",
+      "Parameters set (-set): [\"batch_size\" \"model\" \"train_steps\"]\n",
+      "\t\"/activation\": (string) relu\n",
+      "\t\"/adam_dtype\": (string) \n",
+      "\t\"/adam_epsilon\": (float64) 1e-07\n",
+      "\t\"/batch_size\": (int) 17\n",
+      "\t\"/cnn_dropout_rate\": (float64) 0.5\n",
+      "\t\"/cnn_normalization\": (string) layer\n",
+      "\t\"/cosine_schedule_steps\": (int) 0\n",
+      "\t\"/dropout_rate\": (float64) 0.5\n",
+      "\t\"/eval_batch_size\": (int) 1000\n",
+      "\t\"/l1_regularization\": (float64) 0\n",
+      "\t\"/l2_regularization\": (float64) 0\n",
+      "\t\"/learning_rate\": (float64) 0.0001\n",
+      "\t\"/loss\": (string) cross-entropy\n",
+      "\t\"/model\": (string) 'cnn'\n",
+      "\t\"/nan_logger\": (bool) false\n",
+      "\t\"/num_checkpoints\": (int) 3\n",
+      "\t\"/optimizer\": (string) adamw\n",
+      "\t\"/plots\": (bool) false\n",
+      "\t\"/train_steps\": (int) 10\n",
+      "Parameters set (-set): [\"batch_size\" \"model\" \"train_steps\"]\n",
+      "\t\"/activation\": (string) relu\n",
+      "\t\"/adam_dtype\": (string) \n",
+      "\t\"/adam_epsilon\": (float64) 1e-07\n",
+      "\t\"/batch_size\": (int) 17\n",
+      "\t\"/cnn_dropout_rate\": (float64) 0.5\n",
+      "\t\"/cnn_normalization\": (string) layer\n",
+      "\t\"/cosine_schedule_steps\": (int) 0\n",
+      "\t\"/dropout_rate\": (float64) 0.5\n",
+      "\t\"/eval_batch_size\": (int) 1000\n",
+      "\t\"/l1_regularization\": (float64) 0\n",
+      "\t\"/l2_regularization\": (float64) 0\n",
+      "\t\"/learning_rate\": (float64) 0.0001\n",
+      "\t\"/loss\": (string) cross-entropy\n",
+      "\t\"/model\": (string) 'cnn'\n",
+      "\t\"/nan_logger\": (bool) false\n",
+      "\t\"/num_checkpoints\": (int) 3\n",
+      "\t\"/optimizer\": (string) adamw\n",
+      "\t\"/plots\": (bool) false\n",
+      "\t\"/train_steps\": (int) 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "import (\n",
+    "    \"flags\"\n",
+    "    \n",
+    "    \"github.com/gomlx/gomlx/ml/layers\"\n",
+    "    \"github.com/gomlx/gomlx/ui/commandline\"\n",
+    "    \"github.com/gomlx/gomlx/ml/train/optimizers\"\n",
+    "    \"github.com/gomlx/gomlx/examples/mnist\"\n",
+    "    \"github.com/gomlx/gomlx/ml/context\"\n",
+    ")\n",
+    "\n",
+    "var (\n",
+    "    // ValidModels is the list of model types supported.\n",
+    "    ValidModels = []string{\"linear\", \"cnn\"}\n",
+    "\tflagEval      = flag.Bool(\"eval\", true, \"Whether to evaluate the model on the validation data in the end.\")\n",
+    ")\n",
+    "\n",
+    "// settings is bound to a \"-set\" flag to be used to set context hyperparameters.\n",
+    "var settings = commandline.CreateContextSettingsFlag(CreateDefaultContext(), \"set\")\n",
+    "\n",
+    "// createDefaultContext sets the context with default hyperparameters\n",
+    "func CreateDefaultContext() *context.Context {\n",
+    "\tctx := context.New()\n",
+    "\tctx.RngStateReset()\n",
+    "\tctx.SetParams(map[string]any{\n",
+    "\t\t// Model type to use\n",
+    "\t\t\"model\":           \"linear\",\n",
+    "\t\t\"num_checkpoints\": 3,\n",
+    "\t\t\"train_steps\":     4000,\n",
+    "\n",
+    "\t\t// batch_size for training.\n",
+    "\t\t\"batch_size\": 600,\n",
+    "\n",
+    "\t\t// eval_batch_size can be larger than training, it's more efficient.\n",
+    "\t\t\"eval_batch_size\": 1000,\n",
+    "\n",
+    "\t\t// Debug parameters.\n",
+    "\t\t\"nan_logger\": false, // Trigger nan error as soon as it happens -- expensive, but helps debugging.\n",
+    "\n",
+    "\t\t// \"plots\" trigger generating intermediary eval data for plotting, and if running in GoNB, to actually\n",
+    "\t\t// draw the plot with Plotly.\n",
+    "\t\t//\n",
+    "\t\t// From the command-line, an easy way to monitor the metrics being generated during the training of a model\n",
+    "\t\t// is using the gomlx_checkpoints tool:\n",
+    "\t\t//\n",
+    "\t\t//\t$ gomlx_checkpoints --metrics --metrics_labels --metrics_types=accuracy  --metrics_names='E(Tra)/#loss,E(Val)/#loss' --loop=3s \"<checkpoint_path>\"\n",
+    "\t\tplotly.ParamPlots: false,\n",
+    "\n",
+    "\t\toptimizers.ParamOptimizer:       \"adamw\",\n",
+    "\t\toptimizers.ParamLearningRate:    1e-4,\n",
+    "\t\toptimizers.ParamAdamEpsilon:     1e-7,\n",
+    "\t\toptimizers.ParamAdamDType:       \"\",\n",
+    "\t\tcosineschedule.ParamPeriodSteps: 0,\n",
+    "\t\tactivations.ParamActivation:     \"relu\",\n",
+    "\t\tlayers.ParamDropoutRate:         0.5,\n",
+    "\t\tregularizers.ParamL2:            0.0,\n",
+    "\t\tregularizers.ParamL1:            0.0,\n",
+    "\n",
+    "\t\t// CNN\n",
+    "\t\t\"cnn_dropout_rate\":  0.5,\n",
+    "\t\t\"cnn_normalization\": \"layer\", // \"layer\" or \"batch\".\n",
+    "\t})\n",
+    "\treturn ctx\n",
+    "}\n",
+    "\n",
+    "// ContextFromSettings is the default context (createDefaultContext) changed by -set flag.\n",
+    "func ContextFromSettings() (ctx *context.Context, paramsSet []string) {\n",
+    "    ctx = mnist.CreateDefaultContext()\n",
+    "    paramsSet = must.M1(commandline.ParseContextSettings(ctx, *settings))\n",
+    "    return\n",
+    "}\n",
+    "\n",
+    "// Let's test that we can set hyperparameters by setting it in the \"-set\" flag:\n",
+    "%% -set=\"batch_size=17;model='cnn';train_steps=10\"\n",
+    "fmt.Printf(\"Model types: %q\\n\", ValidModels)\n",
+    "ctx, parametersSet := ContextFromSettings()\n",
+    "fmt.Printf(\"Parameters set (-set): %q\\n\", parametersSet)\n",
+    "fmt.Println(commandline.SprintContextSettings(ctx))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linear model\n",
+    "\n",
+    "A linear model can easily get to ~92% accuracy (a random model would do 10%) with 4000 steps.\n",
+    "\n",
+    "Later we are going to define a CNN model to compare, and we just set a placeholder model here for now.\n",
+    "\n",
+    "> **Note**: \n",
+    ">\n",
+    "> * The code is here just to exemplify. We are actually using the same code from the [`mnist`](https://github.com/gomlx/gomlx/tree/main/examples/mnist) package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logits shape for batch_size=10: (Float32)[10 10]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import (\n",
+    "\t. \"github.com/gomlx/gomlx/graph\"\n",
+    "\t\"github.com/gomlx/gomlx/ml/context\"\n",
+    "\t\"github.com/gomlx/gomlx/ml/layers\"\n",
+    ")\n",
+    "\n",
+    "var _ = NewGraph  // Make sure the graph package is in use.\n",
+    "\n",
+    "// LinearModelGraph builds a simple  model logistic model\n",
+    "// It returns the logit, not the predictions, which works with most losses with shape `[batch_size, NumClasses]`.\n",
+    "// inputs: only one tensor, with shape `[batch_size, width, height, depth]`.\n",
+    "func LinearModelGraph(ctx *context.Context, spec any, inputs []*Node) []*Node {\n",
+    "\tctx = ctx.In(\"model\") // Create the model by default under the \"/model\" scope.\n",
+    "\tbatchSize := inputs[0].Shape().Dimensions[0]\n",
+    "\tembeddings := Reshape(inputs[0], batchSize, -1)\n",
+    "\tlogits := layers.DenseWithBias(ctx, embeddings, mnist.NumClasses)\n",
+    "\treturn []*Node{logits}\n",
+    "}\n",
+    "\n",
+    "%% -set=\"batch_size=10\"\n",
+    "// Let's test that the logits are coming out with the right shape: we want [batch_size, 10], since there are 10 classes.\n",
+    "AssertDownloaded()\n",
+    "ctx, _ := ContextFromSettings()\n",
+    "g := NewGraph(backends.New(), \"placeholder\")\n",
+    "batchSize := context.GetParamOr(ctx, \"batch_size\", int(100))\n",
+    "logits := LinearModelGraph(ctx, nil, []*Node{Parameter(g, \"images\", shapes.Make(DType, batchSize, mnist.Height, mnist.Width, mnist.Depth))})\n",
+    "fmt.Printf(\"Logits shape for batch_size=%d: %s\\n\", batchSize, logits[0].Shape())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training Loop\n",
+    "\n",
+    "With a model function defined, we use the training loop create for the MNIST.\n",
+    "\n",
+    "The trainer is provided in the [`mnist` package](https://github.com/gomlx/gomlx/tree/main/examples/mnist). It is straight forward (and almost the same for every different project) and does the following for us:\n",
+    "\n",
+    "- If a checkpoing is given (--checkpoint) and it has previously saved model, it loads hyperparmeters and trained variables.\n",
+    "- Create trainer: with selected model function (see [Linear model](#Linear-model) and [Linear model for MNIST](#CNN-model-for-MNIST) sections), optimizer, loss and metrics.\n",
+    "- Create a `train.Loop` and attach to it a progressbar, a periodic checkpoint saver and a plotter (`--set=\"plots=true\"`).\n",
+    "- Train the selected number of train steps.\n",
+    "- Report results.\n",
+    "\n",
+    "Below we train 4000 steps with the default settings just to check things are working."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training linear model:\n",
+      "\t- checkpoint in /home/rener/work/mnist/linear\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"dade4a5f\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t- restarting from global step 4000\n",
+      "\t - target train_steps=4000 already reached. To train further, set a number additional to current global step.\n",
+      "\n",
+      "Results on train:\n",
+      "\tMean Loss+Regularization (#loss+): 0.288\n",
+      "\tMean Loss (#loss): 0.288\n",
+      "\tMean Accuracy (#acc): 92.04%\n",
+      "Results on test:\n",
+      "\tMean Loss+Regularization (#loss+): 0.284\n",
+      "\tMean Loss (#loss): 0.284\n",
+      "\tMean Accuracy (#acc): 92.14%\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "var flagCheckpoint = flag.String(\"checkpoint\", \"\", \"Directory save and load checkpoints from. If left empty, no checkpoints are created.\")\n",
+    "\n",
+    "// trainModel with hyperparameters configured with `-set=...`.\n",
+    "func trainModel() {\n",
+    "    ctx, paramsSet := ContextFromSettings()\n",
+    "    must.M(mnist.TrainModel(ctx, *flagDataDir, *flagCheckpoint, paramsSet))\n",
+    "}\n",
+    "\n",
+    "// Train 50 steps, only to test things are working. No plots.\n",
+    "%% --checkpoint=linear  --set=\"model=linear;train_steps=4000;plots=true\"\n",
+    "trainModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CNN Model for MNIST\n",
+    "\n",
+    "Let's now properly define a CNN model to compare.\n",
+    "\n",
+    "The model was built following a [Deep MNIST for Experts](https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow/+/r0.10/tensorflow/g3doc/tutorials/mnist/pros/index.md)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logits shape for batch_size=10: (Float32)[10 10]\n"
+     ]
+    }
+   ],
+   "source": [
+    "// CnnModelGraph builds the CNN model for our demo.\n",
+    "// It returns the logit, not the predictions, which works with most losses with shape `[batch_size, NumClasses]`.\n",
+    "// inputs: only one tensor, with shape `[batch_size, width, height, depth]`.\n",
+    "func CnnModelGraph(ctx *context.Context, spec any, inputs []*Node) []*Node {\n",
+    "\tctx = ctx.In(\"model\") // Create the model by default under the \"/model\" scope.\n",
+    "\tembeddings := CnnEmbeddings(ctx, inputs[0])\n",
+    "\tlogits := layers.Dense(ctx, embeddings, true, mnist.NumClasses)\n",
+    "\treturn []*Node{logits}\n",
+    "}\n",
+    "\n",
+    "func CnnEmbeddings(ctx *context.Context, images *Node) *Node {\n",
+    "\tbatchSize := images.Shape().Dimensions[0]\n",
+    "\tg := images.Graph()\n",
+    "\tdtype := images.DType()\n",
+    "\n",
+    "\tlayerIdx := 0\n",
+    "\tnextCtx := func(name string) *context.Context {\n",
+    "\t\tnewCtx := ctx.Inf(\"%03d_%s\", layerIdx, name)\n",
+    "\t\tlayerIdx++\n",
+    "\t\treturn newCtx\n",
+    "\t}\n",
+    "\t// Dropout.\n",
+    "\tdropoutRate := context.GetParamOr(ctx, \"cnn_dropout_rate\", -1.0)\n",
+    "\tif dropoutRate < 0 {\n",
+    "\t\tdropoutRate = context.GetParamOr(ctx, layers.ParamDropoutRate, 0.0)\n",
+    "\t}\n",
+    "\tvar dropoutNode *Node\n",
+    "\tif dropoutRate > 0.0 {\n",
+    "\t\tdropoutNode = Scalar(g, dtype, dropoutRate)\n",
+    "\t}\n",
+    "\n",
+    "\timages = layers.Convolution(nextCtx(\"conv\"), images).Filters(32).KernelSize(3).PadSame().Done()\n",
+    "\timages.AssertDims(batchSize, 28, 28, 32)\n",
+    "\timages = activations.Relu(images)\n",
+    "\timages = normalizeCNN(nextCtx(\"norm\"), images)\n",
+    "\timages = MaxPool(images).Window(2).Done()\n",
+    "\timages.AssertDims(batchSize, 14, 14, 32)\n",
+    "\n",
+    "\timages = layers.Convolution(nextCtx(\"conv\"), images).Filters(64).KernelSize(3).PadSame().Done()\n",
+    "\timages.AssertDims(batchSize, 14, 14, 64)\n",
+    "\timages = activations.Relu(images)\n",
+    "\timages = normalizeCNN(nextCtx(\"norm\"), images)\n",
+    "\timages = MaxPool(images).Window(2).Done()\n",
+    "\timages = layers.DropoutNormalize(nextCtx(\"dropout\"), images, dropoutNode, true)\n",
+    "\timages.AssertDims(batchSize, 7, 7, 64)\n",
+    "\n",
+    "\t// Flatten images\n",
+    "\timages = Reshape(images, batchSize, -1)\n",
+    "\treturn images\n",
+    "}\n",
+    "\n",
+    "func normalizeCNN(ctx *context.Context, logits *Node) *Node {\n",
+    "\tnormalizationType := context.GetParamOr(ctx, \"cnn_normalization\", \"none\")\n",
+    "\tswitch normalizationType {\n",
+    "\tcase \"layer\":\n",
+    "\t\tif logits.Rank() == 2 {\n",
+    "\t\t\treturn layers.LayerNormalization(ctx, logits, -1).Done()\n",
+    "\t\t} else if logits.Rank() == 4 {\n",
+    "\t\t\treturn layers.LayerNormalization(ctx, logits, 2, 3).Done()\n",
+    "\t\t} else {\n",
+    "\t\t\treturn logits\n",
+    "\t\t}\n",
+    "\tcase \"batch\":\n",
+    "\t\treturn batchnorm.New(ctx, logits, -1).Done()\n",
+    "\tcase \"none\", \"\":\n",
+    "\t\treturn logits\n",
+    "\tdefault:\n",
+    "\t\texceptions.Panicf(\"invalid normalization type %q -- set it with parameter %q\", normalizationType, \"cnn_normalization\")\n",
+    "\t\treturn nil\n",
+    "\t}\n",
+    "}\n",
+    "%% -set=\"batch_size=10\"\n",
+    "// Let's test that the logits are coming out with the right shape: we want [batch_size, 10], since there are 10 classes.\n",
+    "AssertDownloaded()\n",
+    "ctx, _ := ContextFromSettings()\n",
+    "g := NewGraph(backends.New(), \"placeholder\")\n",
+    "batchSize := context.GetParamOr(ctx, \"batch_size\", int(100))\n",
+    "logits := CnnModelGraph(ctx, nil, []*Node{Parameter(g, \"images\", shapes.Make(DType, batchSize, mnist.Height, mnist.Width, mnist.Depth))})\n",
+    "fmt.Printf(\"Logits shape for batch_size=%d: %s\\n\", batchSize, logits[0].Shape())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CNN Model Training\n",
+    "\n",
+    "Let's train the CNN for real this time. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Remove a previously trained model\n",
+    "!rm -rf ~/work/mnist/cnn  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training cnn model:\n",
+      "\t- checkpoint in /home/rener/work/mnist/cnn\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"cf014ec5\"></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t- restarting from global step 4000\n",
+      "\t - target train_steps=4000 already reached. To train further, set a number additional to current global step.\n",
+      "\n",
+      "Results on train:\n",
+      "\tMean Loss+Regularization (#loss+): 0.013\n",
+      "\tMean Loss (#loss): 0.013\n",
+      "\tMean Accuracy (#acc): 99.59%\n",
+      "Results on test:\n",
+      "\tMean Loss+Regularization (#loss+): 0.028\n",
+      "\tMean Loss (#loss): 0.028\n",
+      "\tMean Accuracy (#acc): 99.06%\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%% --checkpoint=cnn --set=\"model=cnn;train_steps=4000;plots=true\"\n",
+    "trainModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inference\n",
+    "\n",
+    "Inference, or serving the model, is done by using the same code as used to train the model.\n",
+    "That is, currently the way to save the model is to export the Go model creation function, along with the checkpoint with learned weights.\n",
+    "\n",
+    "We created a small library `mnist/classifier` that takes an image as input, convert it to a tensor and calls the trained model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p>Image: (28 x 28)</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAACXBIWXMAAAsTAAALEwEAmpwYAAAC+0lEQVRIia2VO0szQRSGz+6O5uKCkChWIgYEQUUjCYKlhZZWBiwsbFKIf0FSKKI2/gQhIGrAC4JBUgQEi+C1UAzYC24Es0ajk53ZGYvBEPf2+aGn2j0z85x9z2VW0nXdNE2EEOccfmeSJFFKm5ub0evrq6qqfwjFGEuVSkVVVUmSfkkUxjmvVCoyY4xS+idEAKCUcs5lWZb/ilg3VKvVAoHAP/fpur69vQ0AIlGcc4TQ9PR0S0uLA9Q0TQ+Wpmm5XI5SenBwcHh4aFm9vr5eW1tz4L68vBiGwZ0sm82OjY05BqsnLZVKNR4xDKNcLsuMMbfPLBQK+XxePA8ODo6Ojo6MjAwPD/v9flENAMhkMg7yPZopmUxijD8+Pjo6OqampgKBAGOMMZbP5+fn5zHGiqKMj487nHx6enKT72alUsnv9wNAKBTK5XLO8v+rqwzDWFpawhgDQCwWi0ajDvJ9Ph9jTFGUn+DS6fTR0dHJyYnw9Pf3t7W1OUC9R75UKl1cXMiyXKvV0un03t6e8Le2tiYSiUQi4XzMraVM01xfXx8aGoKvhm+0lZUVx3SLnCKMcTAYtAdjjC0uLj4/PwOAXc3j46OHPknTtFAohBCyQ3d2dnZ3d3t6etrb2ymlwWBQ1/X9/f2rq6ve3t7z83NVVS2nCCHVahV0XfdoKYyxxSPGIRqNvr29ucn3migA8Pl8Fk9nZ6fQ4TE1zlefiGn3X15ezszMAIA9Xd+ghBBLzM3NzXg8XiwWLVtvb28nJycLhQIAmKbZ1NTkBrUGXF1dXVhYIIQcHx9TSt/f3xFClNJsNru1tfXw8AAA8Xg8lUp5QK19OjExIfxdXV19fX2RSCQSiYg8AoCiKLOzs/f3926FFYWyVv/u7m5ubs4eOxwOJ5PJ09NTN9w3qH2iCCEbGxviHxOLxZaXl8/OzorFYrVa9SbWoZKmaeFw2H6h3NzclMvl7u7uuvafmGh+5NYcAwMDP2dZTJZlmRBSf2eM8a9J55w3vgqP22rj0ieuZu0WF49iIgAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/02/14 02:29:03 Must not error: requested variable \"weights\" in scope \"/model/model/000_conv/conv\" with Context.Reuse set, but variable does not exist\n",
+      "github.com/gomlx/exceptions.Panicf\n",
+      "\t/home/rener/.local/go/pkg/mod/github.com/gomlx/exceptions@v0.0.3/exceptions.go:92\n",
+      "github.com/gomlx/gomlx/ml/context.(*Context).VariableWithShape\n",
+      "\t/home/rener/dev/gomlx/ml/context/context.go:772\n",
+      "github.com/gomlx/gomlx/ml/layers.(*ConvBuilder).Done\n",
+      "\t/home/rener/dev/gomlx/ml/layers/convolution.go:285\n",
+      "github.com/gomlx/gomlx/examples/mnist.CnnEmbeddings\n",
+      "\t/home/rener/dev/gomlx/examples/mnist/model.go:72\n",
+      "github.com/gomlx/gomlx/examples/mnist.CnnModelGraph\n",
+      "\t/home/rener/dev/gomlx/examples/mnist/model.go:46\n",
+      "github.com/gomlx/gomlx/examples/mnist/classifier.New.func1\n",
+      "\t/home/rener/dev/gomlx/examples/mnist/classifier/classifier.go:66\n",
+      "reflect.Value.call\n",
+      "\t/usr/local/go/src/reflect/value.go:581\n",
+      "reflect.Value.Call\n",
+      "\t/usr/local/go/src/reflect/value.go:365\n",
+      "github.com/gomlx/gomlx/ml/context.(*Exec).buildGraphFn.func1\n",
+      "\t/home/rener/dev/gomlx/ml/context/exec.go:312\n",
+      "reflect.Value.call\n",
+      "\t/usr/local/go/src/reflect/value.go:581\n",
+      "reflect.Value.Call\n",
+      "\t/usr/local/go/src/reflect/value.go:365\n",
+      "github.com/gomlx/gomlx/graph.(*Exec).createAndCacheGraph\n",
+      "\t/home/rener/dev/gomlx/graph/exec.go:536\n",
+      "github.com/gomlx/gomlx/graph.(*Exec).findOrCreateGraph\n",
+      "\t/home/rener/dev/gomlx/graph/exec.go:595\n",
+      "github.com/gomlx/gomlx/graph.(*Exec).compileAndExecute\n",
+      "\t/home/rener/dev/gomlx/graph/exec.go:436\n",
+      "github.com/gomlx/gomlx/graph.(*Exec).CallWithGraph\n",
+      "\t/home/rener/dev/gomlx/graph/exec.go:386\n",
+      "github.com/gomlx/gomlx/ml/context.(*Exec).CallWithGraph\n",
+      "\t/home/rener/dev/gomlx/ml/context/exec.go:541\n",
+      "github.com/gomlx/gomlx/ml/context.(*Exec).Call\n",
+      "\t/home/rener/dev/gomlx/ml/context/exec.go:527\n",
+      "github.com/gomlx/gomlx/examples/mnist/classifier.(*Classifier).Classify.func1\n",
+      "\t/home/rener/dev/gomlx/examples/mnist/classifier/classifier.go:83\n",
+      "github.com/gomlx/exceptions.TryCatch[...]\n",
+      "\t/home/rener/.local/go/pkg/mod/github.com/gomlx/exceptions@v0.0.3/exceptions.go:85\n",
+      "github.com/gomlx/gomlx/examples/mnist/classifier.(*Classifier).Classify\n",
+      "\t/home/rener/dev/gomlx/examples/mnist/classifier/classifier.go:83\n",
+      "main.main\n",
+      "\t \u001b[7m[[ Cell [21] Line 22 ]]\u001b[0m /tmp/gonb_eb357154/main.go:247\n",
+      "runtime.main\n",
+      "\t/usr/local/go/src/runtime/proc.go:283\n",
+      "runtime.goexit\n",
+      "\t/usr/local/go/src/runtime/asm_amd64.s:1700\n",
+      "Panicking ...\n",
+      "\n",
+      "panic: requested variable \"weights\" in scope \"/model/model/000_conv/conv\" with Context.Reuse set, but variable does not exist\n",
+      "\n",
+      "goroutine 1 [running]:\n",
+      "github.com/janpfeifer/must.init.func1({0xeb6a00, 0xc000165050})\n",
+      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:13 +0xd3\n",
+      "github.com/janpfeifer/must.M1[...](...)\n",
+      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:41\n",
+      "main.main()\n",
+      "\t \u001b[7m[[ Cell [21] Line 22 ]]\u001b[0m /tmp/gonb_eb357154/main.go:247 +0x4a2\n",
+      "panic: requested variable \"weights\" in scope \"/model/model/000_conv/conv\" with Context.Reuse set, but variable does not exist\n",
+      "\n",
+      "goroutine 1 [running]:\n",
+      "github.com/janpfeifer/must.init.func1({0xeb6a00, 0xc000165050})\n",
+      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:13 +0xd3\n",
+      "github.com/janpfeifer/must.M1[...](...)\n",
+      "\t/home/rener/.local/go/pkg/mod/github.com/janpfeifer/must@v0.2.0/must.go:41\n",
+      "main.main()\n",
+      "\t \u001b[7m[[ Cell [21] Line 22 ]]\u001b[0m /tmp/gonb_eb357154/main.go:247 +0x4a2\n",
+      "exit status 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import (\n",
+    "    \"encoding/base64\"\n",
+    "    \"image/png\"\n",
+    "    \n",
+    "    \"github.com/gomlx/gomlx/examples/mnist/classifier\"\n",
+    "    // We also must import then engine that will execute the model.\n",
+    "    // Currently only XLA is supported.\n",
+    "    _ \"github.com/gomlx/gomlx/backends/xla\"\n",
+    ")\n",
+    "\n",
+    "%%\n",
+    "// Decode and print PNG image.\n",
+    "imgBase64 := bytes.NewBufferString(\"iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAAACXBIWXMAAAsTAAALEwEAmpwYAAAC+0lEQVRIia2VO0szQRSGz+6O5uKCkChWIgYEQUUjCYKlhZZWBiwsbFKIf0FSKKI2/gQhIGrAC4JBUgQEi+C1UAzYC24Es0ajk53ZGYvBEPf2+aGn2j0z85x9z2VW0nXdNE2EEOccfmeSJFFKm5ub0evrq6qqfwjFGEuVSkVVVUmSfkkUxjmvVCoyY4xS+idEAKCUcs5lWZb/ilg3VKvVAoHAP/fpur69vQ0AIlGcc4TQ9PR0S0uLA9Q0TQ+Wpmm5XI5SenBwcHh4aFm9vr5eW1tz4L68vBiGwZ0sm82OjY05BqsnLZVKNR4xDKNcLsuMMbfPLBQK+XxePA8ODo6Ojo6MjAwPD/v9flENAMhkMg7yPZopmUxijD8+Pjo6OqampgKBAGOMMZbP5+fn5zHGiqKMj487nHx6enKT72alUsnv9wNAKBTK5XLO8v+rqwzDWFpawhgDQCwWi0ajDvJ9Ph9jTFGUn+DS6fTR0dHJyYnw9Pf3t7W1OUC9R75UKl1cXMiyXKvV0un03t6e8Le2tiYSiUQi4XzMraVM01xfXx8aGoKvhm+0lZUVx3SLnCKMcTAYtAdjjC0uLj4/PwOAXc3j46OHPknTtFAohBCyQ3d2dnZ3d3t6etrb2ymlwWBQ1/X9/f2rq6ve3t7z83NVVS2nCCHVahV0XfdoKYyxxSPGIRqNvr29ucn3migA8Pl8Fk9nZ6fQ4TE1zlefiGn3X15ezszMAIA9Xd+ghBBLzM3NzXg8XiwWLVtvb28nJycLhQIAmKbZ1NTkBrUGXF1dXVhYIIQcHx9TSt/f3xFClNJsNru1tfXw8AAA8Xg8lUp5QK19OjExIfxdXV19fX2RSCQSiYg8AoCiKLOzs/f3926FFYWyVv/u7m5ubs4eOxwOJ5PJ09NTN9w3qH2iCCEbGxviHxOLxZaXl8/OzorFYrVa9SbWoZKmaeFw2H6h3NzclMvl7u7uuvafmGh+5NYcAwMDP2dZTJZlmRBSf2eM8a9J55w3vgqP22rj0ieuZu0WF49iIgAAAABJRU5ErkJggg==\")\n",
+    "imgPNG := must.M1(io.ReadAll(base64.NewDecoder(base64.StdEncoding, imgBase64)))\n",
+    "img := must.M1(png.Decode(bytes.NewBuffer(imgPNG)))\n",
+    "size := img.Bounds()\n",
+    "gonbui.DisplayHTML(fmt.Sprintf(\"<p>Image: (%d x %d)</p>\", size.Dx(), size.Dy()))\n",
+    "gonbui.DisplayPNG(imgPNG)\n",
+    "\n",
+    "// Classify:\n",
+    "inference := must.M1(classifier.New(\"~/work/mnist/cnn\"))\n",
+    "classID := must.M1(inference.Classify(img))\n",
+    "gonbui.DisplayHTML(fmt.Sprintf(\"<p>Class: <b>(%d)</b></p>\", classID))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Go (gonb)",
+   "language": "go",
+   "name": "gonb"
+  },
+  "language_info": {
+   "codemirror_mode": "",
+   "file_extension": ".go",
+   "mimetype": "text/x-go",
+   "name": "go",
+   "nbconvert_exporter": "",
+   "pygments_lexer": "",
+   "version": "go1.24.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/mnist/train.go
+++ b/examples/mnist/train.go
@@ -44,6 +44,8 @@ import (
 	"github.com/janpfeifer/must"
 )
 
+var ModelList = []string{"linear", "cnn"}
+
 var excludeParams = []string{"data_dir", "train_steps", "num_checkpoints", "plots"}
 
 type ContextFn func(ctx *context.Context) *context.Context
@@ -128,7 +130,7 @@ func TrainModel(ctx *context.Context, dataDir, checkpointPath string, paramsSet 
 		modelFn = CnnModelGraph
 
 	default:
-		return errors.Errorf("Can't find model %q, available models: %q\n", modelType, []string{"linear", "cnn"})
+		return errors.Errorf("Can't find model %q, available models: %q\n", modelType, ModelList)
 	}
 
 	fmt.Printf("Training %s model:\n", modelType)

--- a/examples/mnist/train.go
+++ b/examples/mnist/train.go
@@ -93,7 +93,7 @@ func CreateDefaultContext() *context.Context {
 		// Triplet
 		losses.ParamTripletLossPairwiseDistanceMetric: "L2",
 		losses.ParamTripletLossMiningStrategy:         "Hard",
-		losses.ParamTripletLossMargin:                 "0.5",
+		losses.ParamTripletLossMargin:                 0.5,
 	})
 	return ctx
 }

--- a/graph/ops_test.go
+++ b/graph/ops_test.go
@@ -18,6 +18,10 @@ package graph_test
 
 import (
 	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
 	"github.com/gomlx/gomlx/backends"
 	_ "github.com/gomlx/gomlx/backends/xla" // Make sure xla backend is linked.
 	. "github.com/gomlx/gomlx/graph"
@@ -28,9 +32,6 @@ import (
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math"
-	"reflect"
-	"testing"
 )
 
 var (
@@ -831,22 +832,40 @@ func TestStack(t *testing.T) {
 		}, -1)
 }
 
+func TestNonNegativeIndicator(t *testing.T) {
+	testFuncOneInput(t, "NonNegativeIndicator",
+		func(g *Graph) (input, output *Node) {
+			input = Const(g, []float64{1.0, 0.0001, 0, -0.2, -3.0})
+			output = NonNegativeIndicator(input)
+			return
+		}, []float64{1, 1, 1, 0, 0})
+}
+
 func TestPositiveIndicator(t *testing.T) {
 	testFuncOneInput(t, "PositiveIndicator",
 		func(g *Graph) (input, output *Node) {
 			input = Const(g, []float64{1.0, 0.0001, 0, -0.2, -3.0})
 			output = PositiveIndicator(input)
 			return
-		}, []float64{1, 1, 1, 0, 0})
+		}, []float64{1, 1, 0, 0, 0})
 }
 
-func TestStrictlyPositiveIndicator(t *testing.T) {
-	testFuncOneInput(t, "StrictlyPositiveIndicator",
+func TestNonPositiveIndicator(t *testing.T) {
+	testFuncOneInput(t, "NonPositiveIndicator",
 		func(g *Graph) (input, output *Node) {
 			input = Const(g, []float64{1.0, 0.0001, 0, -0.2, -3.0})
-			output = StrictlyPositiveIndicator(input)
+			output = NonPositiveIndicator(input)
 			return
-		}, []float64{1, 1, 0, 0, 0})
+		}, []float64{0, 0, 1, 1, 1})
+}
+
+func TestNegativeIndicator(t *testing.T) {
+	testFuncOneInput(t, "NegativeIndicator",
+		func(g *Graph) (input, output *Node) {
+			input = Const(g, []float64{1.0, 0.0001, 0, -0.2, -3.0})
+			output = NegativeIndicator(input)
+			return
+		}, []float64{0, 0, 0, 1, 1})
 }
 
 func TestReduceAndKeep(t *testing.T) {

--- a/graph/rev_autodiff.go
+++ b/graph/rev_autodiff.go
@@ -18,12 +18,13 @@ package graph
 
 import (
 	"fmt"
+	"math"
+	"os"
+
 	. "github.com/gomlx/exceptions"
 	"github.com/gomlx/gomlx/types/shapes"
 	"github.com/gomlx/gomlx/types/xslices"
 	"github.com/pkg/errors"
-	"math"
-	"os"
 )
 
 // This file implements reverse-mode automatic differentiation, using AccumulatedVJP (Vector Jacobian Product).
@@ -397,6 +398,7 @@ var VJPRegistration = map[NodeType]VJP{
 	NodeTypeReshape:            vjpForSingleOutput(reshapeVJP),
 	NodeTypeReduceSum:          vjpForSingleOutput(reduceSumVJP),
 	NodeTypeReduceMax:          vjpForSingleOutput(reduceMaxVJP),
+	NodeTypeReduceMin:          vjpForSingleOutput(reduceMinVJP),
 	NodeTypeLogistic:           vjpForSingleOutput(logisticVJP),
 	NodeTypeDot:                vjpForSingleOutput(dotVJP),
 	NodeTypeDotGeneral:         vjpForSingleOutput(dotGeneralVJP),
@@ -719,6 +721,36 @@ func reduceMaxVJP(node, v *Node, _ shapes.Shape) []*Node {
 
 	// vjp is only propagated to the elements at the max value.
 	vjp := Mul(expandedV, maxIndicatorAtInput)
+	return []*Node{vjp}
+}
+
+func reduceMinVJP(node, v *Node, _ shapes.Shape) []*Node {
+	// Reconstruct exactly the reduced dimensions, and build a newShape
+	// (same shape as if we had done ReduceAndKeep(input[0]))
+	params := node.inputs.(*nodeInputsReduceMin)
+	x := params.x
+	reducedDims := params.axes
+	if len(reducedDims) == 0 {
+		// Reduced all dims, reconstruct those.
+		reducedDims = xslices.Iota(0, x.Rank())
+	}
+	newShape := x.Shape().Clone()
+	for _, dim := range reducedDims {
+		newShape.Dimensions[dim] = 1
+	}
+
+	// Expand the node output (with min) to match the input. And then creates
+	// an indicator to which positions are at the min values.
+	minAtOriginalRank := ReshapeWithShape(node, newShape)
+	minIndicatorAtInput := NegativeIndicator(Sub(x, minAtOriginalRank))
+
+	// Expand rank of v to match the input, by re-creating
+	// the reduced dimensions with size 1 and then broadcasting.
+	expandedV := ReshapeWithShape(v, newShape)
+	expandedV = BroadcastToShape(expandedV, x.Shape())
+
+	// vjp is only propagated to the elements at the min value.
+	vjp := Mul(expandedV, minIndicatorAtInput)
 	return []*Node{vjp}
 }
 

--- a/graph/rev_autodiff.go
+++ b/graph/rev_autodiff.go
@@ -657,9 +657,9 @@ func powVJP(node, v *Node, _ shapes.Shape) []*Node {
 
 func minMaxVJP(node, v *Node, _ shapes.Shape) []*Node {
 	// We push the adjoint gradient to one side or the other, depending on which is the max.
-	// Notice because PositiveIndicator(0) == 1, the gradient of Max(x, y) w.r.t. x, where x == y will be 1.0
+	// Notice because NonNegativeIndicator(0) == 1, the gradient of Max(x, y) w.r.t. x, where x == y will be 1.0
 	// (as opposed to 0).
-	side0Indicator := PositiveIndicator(Sub(node.inputNodes[0], node.inputNodes[1]))
+	side0Indicator := NonNegativeIndicator(Sub(node.inputNodes[0], node.inputNodes[1]))
 	side1Indicator := OneMinus(side0Indicator)
 	if node.Type() == NodeTypeMin {
 		// If min, swap directions.
@@ -712,7 +712,7 @@ func reduceMaxVJP(node, v *Node, _ shapes.Shape) []*Node {
 	// Expand the node output (with max) to match the input. And then creates
 	// an indicator to which positions are at the max values.
 	maxAtOriginalRank := ReshapeWithShape(node, newShape)
-	maxIndicatorAtInput := PositiveIndicator(Sub(x, maxAtOriginalRank))
+	maxIndicatorAtInput := NonNegativeIndicator(Sub(x, maxAtOriginalRank))
 
 	// Expand rank of v to match the input, by re-creating
 	// the reduced dimensions with size 1 and then broadcasting.
@@ -742,7 +742,7 @@ func reduceMinVJP(node, v *Node, _ shapes.Shape) []*Node {
 	// Expand the node output (with min) to match the input. And then creates
 	// an indicator to which positions are at the min values.
 	minAtOriginalRank := ReshapeWithShape(node, newShape)
-	minIndicatorAtInput := NegativeIndicator(Sub(x, minAtOriginalRank))
+	minIndicatorAtInput := NonPositiveIndicator(Sub(x, minAtOriginalRank))
 
 	// Expand rank of v to match the input, by re-creating
 	// the reduced dimensions with size 1 and then broadcasting.

--- a/ml/layers/layers.go
+++ b/ml/layers/layers.go
@@ -23,6 +23,7 @@ package layers
 
 import (
 	"fmt"
+
 	. "github.com/gomlx/exceptions"
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/ml/context"
@@ -250,8 +251,8 @@ func PieceWiseLinearCalibration(ctx *context.Context, input, keypoints *Node, ou
 	//
 	zero := ScalarZero(g, dtype)
 	one := ScalarOne(g, dtype)
-	trimLeft := PositiveIndicator(Sub(input2D, kpStarts))
-	trimRight := StrictlyPositiveIndicator(Sub(kpEnds, input2D))
+	trimLeft := NonNegativeIndicator(Sub(input2D, kpStarts))
+	trimRight := PositiveIndicator(Sub(kpEnds, input2D))
 	trimRegions := Mul(trimLeft, trimRight)
 
 	// Calculate "left" weights on each keypoint: left weight is the weight
@@ -266,11 +267,11 @@ func PieceWiseLinearCalibration(ctx *context.Context, input, keypoints *Node, ou
 	// on the edge keypoints.
 	//leftEdge := InsertAxes(SliceLists(keypoints, []int{0}, []int{1}), 0)
 	leftEdge := InsertAxes(Slice(keypoints, AxisRangeFromStart(1)), 0)
-	leftEdge = PositiveIndicator(Sub(leftEdge, input2D))
+	leftEdge = NonNegativeIndicator(Sub(leftEdge, input2D))
 	leftWeights = Concatenate([]*Node{leftEdge, leftWeights}, -1)
 
 	rightEdge := InsertAxes(Slice(keypoints, AxisRangeToEnd(-1)), 0)
-	rightEdge = PositiveIndicator(Sub(input2D, rightEdge))
+	rightEdge = NonNegativeIndicator(Sub(input2D, rightEdge))
 	rightWeights = Concatenate([]*Node{rightWeights, rightEdge}, -1)
 
 	weights := Add(leftWeights, rightWeights)

--- a/ml/train/losses/losses.go
+++ b/ml/train/losses/losses.go
@@ -99,6 +99,18 @@ const (
 
 	// TypeBinCrossLogits represents BinaryCrossentropyLogits.
 	TypeBinCrossLogits
+
+	// TypeSparseCross represents CategoricalCrossEntropy.
+	TypeCategoricalCross
+
+	// TypeBinCrossLogits represents CategoricalCrossEntropyLogits.
+	TypeCategoricalCrossLogits
+
+	// TypeSparseCrossLogits represents SparseCategoricalCrossEntropyLogits
+	TypeSparseCrossLogits
+
+	// TypeTriplet
+	TypeTriplet
 )
 
 // LossFromContext takes the value from the ParamLoss hyperparameter as a string and
@@ -128,6 +140,14 @@ func LossFromContext(ctx *context.Context) (LossFn, error) {
 		return BinaryCrossentropy, nil
 	case TypeBinCrossLogits:
 		return BinaryCrossentropyLogits, nil
+	case TypeCategoricalCross:
+		return CategoricalCrossEntropy, nil
+	case TypeCategoricalCrossLogits:
+		return CategoricalCrossEntropyLogits, nil
+	case TypeSparseCrossLogits:
+		return SparseCategoricalCrossEntropyLogits, nil
+	case TypeTriplet:
+		return MakeTripletLossFromContext(ctx), nil
 	default:
 		return nil, errors.Errorf("Unknown loss type %q set for hyperparameter %q, known losses are \"%s\"",
 			lossType, ParamLoss, strings.Join(TypeStrings(), "\", \""))

--- a/ml/train/losses/triplet.go
+++ b/ml/train/losses/triplet.go
@@ -272,7 +272,7 @@ func TripletLoss(labels, predictions []*Node,
 		loss = AddScalar(loss, margin)
 		loss = MaxScalar(loss, 0.0)
 	} else {
-		loss = Log1P(Exp(loss))
+		loss = Softplus(loss)
 	}
 
 	// Apply weights and mask.

--- a/ml/train/losses/type_enumer.go
+++ b/ml/train/losses/type_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _TypeName = "maemsehuberaplbin_crossbin_cross_logits"
+const _TypeName = "maemsehuberaplbin_crossbin_cross_logitscategorical_crosscategorical_cross_logitssparse_cross_logitstriplet"
 
-var _TypeIndex = [...]uint8{0, 3, 6, 11, 14, 23, 39}
+var _TypeIndex = [...]uint8{0, 3, 6, 11, 14, 23, 39, 56, 80, 99, 106}
 
-const _TypeLowerName = "maemsehuberaplbin_crossbin_cross_logits"
+const _TypeLowerName = "maemsehuberaplbin_crossbin_cross_logitscategorical_crosscategorical_cross_logitssparse_cross_logitstriplet"
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_TypeIndex)-1) {
@@ -35,23 +35,35 @@ func _TypeNoOp() {
 	_ = x[TypeAPL-(3)]
 	_ = x[TypeBinCross-(4)]
 	_ = x[TypeBinCrossLogits-(5)]
+	_ = x[TypeCategoricalCross-(6)]
+	_ = x[TypeCategoricalCrossLogits-(7)]
+	_ = x[TypeSparseCrossLogits-(8)]
+	_ = x[TypeTriplet-(9)]
 }
 
-var _TypeValues = []Type{TypeMAE, TypeMSE, TypeHuber, TypeAPL, TypeBinCross, TypeBinCrossLogits}
+var _TypeValues = []Type{TypeMAE, TypeMSE, TypeHuber, TypeAPL, TypeBinCross, TypeBinCrossLogits, TypeCategoricalCross, TypeCategoricalCrossLogits, TypeSparseCrossLogits, TypeTriplet}
 
 var _TypeNameToValueMap = map[string]Type{
-	_TypeName[0:3]:        TypeMAE,
-	_TypeLowerName[0:3]:   TypeMAE,
-	_TypeName[3:6]:        TypeMSE,
-	_TypeLowerName[3:6]:   TypeMSE,
-	_TypeName[6:11]:       TypeHuber,
-	_TypeLowerName[6:11]:  TypeHuber,
-	_TypeName[11:14]:      TypeAPL,
-	_TypeLowerName[11:14]: TypeAPL,
-	_TypeName[14:23]:      TypeBinCross,
-	_TypeLowerName[14:23]: TypeBinCross,
-	_TypeName[23:39]:      TypeBinCrossLogits,
-	_TypeLowerName[23:39]: TypeBinCrossLogits,
+	_TypeName[0:3]:         TypeMAE,
+	_TypeLowerName[0:3]:    TypeMAE,
+	_TypeName[3:6]:         TypeMSE,
+	_TypeLowerName[3:6]:    TypeMSE,
+	_TypeName[6:11]:        TypeHuber,
+	_TypeLowerName[6:11]:   TypeHuber,
+	_TypeName[11:14]:       TypeAPL,
+	_TypeLowerName[11:14]:  TypeAPL,
+	_TypeName[14:23]:       TypeBinCross,
+	_TypeLowerName[14:23]:  TypeBinCross,
+	_TypeName[23:39]:       TypeBinCrossLogits,
+	_TypeLowerName[23:39]:  TypeBinCrossLogits,
+	_TypeName[39:56]:       TypeCategoricalCross,
+	_TypeLowerName[39:56]:  TypeCategoricalCross,
+	_TypeName[56:80]:       TypeCategoricalCrossLogits,
+	_TypeLowerName[56:80]:  TypeCategoricalCrossLogits,
+	_TypeName[80:99]:       TypeSparseCrossLogits,
+	_TypeLowerName[80:99]:  TypeSparseCrossLogits,
+	_TypeName[99:106]:      TypeTriplet,
+	_TypeLowerName[99:106]: TypeTriplet,
 }
 
 var _TypeNames = []string{
@@ -61,6 +73,10 @@ var _TypeNames = []string{
 	_TypeName[11:14],
 	_TypeName[14:23],
 	_TypeName[23:39],
+	_TypeName[39:56],
+	_TypeName[56:80],
+	_TypeName[80:99],
+	_TypeName[99:106],
 }
 
 // TypeString retrieves an enum value from the enum constants string name.

--- a/ml/train/metrics/metrics.go
+++ b/ml/train/metrics/metrics.go
@@ -19,6 +19,7 @@ package metrics
 
 import (
 	"fmt"
+
 	. "github.com/gomlx/exceptions"
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/ml/context"
@@ -319,7 +320,7 @@ func BinaryAccuracyGraph(_ *context.Context, labels, predictions []*Node) *Node 
 	// Accuracy is true if diff < 0.5. Notice this will take predictions of 0.5 to be false independent of label
 	// (assuming labels are 1 or 0).
 	dtype := prediction.DType()
-	correctExamples := OneMinus(PositiveIndicator(Sub(diff, Const(g, shapes.CastAsDType(0.5, dtype)))))
+	correctExamples := OneMinus(NonNegativeIndicator(Sub(diff, Const(g, shapes.CastAsDType(0.5, dtype)))))
 	countExamples := Const(g, shapes.CastAsDType(correctExamples.Shape().Size(), correctExamples.DType()))
 	return Div(ReduceAllSum(correctExamples), countExamples)
 }
@@ -371,8 +372,8 @@ func BinaryLogitsAccuracyGraph(_ *context.Context, labels, logits []*Node) *Node
 	}
 
 	dtype := logits0.DType()
-	labels0 = Sub(labels0, Const(g, shapes.CastAsDType(0.5, dtype)))    // Labels: -0.5 for false, +0.5 for true.
-	correctExamples := StrictlyPositiveIndicator(Mul(logits0, labels0)) // 0s are considered a miss.
+	labels0 = Sub(labels0, Const(g, shapes.CastAsDType(0.5, dtype))) // Labels: -0.5 for false, +0.5 for true.
+	correctExamples := PositiveIndicator(Mul(logits0, labels0))      // 0s are considered a miss.
 	countExamples := Const(g, shapes.CastAsDType(correctExamples.Shape().Size(), correctExamples.DType()))
 	mean := Div(ReduceAllSum(correctExamples), countExamples)
 	return mean


### PR DESCRIPTION
I just scratch a notebook based on Cifar

Changes:
- Create a notebook bases on cifar nb
- removed flagModel and flagLoss from demo.go and from TrainModel. Getting from context.
- Added Depth = 3 constant
- classifier: just adapt the classifier from cifar/classifier
- Remove Loss map function. Creating lossFn from losses.LoadFromContext
- Implement ReduceMinVJP grad func
- Complete losses.LoadFromContext with Triplet and other loss functions
- Implement Softplus activation for better stability of triplet
- Fix  _GetParamOr_,  when hiperparameter is a string: a _v.CanConvert(typeOfT)_  was build only for float32/float64. Using UnmarshalText its possible to convert string "hard" to TripletLossMiningStrategyHard type.

Erros:
- classifier.New is not working. _ Must not error: requested variable "weights" in scope "/model/model/000_conv/conv" with Context.Reuse set, but variable does not exist_.  I suppose to be the weights os the network, but it is not on checkpoints