### PR TITLE
Fixed L1; L2Normalize now safe for 0 l2-length slices.

### DIFF
--- a/backends/xla/xla.go
+++ b/backends/xla/xla.go
@@ -156,6 +156,7 @@ func GetAvailablePlugins() []string {
 
 	availablePluginsMap := pjrt.AvailablePlugins()
 	pluginNames := types.SetWith(xslices.Keys(availablePluginsMap)...)
+	klog.V(1).Infof("Available plugins: %v\n", pluginNames)
 	availablePluginsList = make([]string, 0, len(pluginNames))
 
 	// Add DefaultPlugins first.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,11 @@
 * Package `graph`:
   * Fixed when using axes != -1 for `L1Norm`.
   * Added `IsZero` shortcut.
-  * Fixed `L2Normalize` to handle 0s without NaN, both in the forward evaluation, and in the gradient. 
+  * Fixed `L2Normalize` to handle 0s without NaN, both in the forward evaluation, and in the gradient.
+  * Renamed indicator functions to `PositiveIndicator`, `NonNegativeIndicator`, `NegativeIndicator` and `NonPositiveIndicator`.
+  * Added backprop for `ReduceMin` that was missing (thx @TuSKan)
+* Package `context`:
+  * Added support for string derived types for `context.GetParamsOr[T]`.
 
 # v0.17.0: bitwise ops, triplet losses, new layers, fixes, and more.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Package `checkpoints`:
   * Loading a checkpoint overwrites the values of variables already present in the context.
   * Fixes when saving, in particular if using `Immediate()` loading.
+* Package `graph`:
+  * Fixed when using axes != -1 for `L1Norm`.
+  * Added `IsZero` shortcut.
+  * Fixed `L2Normalize` to handle 0s without NaN, both in the forward evaluation, and in the gradient. 
 
 # v0.17.0: bitwise ops, triplet losses, new layers, fixes, and more.
 

--- a/graph/ops_util_test.go
+++ b/graph/ops_util_test.go
@@ -29,6 +29,23 @@ func TestScalar(t *testing.T) {
 		}, -1)
 }
 
+func TestIsZero(t *testing.T) {
+	graphtest.RunTestGraphFn(t, t.Name(),
+		func(g *Graph) (inputs, outputs []*Node) {
+			inputs = []*Node{
+				Const(g, []uint8{3, 5, 0, 2}),
+				Const(g, []float32{-2.2, 1e-10, 3.1, 0, -1e-10}),
+				Const(g, []complex64{1e-10, 0, -1e-10i}),
+			}
+			outputs = xslices.Map(inputs, func(x *Node) *Node { return IsZero(x) })
+			return
+		}, []any{
+			[]bool{false, false, true, false},
+			[]bool{false, false, false, true, false},
+			[]bool{false, true, false},
+		}, -1)
+}
+
 func TestEinsum(t *testing.T) {
 	graphtest.RunTestGraphFn(t, "EinsumMatrixMul",
 		func(g *Graph) (inputs, outputs []*Node) {
@@ -569,4 +586,23 @@ func TestReduceSkewness(t *testing.T) {
 			float32(0.0),
 			float32(0.2650554122698573),
 		}, 0.001)
+}
+
+func TestL2Normalize(t *testing.T) {
+	graphtest.RunTestGraphFn(t, t.Name(),
+		func(g *Graph) (inputs, outputs []*Node) {
+			inputs = []*Node{
+				Const(g, [][]float32{{3, 4}, {0, 0}}),
+			}
+			normalized := L2Normalize(inputs[0], -1)
+			grad := Gradient(ReduceAllSum(normalized), inputs[0])[0]
+			outputs = []*Node{
+				normalized,
+				grad,
+			}
+			return
+		}, []any{
+			[][]float32{{0.6, 0.8}, {0, 0}},
+			[][]float32{{0.032, -0.024}, {1, 1}},
+		}, 1e-3)
 }

--- a/graph/rev_autodiff.go
+++ b/graph/rev_autodiff.go
@@ -210,7 +210,7 @@ func Gradient(output *Node, gradientNodes ...*Node) []*Node {
 				// Skip this vjp, input is assumed to be static (or gradient stopped for some other reason)
 				continue
 			}
-			//fmt.Printf("\t\tSetting vjp for %s: %s\n", input, vjp)
+			//vjp.SetLoggedf("\tVJP for %s / input #%d VJP --> to be backprop to %s", node, ii, input)
 			combinedShape := combineOutputShape(outputShape, input.Shape())
 			if !vjp.Shape().Equal(combinedShape) {
 				if node.Trace() != nil {


### PR DESCRIPTION
Fixed L1; L2Normalize now safe for 0 l2-length slices.