### PR TITLE
Losses improvements.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,12 @@
   * Added `CosineSimilarity`, numerically safe for 0 vectors.
 * Package `context`:
   * Added support for string derived types for `context.GetParamsOr[T]`.
+* Package losses:
+  * Triplet losses now work with context.
+  * `CheckExtraLabelsForWeightsAndMask` now (1) accepts weights and mask in any order; (2) normalize weights such that the sum is (non-masked) bathSize, 
+    preserving the ratio. This way the mean will be 1.
+  * Losses with masks and weights fixed to properly normalize the weights for the non-masked out examples.
+    Also, now using MaskedReduceMean if there is a mask.
 
 # v0.17.0: bitwise ops, triplet losses, new layers, fixes, and more.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,8 +20,8 @@
   * Triplet losses now work with context.
   * `CheckExtraLabelsForWeightsAndMask` now (1) accepts weights and mask in any order; (2) normalize weights such that the sum is (non-masked) bathSize, 
     preserving the ratio. This way the mean will be 1.
-  * Losses with masks and weights fixed to properly normalize the weights for the non-masked out examples.
-    Also, now using MaskedReduceMean if there is a mask.
+  * Losses with masks and weights fixed so weights/mask can be given in any order.
+    Also, now using MaskedReduceMean if there is a mask, and all losses return a scalar.
 
 # v0.17.0: bitwise ops, triplet losses, new layers, fixes, and more.
 

--- a/graph/ops.go
+++ b/graph/ops.go
@@ -853,10 +853,12 @@ func MaskedReduceMean(x, mask *Node, reduceAxes ...int) *Node {
 	ones := OnesLike(x)
 	maskedX := Where(mask, x, zeros)
 	sum := ReduceSum(maskedX, reduceAxes...)
+	sum.SetLogged("sum")
 	denominator := Where(mask, ones, zeros)
 	denominator = ReduceSum(denominator, reduceAxes...)
 	denominator = Max(denominator, OnesLike(denominator))
 	denominator.stopGradient = true
+	denominator.SetLogged("denominator")
 	return Div(sum, denominator)
 }
 

--- a/ml/train/losses/losses.go
+++ b/ml/train/losses/losses.go
@@ -158,120 +158,154 @@ func LossFromContext(ctx *context.Context) (LossFn, error) {
 //
 // labels and predictions must have the same shape.
 //
-// If there is an extra element in the input labels with the shape of the labels[0] (usually simply `[bath_size]`),
-// it is assumed to be weights tensor to be applied to the losses.
-// If there is an extra element in the input labels  with booleans and the same dimensions as `labels[0]` (usually
-// simply `batch_size`), it assumed to be a mask tensor to be applied to the losses.
+// Labels can have 2 optional extra values (in any order):
+//
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 func MeanSquaredError(labels, predictions []*Node) (loss *Node) {
 	predictions0 := predictions[0]
 	labels0 := labels[0]
 	if !labels0.Shape().Equal(predictions0.Shape()) {
 		Panicf("labels[0] (%s) and predictions[0] (%s) must have same shape", labels0.Shape(), predictions0.Shape())
 	}
-	weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
 	loss = Sub(labels0, predictions0)
 	loss = Mul(loss, loss)
 
+	// Factor in weights and mask.
+	weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 	if weights != nil {
 		loss = Mul(loss, weights)
 	}
 	if mask != nil {
 		loss = Where(mask, loss, ZerosLike(loss))
+		if !loss.IsScalar() {
+			loss = MaskedReduceAllMean(loss, mask)
+		}
+	} else if !loss.IsScalar() {
+		loss = ReduceAllMean(loss)
 	}
-	loss = ReduceAllMean(loss)
 	return loss
 }
 
-// CheckLabelsForWeightsAndMask in the labels slice of tensors -- it is assumed that labels[0] are the actual labels, so
-// they are not considered.
+// CheckExtraLabelsForWeightsAndMask takes the remainder slice of labels tensor (so without the actual labels values),
+// and separates a mask (bool) and weights (float), which can be provided in any order.
 //
 // `weightsShape` is the expected shape for weights (if present) and the dimensions for a mask (if present), although
 // a mask is assumed to be of dtype `Bool`.
 //
 // If weights and masks are present, weights are converted to zero for masked out values (where mask is false).
 //
-// If there is an extra `labels` `*Node` with the shape of `weightsShape`, it is assumed to be weights.
-// If there is an extra `labels` `*Node` with booleans with the same dimension as `weightsShape`, it is assumed to be a mask.
-func CheckLabelsForWeightsAndMask(weightsShape shapes.Shape, labels []*Node) (weights, mask *Node) {
+// It raises an exception (panic) if there are more or unknown shaped labels.
+//
+// The weights, if given, are normalized such that the sum is (non-masked) bathSize, preserving the ratio. This way the mean will be 1.
+func CheckExtraLabelsForWeightsAndMask(weightsShape shapes.Shape, labels []*Node) (weights, mask *Node) {
 	maskShape := shapes.Make(dtypes.Bool, weightsShape.Dimensions...)
-	// We skip labels[0] because that contains the actual labels.
-	for ii, extra := range labels[1:] {
-		if weights == nil && extra.Shape().Equal(weightsShape) {
-			weights = extra
-		} else if mask == nil && extra.Shape().Equal(maskShape) {
+	for ii, extra := range labels {
+		if mask == nil && extra.Shape().Equal(maskShape) {
 			mask = extra
+		} else if weights == nil && extra.Shape().Equal(weightsShape) {
+			weights = extra
 		} else {
-			Panicf("labels ([]*Node) provided by the dataset to the loss function has extra tensors whose use is unknown: labels[%d].shape=%s "+
+			Panicf("extra labels ([]*Node) provided by the dataset to the loss function has extra tensors whose use is unknown: labels[%d].shape=%s "+
 				"-- label weights shape would be %s, labels mask shape would be %s", ii+1, extra.Shape(), weightsShape, maskShape)
 		}
 	}
-	if weights != nil && mask != nil {
-		weights = Where(mask, weights, ZerosLike(weights))
+	if weights == nil {
+		return
 	}
+
+	// Normalize weights.
+	g := weights.Graph()
+	dtype := weights.DType()
+	var batchSize *Node
+	if mask != nil {
+		// Weights set to 0 where mask is disabled.
+		weights = Where(mask, weights, ZerosLike(weights))
+		batchSize = ReduceAllSum(ConvertDType(mask, dtype))
+	} else {
+		batchSize = Scalar(g, dtype, weights.Shape().Dim(0))
+	}
+	weights = MaxScalar(weights, 0)
+	weightsTotal := ReduceAllSum(weights)
+	weightsTotal = Where(IsZero(weightsTotal), ScalarOne(g, dtype), weightsTotal) // Safety: don't allow infinity.
+	weightsRatio := Div(batchSize, weightsTotal)
+	weights = Mul(weights, weightsRatio)
 	return
 }
 
 // MeanAbsoluteError returns the mean absolute error between labels and predictions.
-// It uses only the first element of each.
+// It uses only the first element of each. labels and predictions must have the same shape.
 //
-// labels and predictions must have the same shape.
+// Labels can have 2 optional extra values (in any order):
 //
-// If there is an extra `labels` `*Node` with the shape of the `labels[0]` (usually simply `[bath_size]`),
-// it is assumed to be weights tensor to be applied to the losses.
-// If there is an extra `labels` `*Node` with booleans and the same dimensions as `labels[0]` (usually simply `batch_size`),
-// it assumed to be a mask tensor to be applied to the losses.
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 func MeanAbsoluteError(labels, predictions []*Node) (loss *Node) {
 	predictions0 := predictions[0]
 	labels0 := labels[0]
 	if !labels0.Shape().Equal(predictions0.Shape()) {
 		Panicf("labels[0] (%s) and predictions[0] (%s) must have same shape", labels0.Shape(), predictions0.Shape())
 	}
-
 	loss = Abs(Sub(labels0, predictions0))
 
-	weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
+	// Factor in weights and mask.
+	weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 	if weights != nil {
 		loss = Mul(loss, weights)
 	}
 	if mask != nil {
 		loss = Where(mask, loss, ZerosLike(loss))
+		if !loss.IsScalar() {
+			loss = MaskedReduceAllMean(loss, mask)
+		}
+	} else if !loss.IsScalar() {
+		loss = ReduceAllMean(loss)
 	}
-	loss = ReduceAllMean(loss)
-	return
+	return loss
 }
 
 // BinaryCrossentropy returns the cross-entropy loss between labels and predictions,
 // for binary classification tasks.
 //
-// labels and predictions must have the same shape.
+// labels and predictions must have the same dimensions.
+//
 // labels is converted to predictions dtype, and it's expected to convert to 1.0 (for true) or 0.0 for false.
-// So booleans should work, as an int type that is 0 or 1.
+// So labels as booleans should work, as well as labels as int type that is 0 or 1.
 //
-// It *does not* reduce-mean the losses, they are returned individually for each element of the batch and need
-// to be ReduceAllMean (usually the mean, but it could be the sum also) before used for training.
+// Labels can have 2 optional extra values (in any order):
 //
-// If there is an extra `labels` `*Node` with the shape of the `labels[0]` (usually simply `[bath_size]`),
-// it is assumed to be weights tensor to be applied to the losses.
-// If there is an extra `labels` `*Node` with booleans and the same dimensions as `labels[0]` (usually simply `batch_size`),
-// it assumed to be a mask tensor to be applied to the losses.
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 func BinaryCrossentropy(labels, predictions []*Node) *Node {
 	predictions0 := predictions[0]
 	labels0 := ConvertDType(labels[0], predictions0.DType())
 	if !labels0.Shape().Equal(predictions0.Shape()) {
 		Panicf("labels[0] (%s) and predictions[0] (%s) must have same shape", labels0.Shape(), predictions0.Shape())
 	}
-	losses := Neg(Add(
+	loss := Neg(Add(
 		Mul(labels0, Log(predictions0)),
 		Mul(OneMinus(labels0), Log(OneMinus(predictions0)))))
 
-	weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
+	// Factor in weights and mask.
+	weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 	if weights != nil {
-		losses = Mul(losses, weights)
+		loss = Mul(loss, weights)
 	}
 	if mask != nil {
-		losses = Where(mask, losses, ZerosLike(losses))
+		loss = Where(mask, loss, ZerosLike(loss))
+		if !loss.IsScalar() {
+			loss = MaskedReduceAllMean(loss, mask)
+		}
+	} else if !loss.IsScalar() {
+		loss = ReduceAllMean(loss)
 	}
-	return losses
+	return loss
 }
 
 // BinaryCrossentropyLogits returns the cross-entropy loss between labels and `sigmoid(logits)`,
@@ -280,19 +314,18 @@ func BinaryCrossentropy(labels, predictions []*Node) *Node {
 // the logits and using the equivalent BinaryCrossentropy.
 // labels and logits must have the same shape.
 //
-// It *does not* reduce-mean the losses, they are returned individually for each element of the batch and need
-// to be ReduceAllMean (usually the mean, but it could be the sum also) before used for training.
-//
 // labels is converted to predictions dtype, and it's expected to convert to 1.0 (for true) or 0.0 for false.
 // So booleans should work, as an int type that is 0 or 1.
 //
 // See mathematical derivation of the stable solution in
 // https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
 //
-// If there is an extra `labels` `*Node` with the shape of the `labels[0]` (usually simply `[bath_size]`),
-// it is assumed to be weights tensor to be applied to the losses.
-// If there is an extra `labels` `*Node` with booleans and the same dimensions as `labels[0]` (usually simply `batch_size`),
-// it assumed to be a mask tensor to be applied to the losses.
+// Labels can have 2 optional extra values (in any order):
+//
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 func BinaryCrossentropyLogits(labels, logits []*Node) *Node {
 	logits0 := logits[0]
 	labels0 := ConvertDType(labels[0], logits0.DType())
@@ -305,27 +338,34 @@ func BinaryCrossentropyLogits(labels, logits []*Node) *Node {
 	logPart := Log1P(Exp(Neg(Abs(logits0))))
 	prodPart := Mul(logits0, labels0)
 	maxPart := Max(logits0, ZerosLike(logits0))
-	losses := Add(Sub(maxPart, prodPart), logPart)
+	loss := Add(Sub(maxPart, prodPart), logPart)
 
-	weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
+	// Factor in weights and mask.
+	weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 	if weights != nil {
-		losses = Mul(losses, weights)
+		loss = Mul(loss, weights)
 	}
 	if mask != nil {
-		losses = Where(mask, losses, ZerosLike(losses))
+		loss = Where(mask, loss, ZerosLike(loss))
+		if !loss.IsScalar() {
+			loss = MaskedReduceAllMean(loss, mask)
+		}
+	} else if !loss.IsScalar() {
+		loss = ReduceAllMean(loss)
 	}
-	return losses
+	return loss
 }
 
 // SparseCategoricalCrossEntropyLogits returns the cross-entropy loss of the logits, given the labels.
 // The labels are provided in "sparse" format, that is, integer numbers from 0 to logits dimension-1.
 // labels and logits must have the same rank, and labels last dimension must be 1.
 //
-// It *does not* reduce-mean the losses, they are returned individually for each element of the batch and need
-// to be ReduceAllMean (usually the mean, but it could be the sum also) before used for training.
+// Labels can have 2 optional extra values (in any order):
 //
-// If there is an extra `labels` `*Node` with the shape of logits without the last axis, it assumed to be weights to the losses.
-// If there is an extra `labels` `*Node` with booleans with the same dimensions as logits without the last axis, it assumed to be a mask.
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 func SparseCategoricalCrossEntropyLogits(labels, logits []*Node) *Node {
 	logits0 := logits[0]
 	labels0 := labels[0]
@@ -342,13 +382,11 @@ func SparseCategoricalCrossEntropyLogits(labels, logits []*Node) *Node {
 	if labelsShape.Dimensions[labelsRank-1] != 1 {
 		Panicf("labels0(%s) are expected to have the last dimension == 1, with the true/labeled category", labelsShape)
 	}
-	weightsShape := shapes.Make(logits0.DType(), labelsShape.Dimensions[:labelsRank-1]...)
-	weights, mask := CheckLabelsForWeightsAndMask(weightsShape, labels)
 
 	// Remove last dimension, it will be re-added by OneHot
 	reducedLabels := Reshape(labels0, labels0.Shape().Dimensions[:labelsRank-1]...)
 	labelsValues := OneHot(reducedLabels, logitsShape.Dimensions[logitsRank-1], logitsShape.DType)
-	return categoricalCrossEntropyLogitsImpl(labelsValues, logits0, weights, mask)
+	return categoricalCrossEntropyLogitsImpl(labelsValues, logits0, labels[1:])
 }
 
 // CategoricalCrossEntropyLogits returns the cross-entropy loss of the logits, given the labels.
@@ -358,80 +396,93 @@ func SparseCategoricalCrossEntropyLogits(labels, logits []*Node) *Node {
 // It *does not* reduce-mean the losses, they are returned individually for each element of the batch and need
 // to be ReduceAllMean (usually the mean, but it could be the sum also) before used for training.
 //
-// If there is an extra `labels` `*Node` with the shape of logits without the last axis (usually simply `[bath_size]`),
-// it assumed to be weights to the losses.
-// If there is an extra `labels` `*Node` with booleans with the same dimensions as logits without the last axis
-// (usually simply `batch_size`), it assumed to be a mask.
+// Labels can have 2 optional extra values (in any order):
+//
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 //
 // TODO: implement faster version with logits, see https://github.com/tensorflow/tensorflow/blob/359c3cdfc5fabac82b3c70b3b6de2b0a8c16874f/tensorflow/python/ops/nn_ops.py#L4051
 func CategoricalCrossEntropyLogits(labels, logits []*Node) *Node {
 	logits0 := logits[0]
 	labels0 := labels[0]
-	weightsShape := shapes.Make(logits0.DType(), labels0.Shape().Dimensions[:labels0.Rank()-1]...)
-	weights, mask := CheckLabelsForWeightsAndMask(weightsShape, labels)
-	return categoricalCrossEntropyLogitsImpl(labels0, logits0, weights, mask)
+	return categoricalCrossEntropyLogitsImpl(labels0, logits0, labels[1:])
 }
 
 // categoricalCrossEntropyLogitsImpl implements CategoricalCrossEntropyLogits.
-func categoricalCrossEntropyLogitsImpl(labels, logits, weights, mask *Node) *Node {
+func categoricalCrossEntropyLogitsImpl(labels, logits *Node, extras []*Node) *Node {
 	shape := labels.Shape()
 	if !shape.Equal(logits.Shape()) {
 		Panicf("labels(%s) and logits(%s) must have the same shapes", shape, logits.Shape())
 	}
+
+	weightsShape := shapes.Make(logits.DType(), labels.Shape().Dimensions[:labels.Rank()-1]...)
+	weights, mask := CheckExtraLabelsForWeightsAndMask(weightsShape, extras)
+
 	var expandedMask *Node
 	if mask != nil {
 		expandedMask = BroadcastToShape(InsertAxes(mask, -1), logits.Shape())
 		logits = Where(expandedMask, logits, ZerosLike(logits))
 	}
 	logPredictions := LogSoftmax(logits)
-	losses := ReduceSum(Neg(Mul(labels, logPredictions)), -1)
-	// Losses will usually be shaped `[batch_size]` now.
+	loss := ReduceSum(Neg(Mul(labels, logPredictions)), -1)
+	// loss will usually be shaped `[batchSize]` now.
 	if weights != nil {
-		losses = Mul(losses, weights)
+		loss = Mul(loss, weights)
 	}
 	if mask != nil {
-		losses = Where(mask, losses, ZerosLike(losses))
+		loss = Where(mask, loss, ZerosLike(loss))
+		if !loss.IsScalar() {
+			loss = MaskedReduceAllMean(loss, mask)
+		}
+	} else if !loss.IsScalar() {
+		loss = ReduceAllMean(loss)
 	}
-	return losses
+	return loss
 }
 
-// CategoricalCrossEntropy returns the cross-entropy loss of the predictions, given the labels.
+// CategoricalCrossEntropy returns the cross-entropy loss of the predictions (as probabilities), given the labels.
 // The labels are provided in "dense" format, they should have the exact same shape as predictions, and be set 1 for
 // the true (labeled) category, and 0 for the others (one-hot encoding) -- or any other distribution that sums to 1.
 // predictions should hold probabilities that must sum to 1.0.
 //
-// It *does not* reduce-mean the losses, they are returned individually for each element of the batch and need
-// to be ReduceAllMean (usually the mean, but it could be the sum also) before used for training.
+// Notice the CategoricalCrossEntropyLogits is more stable, given the choice choose that instead.
 //
-// If there is an extra `labels` `*Node` with the shape of logits without the last axis (usually simply `[bath_size]`),
-// it assumed to be weights to the losses.
-// If there is an extra `labels` `*Node` with booleans with the same dimensions as logits without the last axis
-// (usually simply `batch_size`), it assumed to be a mask.
+// Labels can have 2 optional extra values (in any order):
+//
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 func CategoricalCrossEntropy(labels, predictions []*Node) *Node {
-	weightsShape := shapes.Make(predictions[0].DType(), labels[0].Shape().Dimensions[:labels[0].Rank()-1]...)
-	weights, mask := CheckLabelsForWeightsAndMask(weightsShape, labels)
-	return categoricalCrossEntropyImpl(labels[0], predictions[0], weights, mask)
-}
-
-// categoricalCrossEntropyImpl implements CategoricalCrossEntropy.
-func categoricalCrossEntropyImpl(labels, predictions, weights, mask *Node) *Node {
-	g := predictions.Graph()
-	shape := labels.Shape()
-	dtype := labels.DType()
-	if !shape.Equal(predictions.Shape()) {
-		Panicf("labels(%s) and predictions(%s) must different shapes", shape, predictions.Shape())
+	labels0 := labels[0]
+	predictions0 := predictions[0]
+	g := predictions0.Graph()
+	shape := labels0.Shape()
+	dtype := labels0.DType()
+	if !shape.Equal(predictions0.Shape()) {
+		Panicf("labels(%s) and predictions(%s) must different shapes", shape, predictions0.Shape())
 	}
 	epsilon := epsilonForDType(g, dtype)
-	predictions = Clip(predictions, epsilon, OneMinus(epsilon))
-	losses := ReduceSum(Neg(Mul(labels, Log(predictions))), -1)
-	// Losses will usually be shaped `[batch_size]` now, ready to apply weights multiplication and/or a mask.
+	predictions0 = Clip(predictions0, epsilon, OneMinus(epsilon))
+	loss := ReduceSum(Neg(Mul(labels0, Log(predictions0))), -1)
+
+	// Factor in weights and mask.
+	weightsShape := shapes.Make(predictions[0].DType(), labels[0].Shape().Dimensions[:labels[0].Rank()-1]...)
+	weights, mask := CheckExtraLabelsForWeightsAndMask(weightsShape, labels[1:])
 	if weights != nil {
-		losses = Mul(losses, weights)
+		loss = Mul(loss, weights)
 	}
 	if mask != nil {
-		losses = Where(mask, losses, ZerosLike(losses))
+		loss = Where(mask, loss, ZerosLike(loss))
+		if !loss.IsScalar() {
+			loss = MaskedReduceAllMean(loss, mask)
+		}
+	} else if !loss.IsScalar() {
+		loss = ReduceAllMean(loss)
 	}
-	return losses
+	return loss
 }
 
 // MakeHuberLoss returns a Huber loss function: it's similar to an L2 (MeanSquaredLoss) close to the target,
@@ -440,13 +491,12 @@ func categoricalCrossEntropyImpl(labels, predictions, weights, mask *Node) *Node
 // The delta parameter configures the range where the loss behaves as L2: if the prediction is further than
 // delta it becomes linear. It also defines the slope. A good default value is 1.0.
 //
-// For the returned loss function:
-//   - If there is an extra element in the input labels with the shape of the labels[0] (usually simply `[bath_size]`),
-//     it is assumed to be weights tensor to be applied to the losses.
-//   - If there is an extra element in the input labels  with booleans and the same dimensions as `labels[0]` (usually
-//     simply `batch_size`), it assumed to be a mask tensor to be applied to the losses.
-//   - The loss is returned per element, and not automatically reduced. train.Trainer will by default take the
-//     mean of it.
+// For the returned loss function, labels can have 2 optional extra values (in any order):
+//
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
 //
 // See https://en.wikipedia.org/wiki/Huber_loss
 func MakeHuberLoss(delta float64) LossFn {
@@ -461,7 +511,6 @@ func MakeHuberLoss(delta float64) LossFn {
 		if !labels0.Shape().Equal(predictions0.Shape()) {
 			Panicf("labels[0] (%s) and predictions[0] (%s) must have same shape", labels0.Shape(), predictions0.Shape())
 		}
-		weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
 
 		// Calculate Huber loss.
 		deltaConst := Scalar(g, dtype, delta)
@@ -474,12 +523,18 @@ func MakeHuberLoss(delta float64) LossFn {
 			Mul(deltaConst, linear),
 		)
 
-		// Apply weights and mask.
+		// Factor in weights and mask.
+		weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 		if weights != nil {
 			loss = Mul(loss, weights)
 		}
 		if mask != nil {
 			loss = Where(mask, loss, ZerosLike(loss))
+			if !loss.IsScalar() {
+				loss = MaskedReduceAllMean(loss, mask)
+			}
+		} else if !loss.IsScalar() {
+			loss = ReduceAllMean(loss)
 		}
 		return loss
 	}
@@ -507,6 +562,13 @@ func MakeHuberLossFromContext(ctx *context.Context) LossFn {
 //     and the loss is |labels-predictions|^(powerFar+powerNear)/2.
 //   - sharpness defines how sharp ("sudden") is the transition.
 //
+// For the returned loss function, labels can have 2 optional extra values (in any order):
+//
+//   - mask: a boolean mask of shape [batchSize] set to true for values to be used, and false for those to be ignored.
+//     Typically used for padding. The returned mean loss takes in consideration the mask.
+//   - weights: a float value of shape [batchSize] with the relative weights to be applied to each example. Weights
+//     are automatically normalized to sum to one (preserving their ratio), preserving their ratio.
+//
 // E.g.: setting powerNear to 2, powerFar to 1, this will behave similarly to a HuberLoss.
 func MakeAdaptivePowerLoss(powerNear, powerFar, middleDelta, sharpness float64) LossFn {
 	return func(labels, predictions []*Node) (loss *Node) {
@@ -517,7 +579,6 @@ func MakeAdaptivePowerLoss(powerNear, powerFar, middleDelta, sharpness float64) 
 		if !labels0.Shape().Equal(predictions0.Shape()) {
 			Panicf("labels[0] (%s) and predictions[0] (%s) must have same shape", labels0.Shape(), predictions0.Shape())
 		}
-		weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
 
 		// Calculate AdaptivePowerLoss
 		delta := Abs(Sub(labels0, predictions0))
@@ -555,12 +616,18 @@ func MakeAdaptivePowerLoss(powerNear, powerFar, middleDelta, sharpness float64) 
 			loss = Pow(delta, power)
 		}
 
-		// Apply weights and mask.
+		// Factor in weights and mask.
+		weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 		if weights != nil {
 			loss = Mul(loss, weights)
 		}
 		if mask != nil {
 			loss = Where(mask, loss, ZerosLike(loss))
+			if !loss.IsScalar() {
+				loss = MaskedReduceAllMean(loss, mask)
+			}
+		} else if !loss.IsScalar() {
+			loss = ReduceAllMean(loss)
 		}
 		return loss
 	}

--- a/ml/train/losses/triplet.go
+++ b/ml/train/losses/triplet.go
@@ -178,7 +178,7 @@ func TripletLoss(labels, predictions []*Node,
 
 	predictions0 := predictions[0]
 	labels0 := labels[0]
-	weights, mask := CheckLabelsForWeightsAndMask(labels0.Shape(), labels)
+	weights, mask := CheckExtraLabelsForWeightsAndMask(labels0.Shape(), labels[1:])
 
 	g := predictions0.Graph()
 	batchSize := predictions0.Shape().Dim(0)

--- a/ml/train/metrics/metrics.go
+++ b/ml/train/metrics/metrics.go
@@ -418,7 +418,7 @@ func SparseCategoricalAccuracyGraph(_ *context.Context, labels, logits []*Node) 
 
 	// Weights and masks: checks whether either are defined.
 	weightsShape := shapes.Make(logitsDType, logits0.Shape().Dimensions[:logits0.Rank()-1]...)
-	weights, mask := losses.CheckLabelsForWeightsAndMask(weightsShape, labels)
+	weights, mask := losses.CheckExtraLabelsForWeightsAndMask(weightsShape, labels[1:])
 	modelChoices := ArgMax(logits0, -1, labelsDType)
 	correctExamples := ConvertDType(Equal(modelChoices, Squeeze(labels0, -1)), logitsDType) // correctExamples -> 0/1 per example.
 


### PR DESCRIPTION
* Package losses:
  * Triplet losses now work with context.
  * `CheckExtraLabelsForWeightsAndMask` now (1) accepts weights and mask in any order; (2) normalize weights such that the sum is (non-masked) bathSize, 
    preserving the ratio. This way the mean will be 1.
  * Losses with masks and weights fixed so weights/mask can be given in any order.
    Also, now using MaskedReduceMean if there is a mask, and all losses return a scalar.