### PR TITLE
fix check for mnist

### DIFF
--- a/examples/mnist/dataset.go
+++ b/examples/mnist/dataset.go
@@ -186,7 +186,7 @@ func loadImageFile(filename string) ([]image.Image, error) {
 
 	if header.Magic != ImageMagic ||
 		header.Width != Width ||
-		header.Height != header.Height {
+		header.Height != Height {
 		return nil, fmt.Errorf("mnist: invalid format")
 	}
 


### PR DESCRIPTION
btw: the example `mnist` can't run with `backend/simplego`