### PR TITLE
SimpleGo: parallelization of ops execution

### DIFF
--- a/backends/simplego/exec_special_ops_test.go
+++ b/backends/simplego/exec_special_ops_test.go
@@ -557,6 +557,7 @@ func TestExecSpecialOps_RngBitsGenerator(t *testing.T) {
 				state, values = graph.RandomUniform(state, shape)
 				return []*graph.Node{state, values}
 			}, state)
+			fmt.Printf("\toutput.shape=%s\n", shape)
 			state = outputs[0]
 			y := outputs[1]
 

--- a/backends/simplego/simplego.go
+++ b/backends/simplego/simplego.go
@@ -58,8 +58,8 @@ func New(config string) backends.Backend {
 			// This will force every DotGeneral operation to be executed with both versions and the outputs compared.
 			forceProblemSize = checkProblemSize
 		case "sequential":
-			// This will force the operations to be executed sequentially, as opposed to concurrently as soon as the
-			// ops inputs are available.
+			// This will force the operations to be executed sequentially, as opposed to concurrently, as soon as the
+			// ops' inputs are available.
 			execForceSequential = true
 		}
 	}

--- a/backends/simplego/simplego.go
+++ b/backends/simplego/simplego.go
@@ -55,8 +55,12 @@ func New(config string) backends.Backend {
 			// This will force DotGeneral operation to use the version designed for large matrices.
 			forceProblemSize = largeProblemSize
 		case "force_check":
-			// This will force every DotGeneral operation to be executed with both versions, and the outputs compared.
+			// This will force every DotGeneral operation to be executed with both versions and the outputs compared.
 			forceProblemSize = checkProblemSize
+		case "sequential":
+			// This will force the operations to be executed sequentially, as opposed to concurrently as soon as the
+			// ops inputs are available.
+			execForceSequential = true
 		}
 	}
 	return b

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
     * Version for small inner matrices, with block iteration and loop unrolling.
     * Version for larger inner matrices: re-package inputs in ~4K blocks, and recursively partition matrices.
     * Added parallelization: at batch level and in the partitioning in the larger matrices.
+  * Parallel execution of the Ops: that helps a lot during training (cut the training time almost in half for the adult 
+    dataset), but it may hurt inference if you are running many batches in parallel. In those cases use the `sequential`
+    configuration: `GOMLX_BACKEND=go:sequential`, and it will run the ops sequentially.
 
 # v0.19.4: 2024/05/24 added Vector Neural Networks (VNNs)
 


### PR DESCRIPTION
  * Parallel execution of the Ops: that helps a lot during training (cut the training time almost in half for the adult 
    dataset), but it may hurt inference if you are running many batches in parallel. In those cases use the `sequential`
    configuration: `GOMLX_BACKEND=go:sequential`, and it will run the ops sequentially.
