### PR TITLE
v0.20.2

### DIFF
--- a/backends/simplego/dotgeneral_large.go
+++ b/backends/simplego/dotgeneral_large.go
@@ -21,7 +21,7 @@ var (
 	// It should be the number per thread, not necessarily the number per core.
 	// It was empirically optimized in an AMD 9950x3d.
 	// TODO: find out how to initialize this number in runtime.
-	DotGeneralTargetBlockSize = 4 * 1024
+	DotGeneralTargetBlockSize = 16 * 1024
 
 	// DotGeneralTargetBlockLog2Dim is set per dtype, such that it is square and fits DotGeneralTargetBlockSize.
 	// The block dim is 2^(DotGeneralTargetBlockLog2Dim[dtype]).

--- a/backends/simplego/dotgeneral_test.go
+++ b/backends/simplego/dotgeneral_test.go
@@ -416,7 +416,7 @@ func TestDotGeneral_Exec(t *testing.T) {
 				fmt.Printf("\tgot=%s\n", got.Shape())
 				fmt.Printf("\twant=%s\n", want.Shape())
 
-				// Run 8 workers in parallel, to see if concurrency is a problem:
+				// Run 8 workers in parallel to see if concurrency is a problem:
 				var wg sync.WaitGroup
 				var numCalls atomic.Uint32
 				for runnerIdx := range 16 {
@@ -513,6 +513,11 @@ func TestDotGeneral_PerformanceTable(t *testing.T) {
 	// rhsDims: [Batch, RhsCross, Contracting]
 	// Batch and Contracting dimensions must match between lhs and rhs.
 	benchmarkCases := []dotGeneralBenchmarkParamsCase{
+		{
+			name:     "NoBatch-Large",
+			lhsShape: []int{1536, 1920}, lhsContractingAxes: []int{1}, lhsBatchAxes: nil,
+			rhsShape: []int{1920, 1024}, rhsContractingAxes: []int{0}, rhsBatchAxes: nil,
+		},
 		/*
 			{
 				name:     "KA-Batch-16-#4",

--- a/backends/simplego/dotgeneral_test.go
+++ b/backends/simplego/dotgeneral_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gomlx/gomlx/types/shapes"
 	"github.com/gomlx/gomlx/types/tensors"
 	"github.com/gomlx/gomlx/types/xslices"
+	"github.com/gomlx/gomlx/ui/commandline"
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/gomlx/gopjrt/dtypes/bfloat16"
 	"github.com/muesli/termenv"
@@ -26,20 +27,6 @@ import (
 )
 
 var flagPerf = flag.Bool("perf", false, "Run performance table tests.")
-
-func formatDurationWith2Decimals(d time.Duration) string {
-	s := d.String()
-	re := regexp.MustCompile(`(\d+\.?\d*)([µa-z]+)`)
-	matches := re.FindStringSubmatch(s)
-	if len(matches) != 3 {
-		return s
-	}
-	num, err := strconv.ParseFloat(matches[1], 64)
-	if err != nil {
-		return s
-	}
-	return fmt.Sprintf("%.2f%s", num, matches[2])
-}
 
 func TestDotGeneral_LargeShapesAndCopy(t *testing.T) {
 	if _, ok := backend.(*Backend); !ok {
@@ -739,7 +726,7 @@ func TestDotGeneral_PerformanceTable(t *testing.T) {
 				dimsToStr(benchCase.lhsShape), dimsToStr(benchCase.rhsShape),
 				dtype,
 				batchSize,
-				formatDurationWith2Decimals(avgDurationPerRun),
+				commandline.FormatDuration(avgDurationPerRun),
 				humanize.Comma(int64(numOps)),
 				gOpsPerSecond)
 			fmt.Println(style.Render(row))

--- a/backends/simplego/simplego.go
+++ b/backends/simplego/simplego.go
@@ -30,6 +30,18 @@ func init() {
 	backends.Register(BackendName, New)
 }
 
+// GetBackend returns a singleton backend for SimpleGo, created with the default configuration.
+// The backend is only created at the first call of the function.
+//
+// The singleton is never destroyed.
+var GetBackend = sync.OnceValue(func() backends.Backend {
+	backend, err := New("")
+	if err != nil {
+		panic(err)
+	}
+	return backend
+})
+
 // New constructs a new SimpleGo Backend.
 // There are no configurations, the string is simply ignored.
 func New(config string) (backends.Backend, error) {

--- a/cmd/gomlx_checkpoints/main.go
+++ b/cmd/gomlx_checkpoints/main.go
@@ -14,16 +14,12 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	lgtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/dustin/go-humanize"
 	"github.com/gomlx/gomlx/backends"
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/ml/context"
 	"github.com/gomlx/gomlx/ml/context/checkpoints"
 	"github.com/gomlx/gomlx/ml/train/optimizers"
-	"github.com/gomlx/gomlx/types"
-	"github.com/gomlx/gomlx/types/tensors"
-	"github.com/gomlx/gomlx/types/xslices"
 	"github.com/gomlx/gomlx/ui/plots"
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/janpfeifer/must"
@@ -47,9 +43,6 @@ var (
 	flagMetricsLabels = flag.Bool("metrics_labels", false,
 		fmt.Sprintf("Lists the metrics labels (short names) with their full description from file %q", plots.TrainingPlotFileName))
 
-	flagMetricsNames = flag.String("metrics_names", "", "Comma-separate list of metric names to include in metrics Reports.")
-	flagMetricsTypes = flag.String("metrics_types", "", "Comma-separate list of metric types to include in metrics Reports. ")
-
 	flagBackup     = flag.Bool("backup", false, "Set to true to make a backup of the most recent checkpoint, under the 'backup' subdirectory.")
 	flagDeleteVars = flag.String("delete_vars", "", "Delete variables under the given scope(s). Useful for instance to remove training temporary data.")
 	flagGlossary   = flag.Bool("glossary", true, "Whether to list glossary of abbreviation on the bottom of tables.")
@@ -65,10 +58,11 @@ func main() {
 			_ = must.M1(fmt.Fprintf(flag.CommandLine.Output(), format, args...))
 		}
 		pf("Usage of gomlx_checkpoints (%q):\n", os.Args[0])
-		pf("\n\t$ gomlx_checkpoints [flags...] <checkpoint_path>\n" +
+		pf("\n\t$ gomlx_checkpoints [flags...] <checkpoint_path> [<checkpoint_path2> ...]\n" +
 			"\ngomlx_checkpoints reports back on model size (and memory) usage (--summary), individual variables shapes and sizes (--vars), " +
 			"hyperparameters used with the model (--params) or metrics collected during model training (--metrics, --metrics_labels).\n" +
-			"\n\t<checkpoint_path> is the path of a checkpoint directory used to save a GoMLX model (see package github.com/gomlx/gomlx/ml/context/checkpoints)\n\n" +
+			"\n\t<checkpoint_path> is the path of a checkpoint directory used to save a GoMLX model (see package github.com/gomlx/gomlx/ml/context/checkpoints)\n" +
+			"\tSome flags support more than one checkpoint, which can be used to compare models.\n\n" +
 			"Flags:\n\n")
 		flag.PrintDefaults()
 	}
@@ -77,10 +71,6 @@ func main() {
 	args := flag.Args()
 	if len(args) == 0 {
 		klog.Errorf("Missing checkpoint directory to read from. See 'gomlx_checkpoint -help'")
-		os.Exit(1)
-	}
-	if len(args) > 1 {
-		klog.Errorf("Too many arguments. See 'gomlx_checkpoint -help'.")
 		os.Exit(1)
 	}
 
@@ -103,12 +93,12 @@ func main() {
 	if *flagLoop > 0 {
 		for {
 			ClearScreen()
-			Reports(args[0])
+			Reports(args)
 			fmt.Println(italicStyle.Render(fmt.Sprintf("(... refreshing every %s ...)", *flagLoop)))
 			time.Sleep(*flagLoop)
 		}
 	}
-	Reports(args[0])
+	Reports(args)
 }
 
 func ClearScreen() {
@@ -116,232 +106,52 @@ func ClearScreen() {
 }
 
 var (
-	headerRowStyle = lipgloss.NewStyle().Reverse(true).
-			Padding(0, 2, 0, 2).Align(lipgloss.Center)
-
-	oddRowStyle = lipgloss.NewStyle().Faint(false).
-			PaddingLeft(1).PaddingRight(1)
-	evenRowStyle = lipgloss.NewStyle().Faint(true).
-			PaddingLeft(1).PaddingRight(1)
-
 	titleStyle    = lipgloss.NewStyle().Bold(true).Padding(1, 4, 1, 4)
 	italicStyle   = lipgloss.NewStyle().Italic(true).Faint(true)
 	emphasisStyle = lipgloss.NewStyle().Bold(true).Faint(false)
 	sectionStyle  = lipgloss.NewStyle().Underline(true).Faint(false)
 )
 
-func newPlainTable(withHeader bool, alignments ...lipgloss.Position) *lgtable.Table {
-	return lgtable.New().
-		Border(lipgloss.NormalBorder()).
-		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
-		StyleFunc(func(row, col int) (s lipgloss.Style) {
-			if row < 0 {
-				s = headerRowStyle
-				return
-			}
-			switch {
-			case row%2 == 0:
-				// Even row style.
-				s = oddRowStyle
-			default:
-				// Odd row style
-				s = evenRowStyle
-			}
-			alignment := lipgloss.Left
-			if col < len(alignments) {
-				alignment = alignments[col]
-			} else if len(alignments) > 0 {
-				alignment = alignments[len(alignments)-1]
-			}
-			s = s.Align(alignment)
-			return
-		})
-}
-
-func Reports(checkpointPath string) {
-	ctx := context.New()
-	if *flagSummary || *flagParams || *flagVars {
-		_ = must.M1(checkpoints.Build(ctx).
-			Dir(checkpointPath).Immediate().Done())
+func Reports(checkpointPaths []string) {
+	numCheckpoints := len(checkpointPaths)
+	ctxs := make([]*context.Context, 0, len(checkpointPaths))
+	scopedCtxs := make([]*context.Context, 0, len(checkpointPaths))
+	for _, checkpointPath := range checkpointPaths {
+		ctx := context.New()
+		if *flagSummary || *flagParams || *flagVars {
+			_ = must.M1(checkpoints.Build(ctx).
+				Dir(checkpointPath).Immediate().Done())
+		}
+		scopedCtx := ctx
+		if *flagScope != "" {
+			scopedCtx = ctx.InAbsPath(*flagScope)
+		}
+		ctxs = append(ctxs, ctx)
+		scopedCtxs = append(scopedCtxs, scopedCtx)
 	}
-	scopedCtx := ctx
-	if *flagScope != "" {
-		scopedCtx = ctx.InAbsPath(*flagScope)
+	var names []string
+	if numCheckpoints == 1 {
+		names = []string{checkpointPaths[0]}
+	} else {
+		names = MinimalUniquePaths(checkpointPaths...)
 	}
 
-	// Summary table.
 	if *flagSummary {
-		fmt.Println(titleStyle.Render("Summary"))
-		table := newPlainTable(false, lipgloss.Right, lipgloss.Left)
-		table.Row("checkpoint", checkpointPath)
-		table.Row("scope", *flagScope)
-		globalStepVar := ctx.GetVariable(optimizers.GlobalStepVariableName)
-		if globalStepVar != nil {
-			globalStep := tensors.ToScalar[int64](globalStepVar.Value())
-			table.Row(fmt.Sprintf("global_step(%s)", ctx.Scope()), humanize.Comma(globalStep))
-		}
-
-		var numVars, totalSize int
-		var totalMemory uintptr
-		scopedCtx.EnumerateVariablesInScope(func(v *context.Variable) {
-			numVars++
-			totalSize += v.Shape().Size()
-			totalMemory += v.Shape().Memory()
-		})
-		table.Row("# variables", humanize.Comma(int64(numVars)))
-		table.Row("# parameters", humanize.Comma(int64(totalSize)))
-		table.Row("# bytes", humanize.Bytes(uint64(totalMemory)))
-		fmt.Println(table.Render())
+		Summary(ctxs, scopedCtxs, names)
 	}
-
 	if *flagParams {
-		fmt.Println(titleStyle.Render("Hyperparameters"))
-		table := newPlainTable(true)
-		table.Headers("Scope", "Name", "Type", "Value")
-		ctx.EnumerateParams(func(scope, key string, value any) {
-			table.Row(scope, key, fmt.Sprintf("%T", value), fmt.Sprintf("%v", value))
-		})
-		fmt.Println(table.Render())
+		Params(ctxs, scopedCtxs, names)
 	}
-
-	if *flagVars {
-		ListVariables(scopedCtx)
-	}
-
 	if *flagMetrics || *flagMetricsLabels {
-		metrics(checkpointPath)
+		metrics(checkpointPaths, names)
 	}
-}
-
-func metrics(checkpointPath string) {
-	trainingMetricsPath := path.Join(checkpointPath, plots.TrainingPlotFileName)
-	points := must.M1(plots.LoadPoints(trainingMetricsPath))
-	if len(points) == 0 {
-		klog.Errorf("No metrics found in %q", trainingMetricsPath)
+	if *flagVars {
+		if numCheckpoints > 1 {
+			klog.Fatalf("More than one checkpoint not supported for --vars")
+		}
+		ListVariables(scopedCtxs[0])
 	}
 
-	var metricsNames, metricsTypes types.Set[string]
-	if *flagMetricsNames != "" {
-		metricsNames = types.MakeSet[string]()
-		for _, name := range strings.Split(*flagMetricsNames, ",") {
-			metricsNames.Insert(name)
-		}
-	}
-	if *flagMetricsTypes != "" {
-		metricsTypes = types.MakeSet[string]()
-		for _, name := range strings.Split(*flagMetricsTypes, ",") {
-			metricsTypes.Insert(name)
-		}
-	}
-	metricsUsed := types.MakeSet[string]()
-	nameToShort := make(map[string]string)
-	shortToName := make(map[string]string)
-	for _, point := range points {
-		nameToShort[point.MetricName] = point.Short
-		shortToName[point.Short] = point.MetricName
-		if metricsNames != nil || metricsTypes != nil {
-			foundName := metricsNames != nil && (metricsNames.Has(point.MetricName) || metricsNames.Has(point.Short))
-			foundType := metricsTypes != nil && metricsTypes.Has(point.MetricType)
-			if !foundName && !foundType {
-				continue
-			}
-		}
-		metricsUsed.Insert(point.Short)
-	}
-
-	// map metric name to position in row, starting from 1 (position 0 is for the global set)
-	metricsOrder := make(map[string]int)
-	nextPos := 1
-	if *flagMetricsNames != "" {
-		// Start with the order given by the user:
-		for _, name := range strings.Split(*flagMetricsNames, ",") {
-			if short, found := nameToShort[name]; found {
-				name = short
-			}
-			if metricsUsed.Has(name) {
-				metricsOrder[name] = nextPos
-				nextPos++
-			}
-		}
-	}
-	// Append all other metric names, in alphabetical order.
-	for _, short := range xslices.SortedKeys(metricsUsed) {
-		if _, found := metricsOrder[short]; found {
-			continue // Already listed.
-		}
-		metricsOrder[short] = nextPos
-		nextPos++
-	}
-
-	if *flagMetricsLabels {
-		ReportMetricsLabels(shortToName, nameToShort, metricsOrder)
-	}
-
-	if *flagMetrics {
-		ReportMetrics(checkpointPath, metricsUsed, metricsOrder, points)
-	}
-}
-
-// ReportMetricsLabels list all metrics short and long names.
-func ReportMetricsLabels(shortToName map[string]string, nameToShort map[string]string, metricsOrder map[string]int) {
-	fmt.Println(titleStyle.Render("Metrics Labels"))
-	table := newPlainTable(true, lipgloss.Center, lipgloss.Left)
-	table.Headers("Short", "MetricName")
-	rows := make([][]string, len(metricsOrder))
-	for short, idx := range metricsOrder {
-		name, found := shortToName[short]
-		if !found {
-			// metric manually selected by name:
-			name = short
-			short = nameToShort[name]
-		}
-		rows[idx-1] = []string{short, name}
-	}
-	for _, row := range rows {
-		table.Row(row...)
-	}
-	fmt.Println(table.Render())
-}
-
-// ReportMetrics of the model.
-func ReportMetrics(checkpointPath string, metricsUsed types.Set[string], metricsOrder map[string]int, points []plots.Point) {
-	fmt.Println(titleStyle.Render(fmt.Sprintf("Metrics %q", checkpointPath)))
-	table := newPlainTable(true, lipgloss.Right)
-	header := make([]string, 1+len(metricsUsed))
-	header[0] = "Global Step"
-	for name, idx := range metricsOrder {
-		header[idx] = name
-	}
-	table.Headers(header...)
-
-	currentStep := int64(-1)
-	var currentRow []string
-	for _, point := range points {
-		step := int64(point.Step)
-		if step != currentStep {
-			if currentStep != -1 {
-				table.Row(currentRow...)
-			}
-			currentStep = step
-			currentRow = make([]string, 1+len(metricsUsed))
-			currentRow[0] = humanize.Comma(step)
-		}
-		idx, found := metricsOrder[point.Short]
-		if found {
-			var value string
-			switch point.MetricType {
-			case "accuracy":
-				value = fmt.Sprintf("%.2f%%", 100.0*point.Value)
-			default:
-				value = fmt.Sprintf("%.3g", point.Value)
-			}
-			currentRow[idx] = value
-		}
-	}
-	if currentStep != -1 {
-		table.Row(currentRow...)
-	}
-	fmt.Println(table.Render())
 }
 
 // ListVariables list the variables of a model, with their shape and MAV (max absolute value), RMS (root mean square) and MaxAV (max absolute value) values.

--- a/cmd/gomlx_checkpoints/main.go
+++ b/cmd/gomlx_checkpoints/main.go
@@ -7,6 +7,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
 	"github.com/charmbracelet/lipgloss"
 	lgtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/dustin/go-humanize"
@@ -22,11 +28,6 @@ import (
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/janpfeifer/must"
 	"k8s.io/klog/v2"
-	"os"
-	"path"
-	"slices"
-	"strings"
-	"time"
 
 	_ "github.com/gomlx/gomlx/backends/default"
 )
@@ -332,7 +333,7 @@ func ReportMetrics(checkpointPath string, metricsUsed types.Set[string], metrics
 			case "accuracy":
 				value = fmt.Sprintf("%.2f%%", 100.0*point.Value)
 			default:
-				value = fmt.Sprintf("%.3f", point.Value)
+				value = fmt.Sprintf("%.3g", point.Value)
 			}
 			currentRow[idx] = value
 		}

--- a/cmd/gomlx_checkpoints/main.go
+++ b/cmd/gomlx_checkpoints/main.go
@@ -117,12 +117,12 @@ func ClearScreen() {
 
 var (
 	headerRowStyle = lipgloss.NewStyle().Reverse(true).
-		Padding(0, 2, 0, 2).Align(lipgloss.Center)
+			Padding(0, 2, 0, 2).Align(lipgloss.Center)
 
 	oddRowStyle = lipgloss.NewStyle().Faint(false).
-		PaddingLeft(1).PaddingRight(1)
+			PaddingLeft(1).PaddingRight(1)
 	evenRowStyle = lipgloss.NewStyle().Faint(true).
-		PaddingLeft(1).PaddingRight(1)
+			PaddingLeft(1).PaddingRight(1)
 
 	titleStyle    = lipgloss.NewStyle().Bold(true).Padding(1, 4, 1, 4)
 	italicStyle   = lipgloss.NewStyle().Italic(true).Faint(true)

--- a/cmd/gomlx_checkpoints/metrics.go
+++ b/cmd/gomlx_checkpoints/metrics.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
+	"github.com/gomlx/gomlx/types"
+	"github.com/gomlx/gomlx/types/xslices"
+	"github.com/gomlx/gomlx/ui/plots"
+	"github.com/janpfeifer/must"
+	"k8s.io/klog/v2"
+)
+
+var (
+	flagMetricsNames = flag.String("metrics_names", "", "Regular expression that if matches the name or short name, the metric is included.")
+	flagMetricsTypes = flag.String("metrics_types", "", "Comma-separate list of metric types to include in metrics Reports. ")
+)
+
+func metrics(checkpointPaths, names []string) {
+	numCheckpoints := len(names)
+	checkpointPath := checkpointPaths[0]
+	_ = numCheckpoints
+
+	// Load metrics points from the checkpointPath.
+	trainingMetricsPath := path.Join(checkpointPath, plots.TrainingPlotFileName)
+	points := must.M1(plots.LoadPoints(trainingMetricsPath))
+	if len(points) == 0 {
+		klog.Errorf("No metrics found in %q", trainingMetricsPath)
+	}
+
+	var metricsNamesMatcher *regexp.Regexp
+	if *flagMetricsNames != "" {
+		var err error
+		metricsNamesMatcher, err = regexp.Compile(*flagMetricsNames)
+		if err != nil {
+			klog.Fatalf("Failed to compile -metrics_names=%q matcher: %v", *flagMetricsNames, err)
+		}
+	}
+
+	var metricsTypes types.Set[string]
+	if *flagMetricsTypes != "" {
+		metricsTypes = types.MakeSet[string]()
+		for _, name := range strings.Split(*flagMetricsTypes, ",") {
+			metricsTypes.Insert(name)
+		}
+	}
+	metricsUsed := types.MakeSet[string]()
+	nameToShort := make(map[string]string)
+	shortToName := make(map[string]string)
+	for _, point := range points {
+		nameToShort[point.MetricName] = point.Short
+		shortToName[point.Short] = point.MetricName
+		if metricsNamesMatcher != nil || metricsTypes != nil {
+			foundName := metricsNamesMatcher.MatchString(point.MetricName) || metricsNamesMatcher.MatchString(point.Short)
+			foundType := metricsTypes != nil && metricsTypes.Has(point.MetricType)
+			if !foundName && !foundType {
+				continue
+			}
+		}
+		metricsUsed.Insert(point.Short)
+	}
+
+	// map metric name to position in row, starting from 1 (position 0 is for the global set)
+	metricsOrder := make(map[string]int)
+	nextPos := 1
+	if *flagMetricsNames != "" {
+		// Start with the order given by the user:
+		for _, name := range strings.Split(*flagMetricsNames, ",") {
+			if short, found := nameToShort[name]; found {
+				name = short
+			}
+			if metricsUsed.Has(name) {
+				metricsOrder[name] = nextPos
+				nextPos++
+			}
+		}
+	}
+	// Append all other metric names, in alphabetical order.
+	for _, short := range xslices.SortedKeys(metricsUsed) {
+		if _, found := metricsOrder[short]; found {
+			continue // Already listed.
+		}
+		metricsOrder[short] = nextPos
+		nextPos++
+	}
+
+	if *flagMetricsLabels {
+		ReportMetricsLabels(shortToName, nameToShort, metricsOrder)
+	}
+
+	if *flagMetrics {
+		ReportMetrics(checkpointPath, metricsUsed, metricsOrder, points)
+	}
+}
+
+// ReportMetricsLabels list all metrics short and long names.
+func ReportMetricsLabels(shortToName map[string]string, nameToShort map[string]string, metricsOrder map[string]int) {
+	fmt.Println(titleStyle.Render("Metrics Labels"))
+	table := newPlainTable(true, lipgloss.Center, lipgloss.Left)
+	table.Headers("Short", "MetricName")
+	rows := make([][]string, len(metricsOrder))
+	for short, idx := range metricsOrder {
+		name, found := shortToName[short]
+		if !found {
+			// metric manually selected by name:
+			name = short
+			short = nameToShort[name]
+		}
+		rows[idx-1] = []string{short, name}
+	}
+	for _, row := range rows {
+		table.Row(row...)
+	}
+	fmt.Println(table.Render())
+}
+
+// ReportMetrics of the model.
+func ReportMetrics(checkpointPath string, metricsUsed types.Set[string], metricsOrder map[string]int, points []plots.Point) {
+	fmt.Println(titleStyle.Render(fmt.Sprintf("Metrics %q", checkpointPath)))
+	table := newPlainTable(true, lipgloss.Right)
+	header := make([]string, 1+len(metricsUsed))
+	header[0] = "Global Step"
+	for name, idx := range metricsOrder {
+		header[idx] = name
+	}
+	table.Headers(header...)
+
+	currentStep := int64(-1)
+	var currentRow []string
+	for _, point := range points {
+		step := int64(point.Step)
+		if step != currentStep {
+			if currentStep != -1 {
+				table.Row(currentRow...)
+			}
+			currentStep = step
+			currentRow = make([]string, 1+len(metricsUsed))
+			currentRow[0] = humanize.Comma(step)
+		}
+		idx, found := metricsOrder[point.Short]
+		if found {
+			var value string
+			switch point.MetricType {
+			case "accuracy":
+				value = fmt.Sprintf("%.2f%%", 100.0*point.Value)
+			default:
+				value = fmt.Sprintf("%.3g", point.Value)
+			}
+			currentRow[idx] = value
+		}
+	}
+	if currentStep != -1 {
+		table.Row(currentRow...)
+	}
+	fmt.Println(table.Render())
+}

--- a/cmd/gomlx_checkpoints/params.go
+++ b/cmd/gomlx_checkpoints/params.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/gomlx/gomlx/types"
+	"golang.org/x/exp/maps"
+)
+
+func Params(ctxs, scopedCtxs []*context.Context, names []string) {
+	numCheckpoints := len(names)
+	numCols := numCheckpoints + 3
+
+	fmt.Println(titleStyle.Render("Hyperparameters"))
+	table := newPlainTableWithReds(true)
+
+	// Build the headers row.
+	headers := make([]string, 0, numCols)
+	headers = append(headers, []string{"Scope", "Name", "Type"}...)
+	if numCheckpoints == 1 {
+		headers = append(headers, "Value")
+	} else {
+		for i := 0; i < numCheckpoints; i++ {
+			headers = append(headers, names[i])
+		}
+	}
+	table.Table.Headers(headers...)
+
+	// List params set on all models.
+	type scopeKey struct{ Scope, Key string }
+	scopeKeySet := types.MakeSet[scopeKey]()
+	for _, ctx := range ctxs {
+		ctx.EnumerateParams(func(scope, key string, value any) {
+			scopeKeySet.Insert(scopeKey{Scope: scope, Key: key})
+		})
+	}
+	scopeKeys := maps.Keys(scopeKeySet)
+	slices.SortFunc(scopeKeys, func(a scopeKey, b scopeKey) int {
+		if a.Scope < b.Scope {
+			return -1
+		}
+		if a.Scope > b.Scope {
+			return 1
+		}
+		if a.Key < b.Key {
+			return -1
+		}
+		if a.Key > b.Key {
+			return 1
+		}
+		return 0
+	})
+
+	for _, pair := range scopeKeys {
+		row := make([]string, numCols)
+		scope, key := pair.Scope, pair.Key
+		row[0] = scope
+		row[1] = key
+		for ii, ctx := range ctxs {
+			if scope != "/" {
+				ctx = ctx.In(scope)
+			}
+			value, found := ctx.GetParam(key)
+			if !found {
+				continue
+			}
+			if row[2] == "" {
+				// Set the type of the value.
+				row[2] = fmt.Sprintf("%T", value)
+			}
+			row[3+ii] = fmt.Sprintf("%v", value)
+		}
+		table.Row(!isAllEqual(row[3:]), row...)
+	}
+	fmt.Println(table.Table.Render())
+}

--- a/cmd/gomlx_checkpoints/summary.go
+++ b/cmd/gomlx_checkpoints/summary.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/gomlx/gomlx/ml/train/optimizers"
+	"github.com/gomlx/gomlx/types/tensors"
+)
+
+func Summary(ctxs, scopedCtxs []*context.Context, names []string) {
+	numCheckpoints := len(names)
+
+	// Header
+	fmt.Println(titleStyle.Render("Summary"))
+	table := newPlainTable(false, lipgloss.Right, lipgloss.Left)
+	table.Row(append([]string{"checkpoint"}, names...)...)
+
+	// Scope
+	scopeRow := make([]string, numCheckpoints+1)
+	scopeRow[0] = "scope"
+	for ii := 1; ii < numCheckpoints; ii++ {
+		scopeRow[ii] = *flagScope
+	}
+	table.Row(scopeRow...)
+
+	// Global step:
+	globalStepRow := make([]string, numCheckpoints+1)
+	globalStepRow[0] = "global_step"
+	haveGlobalStep := false
+	for ii, ctx := range ctxs {
+		globalStepVar := ctx.GetVariable(optimizers.GlobalStepVariableName)
+		if globalStepVar != nil {
+			haveGlobalStep = true
+			globalStepRow[ii+1] = humanize.Comma(tensors.ToScalar[int64](globalStepVar.Value()))
+		}
+	}
+	if haveGlobalStep {
+		table.Row(globalStepRow...)
+	}
+
+	// Variables, parameters and memory.
+	variablesRow := make([]string, numCheckpoints+1)
+	parametersRow := make([]string, numCheckpoints+1)
+	memoryRow := make([]string, numCheckpoints+1)
+	variablesRow[0] = "# variables"
+	parametersRow[0] = "# parameters"
+	memoryRow[0] = "# bytes"
+	for ii, scopedCtx := range scopedCtxs {
+		var numVars, totalSize int
+		var totalMemory uintptr
+		scopedCtx.EnumerateVariablesInScope(func(v *context.Variable) {
+			numVars++
+			totalSize += v.Shape().Size()
+			totalMemory += v.Shape().Memory()
+		})
+		variablesRow[ii+1] = humanize.Comma(int64(numVars))
+		parametersRow[ii+1] = humanize.Comma(int64(totalSize))
+		memoryRow[ii+1] = humanize.Bytes(uint64(totalMemory))
+	}
+	table.Row(variablesRow...)
+	table.Row(parametersRow...)
+	table.Row(memoryRow...)
+	fmt.Println(table.Render())
+}

--- a/cmd/gomlx_checkpoints/tables.go
+++ b/cmd/gomlx_checkpoints/tables.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	lgtable "github.com/charmbracelet/lipgloss/table"
+)
+
+var (
+	headerRowStyle = lipgloss.NewStyle().Reverse(true).
+			Padding(0, 2, 0, 2).Align(lipgloss.Center)
+
+	oddRowStyle = lipgloss.NewStyle().Faint(false).
+			PaddingLeft(1).PaddingRight(1)
+	evenRowStyle = lipgloss.NewStyle().Faint(true).
+			PaddingLeft(1).PaddingRight(1)
+	redRowStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "9", Dark: "9"}).
+			Bold(true).
+			PaddingLeft(1).PaddingRight(1)
+)
+
+func newPlainTable(withHeader bool, alignments ...lipgloss.Position) *lgtable.Table {
+	t := newPlainTableWithReds(withHeader, alignments...)
+	return t.Table
+}
+
+type TableWithReds struct {
+	Table *lgtable.Table
+	Count int
+	Reds  map[int]bool
+}
+
+func (t *TableWithReds) Row(isRed bool, row ...string) {
+	if isRed {
+		t.Reds[t.Count] = true
+	}
+	t.Table.Row(row...)
+	t.Count++
+}
+
+func newPlainTableWithReds(withHeader bool, alignments ...lipgloss.Position) *TableWithReds {
+	t := &TableWithReds{
+		Reds: make(map[int]bool),
+	}
+	t.Table = lgtable.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
+		StyleFunc(func(row, col int) (s lipgloss.Style) {
+			if row < 0 {
+				s = headerRowStyle
+				return
+			}
+			if t.Reds[row] {
+				s = redRowStyle
+			} else {
+				switch {
+				case row%2 == 0:
+					// Even row style.
+					s = oddRowStyle
+				default:
+					// Odd row style
+					s = evenRowStyle
+				}
+			}
+			alignment := lipgloss.Left
+			if col < len(alignments) {
+				alignment = alignments[col]
+			} else if len(alignments) > 0 {
+				alignment = alignments[len(alignments)-1]
+			}
+			s = s.Align(alignment)
+			return
+		})
+	return t
+}
+
+func isAllEqual[E comparable](s []E) bool {
+	if len(s) == 0 {
+		return true
+	}
+	v := s[0]
+	for ii := range len(s) - 1 {
+		if v != s[ii+1] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/gomlx_checkpoints/uniquepaths.go
+++ b/cmd/gomlx_checkpoints/uniquepaths.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// MinimalUniquePaths takes a list of file paths and returns a list of minimal unique identifiers
+// that distinguish each path from others using the minimum necessary path parts.
+func MinimalUniquePaths(paths ...string) []string {
+	if len(paths) <= 1 {
+		return paths
+	}
+
+	// Split all paths into components
+	splitPaths := make([][]string, len(paths))
+	for i, path := range paths {
+		splitPaths[i] = strings.Split(filepath.Clean(path), string(filepath.Separator))
+	}
+
+	// Find minimal unique representations
+	result := make([]string, len(paths))
+	for i, components := range splitPaths {
+		diffIndexes := []int{}
+
+		// Compare with all other paths
+		for j, otherComponents := range splitPaths {
+			if i == j {
+				continue
+			}
+
+			// Find different components
+			minLen := len(components)
+			if len(otherComponents) < minLen {
+				minLen = len(otherComponents)
+			}
+
+			for k := 0; k < minLen; k++ {
+				if components[k] != otherComponents[k] {
+					found := false
+					for _, idx := range diffIndexes {
+						if idx == k {
+							found = true
+							break
+						}
+					}
+					if !found {
+						diffIndexes = append(diffIndexes, k)
+					}
+				}
+			}
+		}
+
+		// Create minimal representation
+		if len(diffIndexes) == 0 {
+			result[i] = components[len(components)-1]
+		} else if len(diffIndexes) == 1 {
+			result[i] = components[diffIndexes[0]]
+		} else {
+			// Multiple differences - use ellipsis
+			first := components[diffIndexes[0]]
+			last := components[diffIndexes[len(diffIndexes)-1]]
+			result[i] = first + "..." + last
+		}
+	}
+
+	return result
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GoMLX changelog
 
-# Next
+# Next: MultiHeadAttention implementation slightly changed!
 
 * Package `simplego`:
   * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
@@ -12,6 +12,10 @@
 * Package `ml/trainer`
   * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
   * Added `Trainer.WithMaxExecutors`.
+* Package `ml/layers`
+  * Added normalizing 1/sqrt(d_k) factor to attention logits in the MultiHeadAttention layer: this will break current
+    models using it.
+  * Added `RMSNorm` normalizer.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Package `graph`
   * Added gradients of `Cos` and `Sin` that were missing.
 * Package `ml/trainer`
-  * Fixed evaluation (context reuse) for when using accumulated gradients.
+  * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
   * Added `Trainer.WithMaxExecutors`.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Package `simplego`:
   * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
+* Package `ui/commandline`:
+  * Added optional extra arbitrary metrics to print in the command-line with `AttachProgressBar`.
+  * Added `FormatDuration` to pretty-print duration.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@
   * Added normalizing 1/sqrt(d_k) factor to attention logits in the MultiHeadAttention layer: this will break current
     models using it.
   * Added `RMSNorm` normalizer.
+* `gomlx_checkpoints` command-line tool:
+  * Added support for multiple models to allow comparing models.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GoMLX changelog
 
+# Next
+
+* Package `simplego`:
+  * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
+
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 
 * Package `train`:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Package `ui/commandline`:
   * Added optional extra arbitrary metrics to print in the command-line with `AttachProgressBar`.
   * Added `FormatDuration` to pretty-print duration.
+* Package `graph`
+  * Added gradients of `Cos` and `Sin` that were missing.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
   * Added `FormatDuration` to pretty-print duration.
 * Package `graph`
   * Added gradients of `Cos` and `Sin` that were missing.
+* Package `ml/trainer`
+  * Fixed evaluation (context reuse) for when using accumulated gradients.
+  * Added `Trainer.WithMaxExecutors`.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/graph/rev_autodiff.go
+++ b/graph/rev_autodiff.go
@@ -192,7 +192,7 @@ func Gradient(output *Node, gradientNodes ...*Node) []*Node {
 			var ok bool
 			vjpFn, ok = VJPRegistration[node.Type()]
 			if !ok {
-				Panicf("graph has node %s, for which no gradient is defined yet, cannot generate graph gradient", node)
+				Panicf("graph has node %s with type %q, for which no gradient is defined yet, cannot generate graph gradient", node, node.Type())
 			}
 		}
 
@@ -367,6 +367,8 @@ var VJPRegistration = map[NodeType]VJP{
 	NodeTypeExp:                  vjpForSingleOutput(expVJP),
 	NodeTypeLog:                  vjpForSingleOutput(logVJP),
 	NodeTypeLog1p:                vjpForSingleOutput(log1pVJP),
+	NodeTypeCos:                  vjpForSingleOutput(cosVJP),
+	NodeTypeSin:                  vjpForSingleOutput(sinVJP),
 	NodeTypeTanh:                 vjpForSingleOutput(tanhVJP),
 	NodeTypeAdd:                  vjpForSingleOutput(addVJP),
 	NodeTypeSub:                  vjpForSingleOutput(subVJP),
@@ -524,6 +526,16 @@ func logVJP(node, v *Node, _ shapes.Shape) []*Node {
 func log1pVJP(node, v *Node, _ shapes.Shape) []*Node {
 	one := ScalarOne(node.Graph(), node.inputNodes[0].DType())
 	return []*Node{Mul(v, Inverse(Add(one, node.inputNodes[0])))}
+}
+
+func sinVJP(node, v *Node, _ shapes.Shape) []*Node {
+	x := node.inputNodes[0]
+	return []*Node{Mul(v, Cos(x))}
+}
+
+func cosVJP(node, v *Node, _ shapes.Shape) []*Node {
+	x := node.inputNodes[0]
+	return []*Node{Mul(v, Neg(Sin(x)))}
 }
 
 func tanhVJP(node, v *Node, _ shapes.Shape) []*Node {

--- a/ml/layers/rmsnorm.go
+++ b/ml/layers/rmsnorm.go
@@ -1,0 +1,100 @@
+package layers
+
+import (
+	"slices"
+	"sort"
+
+	. "github.com/gomlx/gomlx/graph"
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/gomlx/gomlx/ml/context/initializers"
+	"github.com/gomlx/gomlx/types/shapes"
+	"github.com/gomlx/gomlx/types/xslices"
+)
+
+// RMSNormBuilder holds the configuration for RMSNorm.
+// Once finished configuring, call RMSNormBuilder.Done()
+type RMSNormBuilder struct {
+	ctx               *context.Context
+	operand           *Node
+	useScale          bool
+	normalizationAxes []int
+	epsilon           float64
+}
+
+// RMSNorm starts the configuration of an RMS normalization operation,
+// as described in https://arxiv.org/abs/1910.07467.
+//
+// It normalizes the input with a simple:
+//
+//		RMS(a) = Sqrt(1/n * \sum{a_i^2})
+//	 RMSNorm(a) = a_i / RMS(a) * g_i
+//
+// Where g_i is a learnable gain (scale), enabled by default.
+//
+// Call RMSNormBuilder.Done when you finished the configuration.
+func RMSNorm(ctx *context.Context, operand *Node) *RMSNormBuilder {
+	return &RMSNormBuilder{
+		ctx:               ctx,
+		operand:           operand,
+		useScale:          true,
+		normalizationAxes: []int{-1},
+		epsilon:           1e-6,
+	}
+}
+
+// WithScale sets whether to use the gain parameter in the RMSNorm configuration and returns the updated builder.
+func (rms *RMSNormBuilder) WithScale(useScale bool) *RMSNormBuilder {
+	rms.useScale = useScale
+	return rms
+}
+
+// WithEpsilon sets the epsilon value used in RMSNorm configuration and returns the updated builder.
+// The default value is 1e-6.
+func (rms *RMSNormBuilder) WithEpsilon(epsilon float64) *RMSNormBuilder {
+	rms.epsilon = epsilon
+	return rms
+}
+
+// WithNormalizationAxes sets the axes over which to normalize in the RMSNorm configuration and returns the updated builder.
+// The default value is -1 (the last axis).
+func (rms *RMSNormBuilder) WithNormalizationAxes(axes ...int) *RMSNormBuilder {
+	rms.normalizationAxes = axes
+	return rms
+}
+
+// Done uses the current configuration to perform RMSNorm.
+// It returns the normalized operand.
+func (rms *RMSNormBuilder) Done() *Node {
+	ctx := rms.ctx.In("rms_norm")
+	x := rms.operand
+	g := x.Graph()
+	shape := x.Shape()
+	rank := x.Rank()
+	dtype := x.DType()
+
+	x2 := Square(x)
+	rmsX := ReduceAndKeep(x2, ReduceMean, rms.normalizationAxes...)
+	if rms.epsilon != 0 {
+		rmsX = AddScalar(rmsX, rms.epsilon)
+	}
+	rmsX = Sqrt(rmsX)
+	x = Div(x, rmsX)
+	if rms.useScale {
+		// Create scale variable: shaped with the dimensions of the sorted normalized axes.
+		normAxes := xslices.Map(rms.normalizationAxes, func(axis int) int { return AdjustAxisToOperandRank(x, axis) })
+		sort.Ints(normAxes)
+		dims := xslices.Map(normAxes, func(axis int) int { return shape.Dim(axis) })
+		scaleShape := shapes.Make(dtype, dims...)
+		scaleVar := ctx.WithInitializer(initializers.One).VariableWithShape("scale", scaleShape)
+		scale := scaleVar.ValueGraph(g)
+
+		// Apply scale variable: broadcast to all axes not in normAxes.
+		scaleToXShape := slices.Repeat([]int{1}, rank)
+		for _, axis := range normAxes {
+			scaleToXShape[axis] = shape.Dimensions[axis]
+		}
+		scale = Reshape(scale, scaleToXShape...)
+		x = Mul(x, scale)
+	}
+	return x
+}

--- a/ml/layers/rmsnorm_test.go
+++ b/ml/layers/rmsnorm_test.go
@@ -1,0 +1,40 @@
+package layers
+
+import (
+	"fmt"
+
+	. "github.com/gomlx/gomlx/graph"
+	"github.com/gomlx/gomlx/graph/graphtest"
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/stretchr/testify/require"
+
+	"testing"
+)
+
+func TestRMSNorm(t *testing.T) {
+	backend := graphtest.BuildTestBackend()
+	ctx := context.New()
+	exec := context.NewExec(backend, ctx, func(ctx *context.Context, x *Node) *Node {
+		return RMSNorm(ctx, x).
+			WithNormalizationAxes(-1, -2).
+			Done()
+	})
+
+	x := [][][]float32{
+		{{3, 4}, {5, 6}, {7, 8}},
+		{{3 * 2, 4 * 2}, {5 * 2, 6 * 2}, {7 * 2, 8 * 2}},
+	}
+	got := exec.Call(x)[0]
+	require.NoError(t, got.Shape().CheckDims(2, 3, 2), "shape should not have changed")
+	want := [][][]float32{{
+		{0.52091914, 0.6945589}, {0.86819863, 1.0418383}, {1.2154781, 1.3891178},
+	}, {
+		{0.52091914, 0.6945589}, {0.86819863, 1.0418383}, {1.2154781, 1.3891178},
+	}}
+	fmt.Printf("RMS(%v) = %s\n", x, got.GoStr())
+	require.Equal(t, want, got.Value())
+
+	scaleVar := ctx.GetVariableByScopeAndName("/rms_norm", "scale")
+	require.NotNil(t, scaleVar)
+	require.NoError(t, scaleVar.Shape().CheckDims(3, 2))
+}

--- a/ml/train/accgradients.go
+++ b/ml/train/accgradients.go
@@ -25,6 +25,9 @@ type OptimizeWithGradients interface {
 
 // AccumulateGradients configures the trainer to accumulate numAccumulatingSteps of gradients before actually applying them.
 // globalStep will only be updated after numAccumulatingSteps are fed with Trainer.TrainStep.
+//
+// Notice that setting this makes the concept of "TrainStep" and "GlobalStep" diverge: there will now be numAccumulatingSteps "train steps"
+// per "global step".
 func (r *Trainer) AccumulateGradients(numAccumulatingSteps int) error {
 	if r.optimizer == nil {
 		return errors.New("optimizer is nil!?")
@@ -36,6 +39,12 @@ func (r *Trainer) AccumulateGradients(numAccumulatingSteps int) error {
 	r.accumulateGradientsSteps = numAccumulatingSteps
 	r.accumulateGradientsCurrentStep = 0
 	return nil
+}
+
+// NumAccumulatingSteps return the number of accumulating steps, if AccumulateGradients is being used.
+// Otherwise, it returns 0.
+func (r *Trainer) NumAccumulatingSteps() int {
+	return r.accumulateGradientsSteps
 }
 
 // iterTrainableAndAccumulatorVariables iterates over all the trainable variables (in the current graph g) and yields

--- a/ml/train/trainer.go
+++ b/ml/train/trainer.go
@@ -123,7 +123,10 @@ type LossFn = losses.LossFn
 
 // DefaultMaxExecutors used for Trainer objects. Each different `spec` value from a Dataset triggers
 // the creation of a new executor.
-var DefaultMaxExecutors = 20
+//
+// If using AccumulateGradients, there will be 2 graphs per shape of input data: one to accumulate the gradients
+// and another to accumulate and apply the gradients.
+var DefaultMaxExecutors = 50
 
 // GraphType can be TrainGraph or EvalGraph, when there needs to be a distinction.
 type GraphType int
@@ -135,13 +138,13 @@ const (
 )
 
 // NewTrainer constructs a trainer that can be used for training steps and evaluation. It also creates a new Context
-// for model, which will hold the variables, hyperparameters and other information. It can be changed by the user.
+// for model, which will hold the variables, hyperparameters, and other information. It can be changed by the user.
 //
 // Its arguments are:
 //
 //   - backend needed to create and compile computation graphs.
 //
-//   - ctx (will) hold the variables, hyperparameters and related information for the model.
+//   - ctx (will) hold the variables, hyperparameters, and related information for the model.
 //
 //   - modelFn builds the graph that transforms inputs into predictions (or logits).
 //
@@ -284,6 +287,18 @@ func (r *Trainer) SetContext(ctx *context.Context) *Trainer {
 	return r
 }
 
+// WithMaxExecutors configure the Trainer to allow these many different executors to be created before failing.
+//
+// One executor is created per each different shape of input, times one for training, and one for evaluation (if
+// Trainer.Eval is being used).
+// The default is DefaultMaxExecutors.
+//
+// It returns the Trainer itself.
+func (r *Trainer) WithMaxExecutors(maxExecutors int) *Trainer {
+	r.maxExecutors = maxExecutors
+	return r
+}
+
 // TrainMetrics returns the train metrics objects (not the actual values just the objects
 // that implement them).
 func (r *Trainer) TrainMetrics() []metrics.Interface { return r.trainMetrics }
@@ -296,13 +311,15 @@ func (r *Trainer) EvalMetrics() []metrics.Interface { return r.evalMetrics }
 // any reason, including exceeding maxExecutors.
 func (r *Trainer) createExecutor(spec any, inputsLen, labelsLen int,
 	graphFn func(spec any, ctx *context.Context, inputs, labels []*graph.Node) (metrics []*graph.Node)) *context.Exec {
-	numExecs := len(r.trainStepExecMap) + len(r.evalStepExecMap)
+	numExecs := len(r.trainStepExecMap) + len(r.evalStepExecMap) +
+		len(r.accumulateGradientsExecMap) + len(r.accumulateGradientsAndApplyExecMap) +
+		len(r.batchNormStepExecMap)
 	if numExecs > r.maxExecutors {
 		Panicf("Max number of executors reached: one is created for each "+
 			"different value of `spec` returned by Dataset, triggering a different JIT-compiled "+
 			"computation graph. Probably you want to limit the number of different datasets configuration "+
-			"(spec) supported, or increase train.DefaultMaxExecutor if this is what you want. Value of spec "+
-			"passed at this iteration: %+v", spec)
+			"(spec) or shapes supported, or increase the allowed number of executors (see Train.WithMaxExecutors) "+
+			" if this is what you want. Value of spec passed at this iteration: %+v", spec)
 	}
 	if numExecs > 0 {
 		r.context = r.context.Checked(false) // Only check for duplicate variables at the first graph creation.

--- a/ml/train/trainer.go
+++ b/ml/train/trainer.go
@@ -592,6 +592,11 @@ func (r *Trainer) Metrics() []metrics.Interface {
 	return r.evalMetrics
 }
 
+// GlobalStep is an alias for optimizers.GetGlobalStep using Trainer.Context().
+func (r *Trainer) GlobalStep() int64 {
+	return optimizers.GetGlobalStep(r.context)
+}
+
 // OnExecFn is a handler that can be called when executors are created.
 // See Train.OnExecCreation.
 type OnExecFn func(exec *context.Exec, graphType GraphType)

--- a/ui/commandline/duration.go
+++ b/ui/commandline/duration.go
@@ -1,0 +1,23 @@
+package commandline
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// FormatDuration pretty prints duration without a long list of decimal points.
+func FormatDuration(d time.Duration) string {
+	s := d.String()
+	re := regexp.MustCompile(`(\d+\.?\d*)([µa-z]+)`)
+	matches := re.FindStringSubmatch(s)
+	if len(matches) != 3 {
+		return s
+	}
+	num, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return s
+	}
+	return fmt.Sprintf("%.2f%s", num, matches[2])
+}

--- a/ui/plots/plots.go
+++ b/ui/plots/plots.go
@@ -4,6 +4,13 @@ package plots
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
+	"os"
+	"path"
+	"slices"
+	"sort"
+
 	"github.com/charmbracelet/lipgloss"
 	lgtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/gomlx/exceptions"
@@ -16,13 +23,7 @@ import (
 	"github.com/gomlx/gomlx/types/xslices"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
-	"io"
 	"k8s.io/klog/v2"
-	"math"
-	"os"
-	"path"
-	"slices"
-	"sort"
 )
 
 // TrainingPlotFileName is the default file name within a checkpoint directory to store
@@ -85,7 +86,7 @@ func AddTrainAndEvalMetrics(plotter Plotter, loop *train.Loop, trainMetrics []*t
 	}
 
 	// Training metrics are pre-generated and given.
-	step := float64(loop.LoopStep)
+	step := float64(loop.Trainer.GlobalStep())
 	var incomplete bool
 	for ii, desc := range loop.Trainer.TrainMetrics() {
 		if desc.Name() == "Batch Loss" {


### PR DESCRIPTION
* Package `simplego`:
  * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
* Package `ui/commandline`:
  * Added optional extra arbitrary metrics to print in the command-line with `AttachProgressBar`.
  * Added `FormatDuration` to pretty-print duration.
* Package `graph`
  * Added gradients of `Cos` and `Sin` that were missing.
* Package `ml/trainer`
  * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
  * Added `Trainer.WithMaxExecutors`.
* Package `ml/layers`
  * Added normalizing 1/sqrt(d_k) factor to attention logits in the MultiHeadAttention layer: this will break current
    models using it.
  * Added `RMSNorm` normalizer.
* `gomlx_checkpoints` command-line tool:
  * Added support for multiple models to allow comparing models.

