### PR TITLE
v0.21.0: 2025/07/01 🌞 Summer Edition 🌞

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,12 +20,10 @@
 * Package `ml/trainer`
   * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
   * Added `Trainer.WithMaxExecutors`.
-* Package `ml/train/metrics`:
+* Package `ml/trainer/metrics`:
   * `MeanMetric` allows for disabling dynamic batch weighting.  API slightly changed: `NewMeanMetric` now
     returns a `MeanMetric` struct, not an interface.
   * Added `StreamingMedianMetric`.
-* Package `ml/train/optimizers`:
-  * Added `RMSProp` optimizer.
 * Package `ml/layers`
   * Added normalizing 1/sqrt(d_k) factor to attention logits in the MultiHeadAttention layer: this will break current
     models using it.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,10 @@
      from being assigned to the functions.
   * Added parameters `sorted` and `unique` to `Scatter` (like the other functions `Scatter*`) -- **Small API change**.
   * Added `ScatterUpdate`, for now only for `unique=true`.
+  * Package `nanlogger`:
+    * Allow traces that only report also.
+    * Created context parameter `optimizer.ParamNanLogger`: if set to NanLogger, it will trace all occurrences of
+      of NaN values in gradient: great to debug where are the NaN appearing in the model first.
 * Package `ml/trainer`
   * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
   * Added `Trainer.WithMaxExecutors`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,6 @@
 # GoMLX changelog
 
-# Next: MultiHeadAttention implementation slightly changed!
-
-Hightlights:  Added RMSProp optimizers; Added RMSNorm normalizer; Default variable initializer set to He.
+# v0.21.0: 2025/07/01 🌞 Summer Edition 🌞
 
 * Package `simplego`:
   * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
@@ -41,6 +39,7 @@ Hightlights:  Added RMSProp optimizers; Added RMSNorm normalizer; Default variab
   * Package `initializers`:
     * They now use the `context` random number generator state, which simplifies things. 
     * `ParamInitialSeed` removed, since the RNG is initialized by `Context.RngStateWithSeed()`.
+* Fixed some flaky tests.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,9 +35,12 @@ Hightlights:  Added RMSProp optimizers; Added RMSNorm normalizer; Default variab
 * `gomlx_checkpoints` command-line tool:
   * Added support for multiple models to allow comparing models.
   * Fixed the printing of metrics with tiny values.
-* Package `context`
+* Package `context`:
   * Allow VariableInitializers to use the `context.Context` itself, with its own random initializer.
   * `DefaultInitializer` now creates an initializer. The new default uses He initializer, the same used in PyTorch.
+  * Package `initializers`:
+    * They now use the `context` random number generator state, which simplifies things. 
+    * `ParamInitialSeed` removed, since the RNG is initialized by `Context.RngStateWithSeed()`.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # GoMLX changelog
 
-# Next: MultiHeadAttention implementation slightly changed! Added RMSProp optimizers; Added RMSNorm normalizer.
+# Next: MultiHeadAttention implementation slightly changed!
+
+Hightlights:  Added RMSProp optimizers; Added RMSNorm normalizer; Default variable initializer set to He.
 
 * Package `simplego`:
   * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
@@ -33,6 +35,9 @@
 * `gomlx_checkpoints` command-line tool:
   * Added support for multiple models to allow comparing models.
   * Fixed the printing of metrics with tiny values.
+* Package `context`
+  * Allow VariableInitializers to use the `context.Context` itself, with its own random initializer.
+  * `DefaultInitializer` now creates an initializer. The new default uses He initializer, the same used in PyTorch.
 
 # v0.20.1: 2025/06/12 Trainer.AccumulateGradients (when the batch doesn't fit memory); VNN fixes; Numpy improvements. 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GoMLX changelog
 
-# Next: MultiHeadAttention implementation slightly changed!
+# Next: MultiHeadAttention implementation slightly changed! Added RMSProp optimizers; Added RMSNorm normalizer.
 
 * Package `simplego`:
   * Added `GetBackend` that returns a singleton backend, created with the default configuration at the first request.
@@ -17,13 +17,15 @@
     * Allow traces that only report also.
     * Created context parameter `optimizer.ParamNanLogger`: if set to NanLogger, it will trace all occurrences of
       of NaN values in gradient: great to debug where are the NaN appearing in the model first.
-* Package `ml/trainer`
+* Package `ml/train`:
   * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
   * Added `Trainer.WithMaxExecutors`.
-* Package `ml/trainer/metrics`:
+* Package `ml/train/metrics`:
   * `MeanMetric` allows for disabling dynamic batch weighting.  API slightly changed: `NewMeanMetric` now
     returns a `MeanMetric` struct, not an interface.
   * Added `StreamingMedianMetric`.
+* Package `ml/train/optimizers`:
+  * Added `RMSProp()` optimizer.
 * Package `ml/layers`
   * Added normalizing 1/sqrt(d_k) factor to attention logits in the MultiHeadAttention layer: this will break current
     models using it.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,10 +20,12 @@
 * Package `ml/trainer`
   * Improved support for accumulated gradients. Fixed evaluation (context reuse) for when using accumulated gradients.
   * Added `Trainer.WithMaxExecutors`.
-* Package `ml/trainer/metrics`:
+* Package `ml/train/metrics`:
   * `MeanMetric` allows for disabling dynamic batch weighting.  API slightly changed: `NewMeanMetric` now
     returns a `MeanMetric` struct, not an interface.
   * Added `StreamingMedianMetric`.
+* Package `ml/train/optimizers`:
+  * Added `RMSProp` optimizer.
 * Package `ml/layers`
   * Added normalizing 1/sqrt(d_k) factor to attention logits in the MultiHeadAttention layer: this will break current
     models using it.

--- a/examples/FlowMatching/train.go
+++ b/examples/FlowMatching/train.go
@@ -213,14 +213,14 @@ func BuildTrainingModelGraph(config *diffusion.Config) train.ModelFn {
 		images = diffusion.AugmentImages(ctx, images)
 
 		// Convert to the corresponding image size.
-		config.NanLogger.Trace(images, "RawImages")
+		config.NanLogger.TraceFirstNaN(images, "RawImages")
 		images = config.PreprocessImages(images, true)
-		config.NanLogger.Trace(images, "NormalizedImages")
+		config.NanLogger.TraceFirstNaN(images, "NormalizedImages")
 		images = ConvertDType(images, dtype)
 
 		// Gaussian noise to be transposed to the images.
 		noises := ctx.RandomNormal(g, images.Shape())
-		config.NanLogger.Trace(noises, "noises")
+		config.NanLogger.TraceFirstNaN(noises, "noises")
 
 		// Cosine schedule, if enabled.
 		cosineschedule.New(ctx, g, dtype).FromContext().Done()
@@ -238,13 +238,13 @@ func BuildTrainingModelGraph(config *diffusion.Config) train.ModelFn {
 		noisyImages := Add(
 			Mul(images, t),
 			Mul(noises, OneMinus(t)))
-		config.NanLogger.Trace(noisyImages, "noisyImages (A)")
+		config.NanLogger.TraceFirstNaN(noisyImages, "noisyImages (A)")
 		noisyImages = StopGradient(noisyImages)
 
 		// Target and predicted velocity (aka. u(X,t)).
 		targetVelocity := Sub(images, noises)
 		predictedVelocity := diffusion.UNetModelGraph(ctx, config.NanLogger, noisyImages, t, flowerIds)
-		config.NanLogger.Trace(predictedVelocity, "predictedVelocity")
+		config.NanLogger.TraceFirstNaN(predictedVelocity, "predictedVelocity")
 
 		// Calculate our loss inside the model: use losses.ParamLoss to define the loss, and if not set,
 		// back-off to "diffusion_loss" hyperparam (for backward compatibility).

--- a/examples/ogbnmag/gnn/gnn.go
+++ b/examples/ogbnmag/gnn/gnn.go
@@ -277,7 +277,7 @@ func edgeMessageGraph(ctx *context.Context, gatheredStates, gatheredMask *Node) 
 		messages = activations.ApplyFromContext(ctx, messages)
 	}
 	if NanLogger != nil {
-		NanLogger.Trace(messages, fmt.Sprintf("(KAN)edgeMessageGraph(%s)", ctx.Scope()))
+		NanLogger.TraceFirstNaN(messages, fmt.Sprintf("(KAN)edgeMessageGraph(%s)", ctx.Scope()))
 	}
 
 	mask = gatheredMask
@@ -486,7 +486,7 @@ func updateState(ctx *context.Context, prevState, input, mask *Node) *Node {
 	}
 	state = layers.MaskedNormalizeFromContext(ctx.In("normalization"), state, mask)
 	if NanLogger != nil {
-		NanLogger.Trace(state, fmt.Sprintf("UpdateState(%s)", ctx.Scope()))
+		NanLogger.TraceFirstNaN(state, fmt.Sprintf("UpdateState(%s)", ctx.Scope()))
 	}
 	return state
 }
@@ -546,7 +546,7 @@ func kanUpdateState(ctx *context.Context, prevState, input, mask *Node) *Node {
 		state = Add(state, prevState)
 	}
 	if NanLogger != nil {
-		NanLogger.Trace(state, fmt.Sprintf("(KAN)UpdateState(%s)", ctx.Scope()))
+		NanLogger.TraceFirstNaN(state, fmt.Sprintf("(KAN)UpdateState(%s)", ctx.Scope()))
 	}
 	return state
 }

--- a/examples/oxfordflowers102/diffusion/data.go
+++ b/examples/oxfordflowers102/diffusion/data.go
@@ -152,7 +152,7 @@ func (c *Config) PreprocessImages(images *Node, normalize bool) *Node {
 
 	// ReduceAllMax(images).SetLogged("Max(uint8):")
 	images = ConvertDType(images, dtypes.Float32)
-	c.NanLogger.Trace(images, "PreprocessImages:input")
+	c.NanLogger.TraceFirstNaN(images, "PreprocessImages:input")
 	if !normalize {
 
 		return images
@@ -168,7 +168,7 @@ func (c *Config) PreprocessImages(images *Node, normalize bool) *Node {
 		Sub(images, mean),
 		data.ReplaceZerosByOnes(stddev))
 	images = ConvertDType(images, c.DType)
-	c.NanLogger.Trace(images, "PreprocessImages:"+c.DType.String())
+	c.NanLogger.TraceFirstNaN(images, "PreprocessImages:"+c.DType.String())
 	return images
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -91,6 +91,10 @@ package graph
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/gomlx/exceptions"
 	"github.com/gomlx/gomlx/backends"
 	"github.com/gomlx/gomlx/types"
@@ -100,9 +104,6 @@ import (
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
-	"strings"
-	"sync"
-	"time"
 )
 
 // Graph with the operations and dependencies needed to run a computation.

--- a/graph/nanlogger/nanlogger_test.go
+++ b/graph/nanlogger/nanlogger_test.go
@@ -17,11 +17,12 @@
 package nanlogger
 
 import (
+	"testing"
+
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/graph/graphtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	_ "github.com/gomlx/gomlx/backends/xla"
 )
@@ -37,16 +38,15 @@ func TestNanLogger(t *testing.T) {
 	}
 
 	// Create a NanLogger and a trivial executor that will trigger NaN and Inf.
-	l := New()
-	l.SetHandler(handler)
+	l := New().WithHandler(handler)
 	e := NewExec(backend, func(values *Node) *Node {
 		l.PushScope("scope1")
 		v1 := Sqrt(values)
-		l.Trace(v1)
+		l.TraceFirstNaN(v1)
 		l.PopScope()
 		l.PushScope("base")
 		v2 := Inverse(values)
-		l.Trace(v2, "scope2")
+		l.TraceFirstNaN(v2, "scope2")
 		l.PopScope()
 		return Add(v1, v2)
 	})

--- a/ml/context/context_test.go
+++ b/ml/context/context_test.go
@@ -19,6 +19,7 @@ package context_test
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/gomlx/gomlx/graph/graphtest"
@@ -167,7 +168,13 @@ func TestEnumerateVariables(t *testing.T) {
 
 	// Checks EnumerateVariables lists all variables:
 	got := types.MakeSet[string]()
-	setGotFn := func(v *Variable) { got.Insert(v.Name()) }
+	setGotFn := func(v *Variable) {
+		if strings.HasPrefix(v.Name(), "#") {
+			// Skip internal variables, like #rngstate.
+			return
+		}
+		got.Insert(v.Name())
+	}
 	ctx.EnumerateVariables(setGotFn)
 	assert.Equal(t, 3, len(got))
 	assert.True(t, got.Has("x") && got.Has("y") && got.Has("z"))
@@ -200,6 +207,10 @@ func TestIterVariables(t *testing.T) {
 	// Checks IterVariables lists all variables:
 	got := types.MakeSet[string]()
 	for v := range ctx.IterVariables() {
+		if strings.HasPrefix(v.Name(), "#") {
+			// Skip internal variables, like #rngstate.
+			continue
+		}
 		got.Insert(v.Name())
 	}
 	assert.Equal(t, 3, len(got))
@@ -208,6 +219,10 @@ func TestIterVariables(t *testing.T) {
 	// Checks IterVariables lists all variables, even if starting from a different scope:
 	got = types.MakeSet[string]()
 	for v := range ctx.IterVariables() {
+		if strings.HasPrefix(v.Name(), "#") {
+			// Skip internal variables, like #rngstate.
+			continue
+		}
 		got.Insert(v.Name())
 	}
 	assert.Equal(t, 3, len(got))
@@ -216,6 +231,10 @@ func TestIterVariables(t *testing.T) {
 	// Checks IterVariablesInScope:
 	got = types.MakeSet[string]()
 	for v := range ctx1.IterVariablesInScope() {
+		if strings.HasPrefix(v.Name(), "#") {
+			// Skip internal variables, like #rngstate.
+			continue
+		}
 		got.Insert(v.Name())
 	}
 	assert.Equal(t, 2, len(got))

--- a/ml/context/defaultinitializer.go
+++ b/ml/context/defaultinitializer.go
@@ -1,0 +1,74 @@
+package context
+
+import (
+	"math"
+
+	"github.com/gomlx/gomlx/graph"
+	"github.com/gomlx/gomlx/types/shapes"
+)
+
+// VariableInitializer builds a valueNode that returns a value to initialize a variable of the given
+// shape. It is defined in the Context.
+type VariableInitializer = func(g *graph.Graph, shape shapes.Shape) *Node
+
+// computeFanInFanOut of a variable expected to be the parameters of
+// either layers.Dense or layers.Convolution.
+//
+// Copied from initializers package to set the DefaultInitializer with a good value.
+func computeFanInFanOut(shape shapes.Shape) (fanIn, fanOut int) {
+	rank := shape.Rank()
+	switch rank {
+	case 0: // Scalar.
+		fanIn = 1
+		fanOut = fanIn
+	case 1: // 1D shape, like a bias term in a dense layer.
+		fanIn = 0
+		fanOut = fanIn
+	case 2: // 2D shape, weights of a dense layer.
+		fanIn = shape.Dimensions[0]
+		fanOut = shape.Dimensions[1]
+	default: // Assuming convolution kernels (2D, 3D, or more):
+		receptiveFieldSize := 1
+		for _, dim := range shape.Dimensions[:rank-2] {
+			receptiveFieldSize *= dim
+		}
+		fanIn = shape.Dimensions[rank-2] * receptiveFieldSize
+		fanOut = shape.Dimensions[rank-1] * receptiveFieldSize
+	}
+	return
+}
+
+// heInitializer returns the initializer that tries to preserve the variance of 1, calculated for the Relu activation functions.
+//
+// It initializes biases (anything with rank <= 1) to zeros.
+//
+// [1] https://medium.com/@tylernisonoff/weight-initialization-for-cnns-a-deep-dive-into-he-initialization-50b03f37f53d
+// [2] https://arxiv.org/pdf/1502.01852
+//
+// Copy from package initializers, used to populate the DefaultInitializer.
+//
+// It uses the context random state (as opposed to initializers.HeFn which uses initializers own RNG state).
+func heInitializer(ctx *Context) VariableInitializer {
+	return func(g *Graph, shape shapes.Shape) *Node {
+		if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
+			return graph.Zeros(g, shape)
+		}
+		if shape.Rank() <= 1 {
+			// Zero-bias.
+			return graph.Zeros(g, shape)
+		}
+		fanIn, _ := computeFanInFanOut(shape)
+		scale := max(1.0, float64(fanIn))
+		stddev := math.Sqrt(2.0 / scale)
+		values := ctx.RandomNormal(g, shape)
+		return graph.MulScalar(values, stddev)
+	}
+}
+
+// DefaultInitializer is used whenever a new context is created to create a new VariableInitializer.
+// You can always set your own initializer with Context.WithInitializer.
+//
+// See package initializers for various standard initializers.
+//
+// It defaults to a He initializer (https://arxiv.org/pdf/1502.01852)
+var DefaultInitializer func(ctx *Context) VariableInitializer = heInitializer

--- a/ml/context/initializers/initializers.go
+++ b/ml/context/initializers/initializers.go
@@ -19,15 +19,16 @@
 package initializers
 
 import (
+	"math"
+	"slices"
+	"sync"
+
 	. "github.com/gomlx/exceptions"
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/ml/context"
 	"github.com/gomlx/gomlx/types/shapes"
 	"github.com/gomlx/gomlx/types/tensors"
 	"github.com/gomlx/gopjrt/dtypes"
-	"math"
-	"slices"
-	"sync"
 )
 
 var (
@@ -73,7 +74,7 @@ func Finalize() {
 
 // UseRngState will provide a random-number generator state for the current graph, to be used for initialization.
 //
-// If all initializers of a model uses random from this, in a deterministic order, then the initialization
+// If all initializers of a model use random values from this, in a deterministic order, then the initialization
 // of the model will be deterministic and can be replicated exactly.
 //
 // The initialSeed is only used the first time the function is called for a Graph. If the initialSeed is 0,
@@ -201,8 +202,8 @@ func GlorotUniformFn(ctx *context.Context) VariableInitializer {
 	}
 }
 
-// computeFanInFanOut of a variable that is expected to be the parameters of
-// either a [layers.Dense] or [layers.Convolution].
+// computeFanInFanOut of a variable expected to be the parameters of
+// either layers.Dense or layers.Convolution.
 func computeFanInFanOut(shape shapes.Shape) (fanIn, fanOut int) {
 	rank := shape.Rank()
 	switch rank {

--- a/ml/context/initializers/initializers.go
+++ b/ml/context/initializers/initializers.go
@@ -14,14 +14,14 @@
  *	limitations under the License.
  */
 
-// Package initializers include several weight initializers, to be used with context.
-// They implement computation.VariableInitializer type.
+// Package initializers include several weight initializers, to be used with a context.Context.
+//
+// They construct computation.VariableInitializer closures.
 package initializers
 
 import (
 	"math"
 	"slices"
-	"sync"
 
 	. "github.com/gomlx/exceptions"
 	. "github.com/gomlx/gomlx/graph"
@@ -33,14 +33,11 @@ import (
 
 var (
 	// ParamInitialSeed is the key for the hyperparameter to use for initial seed (int64). The default is 0,
-	// which makes it non-deterministic. Set it to a value different from 0 for a deterministic (as long
-	// as the model doesn't change) initialization.
+	// which makes it non-deterministic. Set it to a value different from 0 for a deterministic initialization
+	// (as long as the model doesn't change).
 	//
-	// If you set this hyperparameter, remember to configure a new default initializer in your context (context.Context.WithInitializer),
-	// so that it is used.
-	//
-	// More details in initializers.UseRngState.
-	ParamInitialSeed = "initializers_seed"
+	// It is an alias to context.ParamInitialSeed.
+	ParamInitialSeed = context.ParamInitialSeed
 )
 
 // VariableInitializer builds a node that returns a value to initialize a variable of the given
@@ -57,59 +54,6 @@ func One(graph *Graph, shape shapes.Shape) *Node {
 	return Ones(graph, shape)
 }
 
-var (
-	muRngStates sync.Mutex
-	rngStates   = make(map[GraphId]*Node)
-)
-
-// Finalize will clear the global state kept alive and free up the memory.
-// Namely, the random number generator states.
-//
-// Used for testing and debugging.
-func Finalize() {
-	muRngStates.Lock()
-	defer muRngStates.Unlock()
-	rngStates = make(map[GraphId]*Node)
-}
-
-// UseRngState will provide a random-number generator state for the current graph, to be used for initialization.
-//
-// If all initializers of a model use random values from this, in a deterministic order, then the initialization
-// of the model will be deterministic and can be replicated exactly.
-//
-// The initialSeed is only used the first time the function is called for a Graph. If the initialSeed is 0,
-// a random seed is generated -- in which case initialization is not deterministic.
-// the returned updated state.
-//
-// See examples usage in RandomNormalFn and RandomUniformFn.
-//
-// It locks the state, so only one call to it will be happening at a time.
-func UseRngState(g *Graph, initialSeed int64, fn func(rngState *Node) (newRngState *Node)) {
-	g.AssertValid()
-	muRngStates.Lock()
-	defer muRngStates.Unlock()
-
-	graphId := g.GraphId()
-	rngState, found := rngStates[graphId]
-	if !found {
-		if initialSeed != NoSeed {
-			rngState = Const(g, RngStateFromSeed(initialSeed))
-		} else {
-			rngState = Const(g, RngState())
-		}
-	}
-	newRngState := fn(rngState)
-	if !rngState.Shape().Equal(newRngState.Shape()) {
-		Panicf("updated rngState for the random number generator has invalid shape: %s (should be %s)",
-			newRngState.Shape(), rngState.Shape())
-	}
-	rngStates[graphId] = newRngState
-}
-
-// NoSeed is the default seed value for ParamInitialSeed, and it means a seed is randomly generated -- which
-// also means initialization is not deterministic.
-const NoSeed = int64(0)
-
 // RandomNormalFn returns an initializer that generates random normal values with the given standard deviation
 // and mean set to 0.
 //
@@ -119,21 +63,16 @@ const NoSeed = int64(0)
 //
 // Non-float and non-complex variables are initialized with zero instead.
 func RandomNormalFn(ctx *context.Context, stddev float64) VariableInitializer {
-	initialSeed := context.GetParamOr(ctx, ParamInitialSeed, NoSeed)
 	return func(g *Graph, shape shapes.Shape) *Node {
 		if shape.DType != dtypes.Float32 && shape.DType != dtypes.Float64 {
 			return Zeros(g, shape)
 		}
-		var values *Node
-		UseRngState(g, initialSeed, func(rngState *Node) (newRngState *Node) {
-			newRngState, values = RandomNormal(rngState, shape)
-			return newRngState
-		})
+		values := ctx.RandomNormal(g, shape)
 		return MulScalar(values, stddev)
 	}
 }
 
-// RandomUniformFn return an initializer that generates a random uniform values from [min, max).
+// RandomUniformFn return an initializer that generates random uniform values from [min, max).
 //
 // It uses the context's ParamInitialSeed hyperparameter to initialize the random number generator --
 // only the first time it is used for a graph.
@@ -141,16 +80,11 @@ func RandomNormalFn(ctx *context.Context, stddev float64) VariableInitializer {
 //
 // Non-float and non-complex variables are initialized with zero instead.
 func RandomUniformFn(ctx *context.Context, min, max float64) VariableInitializer {
-	initialSeed := context.GetParamOr(ctx, ParamInitialSeed, NoSeed)
 	return func(g *Graph, shape shapes.Shape) *Node {
 		if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
 			return Zeros(g, shape)
 		}
-		var values *Node
-		UseRngState(g, initialSeed, func(rngState *Node) (newRngState *Node) {
-			newRngState, values = RandomUniform(rngState, shape)
-			return newRngState
-		})
+		values := ctx.RandomUniform(g, shape)
 		values = MulScalar(values, max-min)
 		values = AddScalar(values, min)
 		return values
@@ -179,7 +113,6 @@ func RandomUniformFn(ctx *context.Context, min, max float64) VariableInitializer
 //
 // Non-float and non-complex variables are initialized with zero instead.
 func GlorotUniformFn(ctx *context.Context) VariableInitializer {
-	initialSeed := context.GetParamOr(ctx, ParamInitialSeed, NoSeed)
 	return func(g *Graph, shape shapes.Shape) *Node {
 		if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
 			return Zeros(g, shape)
@@ -191,11 +124,7 @@ func GlorotUniformFn(ctx *context.Context) VariableInitializer {
 		fanIn, fanOut := computeFanInFanOut(shape)
 		scale := max(1.0, float64(fanIn+fanOut)/2.0)
 		limit := math.Sqrt(3.0 / scale)
-		var values *Node
-		UseRngState(g, initialSeed, func(rngState *Node) (newRngState *Node) {
-			newRngState, values = RandomUniform(rngState, shape)
-			return newRngState
-		})
+		values := ctx.RandomUniform(g, shape)
 		values = MulScalar(values, 2*limit)
 		values = AddScalar(values, -limit)
 		return values
@@ -227,7 +156,7 @@ func computeFanInFanOut(shape shapes.Shape) (fanIn, fanOut int) {
 	return
 }
 
-// XavierUniformFn returns an initializer that generates random values with an uniform distribution with a range
+// XavierUniformFn returns an initializer that generates random values with a uniform distribution with a range
 // defined by +/- sqrt(6 / (fanIn+fanOut)). See description in https://paperswithcode.com/method/xavier-initialization
 //
 // It uses the context's ParamInitialSeed hyperparameter to initialize the random number generator --
@@ -238,7 +167,6 @@ func computeFanInFanOut(shape shapes.Shape) (fanIn, fanOut int) {
 //
 // Non-float and non-complex variables are initialized with zero instead.
 func XavierUniformFn(ctx *context.Context) VariableInitializer {
-	initialSeed := context.GetParamOr(ctx, ParamInitialSeed, NoSeed)
 	return func(g *Graph, shape shapes.Shape) *Node {
 		if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
 			return Zeros(g, shape)
@@ -250,11 +178,7 @@ func XavierUniformFn(ctx *context.Context) VariableInitializer {
 		fanIn, fanOut := computeFanInFanOut(shape)
 		scale := max(1.0, float64(fanIn+fanOut))
 		limit := math.Sqrt(6.0 / scale)
-		var values *Node
-		UseRngState(g, initialSeed, func(rngState *Node) (newRngState *Node) {
-			newRngState, values = RandomUniform(rngState, shape)
-			return newRngState
-		})
+		values := ctx.RandomUniform(g, shape)
 		values = MulScalar(values, 2*limit)
 		values = AddScalar(values, -limit)
 		return values
@@ -272,7 +196,6 @@ func XavierUniformFn(ctx *context.Context) VariableInitializer {
 //
 // Non-float and non-complex variables are initialized with zero instead.
 func XavierNormalFn(ctx *context.Context) VariableInitializer {
-	initialSeed := context.GetParamOr(ctx, ParamInitialSeed, NoSeed)
 	return func(g *Graph, shape shapes.Shape) *Node {
 		if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
 			return Zeros(g, shape)
@@ -284,11 +207,7 @@ func XavierNormalFn(ctx *context.Context) VariableInitializer {
 		fanIn, fanOut := computeFanInFanOut(shape)
 		scale := max(1.0, float64(fanIn+fanOut))
 		stddev := math.Sqrt(2.0 / scale)
-		var values *Node
-		UseRngState(g, initialSeed, func(rngState *Node) (newRngState *Node) {
-			newRngState, values = RandomNormal(rngState, shape)
-			return newRngState
-		})
+		values := ctx.RandomNormal(g, shape)
 		return MulScalar(values, stddev)
 	}
 }
@@ -304,7 +223,6 @@ func XavierNormalFn(ctx *context.Context) VariableInitializer {
 // [1] https://medium.com/@tylernisonoff/weight-initialization-for-cnns-a-deep-dive-into-he-initialization-50b03f37f53d
 // [2] https://arxiv.org/pdf/1502.01852
 func HeFn(ctx *context.Context) VariableInitializer {
-	initialSeed := context.GetParamOr(ctx, ParamInitialSeed, NoSeed)
 	return func(g *Graph, shape shapes.Shape) *Node {
 		if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
 			return Zeros(g, shape)
@@ -316,20 +234,16 @@ func HeFn(ctx *context.Context) VariableInitializer {
 		fanIn, _ := computeFanInFanOut(shape)
 		scale := max(1.0, float64(fanIn))
 		stddev := math.Sqrt(2.0 / scale)
-		var values *Node
-		UseRngState(g, initialSeed, func(rngState *Node) (newRngState *Node) {
-			newRngState, values = RandomNormal(rngState, shape)
-			return newRngState
-		})
+		values := ctx.RandomNormal(g, shape)
 		return MulScalar(values, stddev)
 	}
 }
 
-// BroadcastTensorToShape is an initializer that takes a constant tensor as baseValue and during initialization
+// BroadcastTensorToShape is an initializer that takes a constant tensor as baseValue, and during initialization
 // it broadcast it to the requested variable shape.
 //
-// The broadcasting happens only on the prefix dimensions (using graph.BroadcastPrefix), so the shape of the
-// baseValue tensor mush match the last dimensions of the variables shape.
+// The broadcasting happens only on the prefix dimensions (using graph.BroadcastPrefix), so the
+// baseValue tensor's shape must match the last dimensions of the variable's shape.
 //
 // The baseValue can have a different dtype, in which case it is converted (using graph.ConvertDType) to the
 // requested variable dtype.

--- a/ml/context/variable.go
+++ b/ml/context/variable.go
@@ -18,12 +18,13 @@ package context
 
 import (
 	"fmt"
+	"strings"
+
 	. "github.com/gomlx/exceptions"
 	"github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/types/shapes"
 	"github.com/gomlx/gomlx/types/tensors"
 	"github.com/gomlx/gomlx/types/xsync"
-	"strings"
 )
 
 // Variable is a value shared among computation graphs, or across multiple executions of the same graph.
@@ -75,29 +76,6 @@ func (v *Variable) CloneToContext(toCtx *Context) *Variable {
 	}
 	toCtx.InAbsPath(v.scope).setVariableInScope(v.name, newV)
 	return newV
-}
-
-// VariableInitializer builds a valueNode that returns a value to initialize a variable of the given
-// shape. It is defined in the Context.
-type VariableInitializer = func(g *graph.Graph, shape shapes.Shape) *Node
-
-// DefaultInitializer is used whenever a new context is created.
-// You can always set your own initializer with Context.WithInitializer.
-//
-// See package initializers for various standard initializers.
-//
-// It's a uniform random sampler [-0.05 to 0.05] for float and complex numbers, zero otherwise.
-var DefaultInitializer VariableInitializer = func(g *Graph, shape shapes.Shape) *Node {
-	if !shape.DType.IsFloat() && !shape.DType.IsComplex() {
-		return graph.Zeros(g, shape)
-	}
-	rngState := graph.Const(g, graph.RngState())
-	_, uniform := graph.RandomUniform(rngState, shape)
-	minValue, maxValue := -0.05, 0.05
-	values := graph.MulScalar(uniform, maxValue-minValue)
-	values = graph.AddScalar(values, minValue)
-	return values
-
 }
 
 // variableNodes is used to store the variable parameter node (fed to the graph) and current value Node for a given graph.

--- a/ml/layers/fnn/fnn_test.go
+++ b/ml/layers/fnn/fnn_test.go
@@ -2,6 +2,9 @@ package fnn
 
 import (
 	"fmt"
+	"math"
+	"testing"
+
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/graph/graphtest"
 	"github.com/gomlx/gomlx/ml/context"
@@ -16,8 +19,6 @@ import (
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math"
-	"testing"
 
 	_ "github.com/gomlx/gomlx/backends/xla"
 )
@@ -146,6 +147,7 @@ func TestFNNRegularized(t *testing.T) {
 			Residual(true).
 			Normalization("layer").
 			Regularizer(regularizers.L1(0.01)).
+			Dropout(0).
 			Done()
 	}
 	opt := optimizers.Adam().LearningRate(0.001).Done()
@@ -158,7 +160,7 @@ func TestFNNRegularized(t *testing.T) {
 	commandline.AttachProgressBar(loop) // Attaches a progress bar to the loop.
 	metrics, err := loop.RunSteps(ds, 10_000)
 	loss := metrics[1].Value().(float64)
-	assert.Truef(t, loss < 0.04, "Expected a loss < 0.04, got %g instead", loss)
+	assert.Truef(t, loss < 0.07, "Expected a loss < 0.07, got %g instead", loss)
 	require.NoErrorf(t, err, "Failed training: %+v", err)
 	fmt.Println("Metrics:")
 	for ii, m := range metrics {

--- a/ml/layers/vnn/vnn_test.go
+++ b/ml/layers/vnn/vnn_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/graph/graphtest"
 	"github.com/gomlx/gomlx/ml/context"
-	"github.com/gomlx/gomlx/ml/context/initializers"
 	"github.com/gomlx/gomlx/ml/data"
 	"github.com/gomlx/gomlx/ml/layers/regularizers"
 	"github.com/gomlx/gomlx/ml/train"
@@ -40,8 +39,7 @@ func TestLinearLayer(t *testing.T) {
 		yaw := MulScalar(ctx.RandomUniform(g, shapes.Make(dtypes.Float64)), pi2)
 
 		// Linear function: fix seed so we always have the same values.
-		ctx.SetParam(initializers.ParamInitialSeed, 42)
-		ctx = ctx.Checked(false).WithInitializer(initializers.HeFn(ctx))
+		ctx = ctx.Checked(false)
 		linearFn := func(x *Node) *Node {
 			return New(ctx, x, 2).
 				NumHiddenLayers(0, 0).
@@ -84,8 +82,7 @@ func TestRelu(t *testing.T) {
 					yaw := MulScalar(ctx.RandomUniform(g, shapes.Make(dtypes.Float64)), pi2)
 
 					// Linear function: fix seed so we always have the same values.
-					ctx.SetParam(initializers.ParamInitialSeed, 42)
-					ctx = ctx.Checked(false).WithInitializer(initializers.HeFn(ctx))
+					ctx = ctx.Checked(false)
 
 					// Outputs: out1 rotates after linear transformation, out2 rotates before linear transformation.
 					out1 := Relu(ctx, input).
@@ -132,8 +129,7 @@ func TestLayerNormalization(t *testing.T) {
 		yaw := MulScalar(ctx.RandomUniform(g, shapes.Make(dtypes.Float64)), pi2)
 
 		// Linear function: fix seed so we always have the same values.
-		ctx.SetParam(initializers.ParamInitialSeed, 42)
-		ctx = ctx.Checked(false).WithInitializer(initializers.HeFn(ctx))
+		ctx = ctx.Checked(false)
 
 		// Outputs: out1 rotates after linear transformation, out2 rotates before linear transformation.
 		epsilon := 1e-5
@@ -169,8 +165,7 @@ func TestVNN_Equivariant(t *testing.T) {
 		yaw := MulScalar(ctx.RandomUniform(g, shapes.Make(dtypes.Float64)), pi2)
 
 		// vnn layer: fix seed so we always have the same values.
-		ctx.SetParam(initializers.ParamInitialSeed, 42)
-		ctx = ctx.Checked(false).WithInitializer(initializers.HeFn(ctx))
+		ctx = ctx.Checked(false)
 		vnnFn := func(x *Node) *Node {
 			return New(ctx, x, 5).
 				NumHiddenLayers(3, 10).

--- a/ml/train/metrics/median_test.go
+++ b/ml/train/metrics/median_test.go
@@ -95,6 +95,6 @@ func TestStreamingMedian(t *testing.T) {
 		slices.Sort(values)
 		want := values[numExamples/2]
 		fmt.Printf("\tgot medianT=%.5g, wanted medianT=%.5g\n", median, want)
-		require.InDelta(t, want, median, 100)
+		require.InDelta(t, want, median, 200)
 	})
 }

--- a/ml/train/optimizers/adam.go
+++ b/ml/train/optimizers/adam.go
@@ -48,20 +48,17 @@ const (
 	ParamAdamWeightDecay = "adam_weight_decay"
 )
 
-// Adam optimization is a stochastic gradient descent method based on an adaptive estimation of first-order and
+// Adam optimization is a stochastic gradient descent method that is based on adaptive estimation of first-order and
 // second-order moments. According to [Kingma et al., 2014](http://arxiv.org/abs/1412.6980),
 // the method is "*computationally efficient, has little memory requirement, invariant to diagonal rescaling of
 // gradients, and is well suited for problems that are large in terms of data/parameters*".
 //
-// It returns a configuration object that can be used to set its parameters. Once configured, call AdamConfig.Done,
-// and it will return an optimizer.Interface that can be used with the `train.Trainer` or directly in a custom
-// optimization loop.
+// It returns a configuration object that can be used to set its parameters. Once configured call IsNil, and it
+// will return an optimizer.Interface.
 //
 // See [AdamConfig.FromContext] to configure it from the context hyperparameters.
 //
-// Clipping of the gradient updates available by setting the context hyperparameters ParamClipStepByValue("clip_step_by_value")
-// and ParamClipNaN ("clip_nan"). NaN in gradients can be reported by assigning a `nanlogger.NanLogger` to the parameter
-// ParamNanLogger.
+// Clipping of the gradient updates available by setting the context hyperparameter [ParamClipStepByValue]("clip_step_by_value").
 func Adam() *AdamConfig {
 	return &AdamConfig{
 		scopeName:    AdamDefaultScope,
@@ -74,31 +71,8 @@ func Adam() *AdamConfig {
 	}
 }
 
-// RMSProp is an optimizer that divides the learning rate for a weight by a running average
-// of the recent gradients magnitudes (L2) for that weight.
-//
-// It uses Adam to implement it -- it's somewhat equivalent to an Adam without the 1st moment
-// of the gradients.
-//
-// It was described first in the following sources:
-// * https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf (Hinton)
-// * https://arxiv.org/pdf/1308.0850 (Graves)
-//
-// It returns a configuration object that can be used to set its parameters. Once configured, call AdamConfig.Done,
-// and it will return an optimizer.Interface that can be used with the `train.Trainer` or directly in a custom
-// optimization loop.
-//
-// Clipping of the gradient updates available by setting the context hyperparameters ParamClipStepByValue("clip_step_by_value")
-// and ParamClipNaN ("clip_nan"). NaN in gradients can be reported by assigning a `nanlogger.NanLogger` to the parameter
-// ParamNanLogger.
-func RMSProp() *AdamConfig {
-	c := Adam()
-	c.rmsProp = true
-	return c
-}
-
 // AdamConfig holds the configuration for an Adam configuration, create using Adam(), and once configured
-// call Done to create an Adam-based optimizer.Interface.
+// call Done to create an Adam based optimizer.Interface.
 type AdamConfig struct {
 	scopeName    string
 	dtype        dtypes.DType // If invalid, use the loss type instead.
@@ -108,7 +82,6 @@ type AdamConfig struct {
 	amsGrad      bool
 	adamax       bool    // Works as Adamax.
 	weightDecay  float64 // Works as AdamW.
-	rmsProp      bool    // Works as RMSProp.
 }
 
 // FromContext will configure Adam with hyperparameters set in the given context.
@@ -270,13 +243,8 @@ func (o *adam) UpdateGraphWithGradients(ctx *context.Context, grads []*Node, los
 // If `Adamax` is set, we use instead moment2 to store the L-infinity (the max) of the gradient.
 func (o *adam) applyAdamGraph(ctx *context.Context, g *Graph, v *context.Variable, dtype dtypes.DType, grad *Node,
 	learningRate, beta1, debiasTermBeta1, beta2, debiasTermBeta2, epsilon *Node) {
-	rmsProp := o.config.rmsProp // If set, don't use 1st momentum.
 	m1Var, m2Var := o.getMomentVariables(ctx, v, dtype)
-	var moment1 *Node
-	if !rmsProp {
-		moment1 = m1Var.ValueGraph(g)
-	}
-	moment2 := m2Var.ValueGraph(g)
+	moment1, moment2 := m1Var.ValueGraph(g), m2Var.ValueGraph(g)
 
 	// Adam runs on a fixed dtype -- defaults to the dtype of the loss, but it can be configured.
 	// We convert the grad to the dtype used by Adam for its computation.
@@ -287,15 +255,11 @@ func (o *adam) applyAdamGraph(ctx *context.Context, g *Graph, v *context.Variabl
 	grad = ClipNaNsInGradients(ctx, grad)
 
 	// Do the gradient step with momentum.
-	// The momentum is disabled (we simply take the gradien) if rmsProp is set.
-	debiasedMoment1 := grad
-	if !rmsProp {
-		moment1 = Add(
-			Mul(beta1, moment1),
-			Mul(OneMinus(beta1), grad))
-		m1Var.SetValueGraph(moment1)
-		debiasedMoment1 = Mul(moment1, debiasTermBeta1)
-	}
+	moment1 = Add(
+		Mul(beta1, moment1),
+		Mul(OneMinus(beta1), grad))
+	m1Var.SetValueGraph(moment1)
+	debiasedMoment1 := Mul(moment1, debiasTermBeta1)
 
 	var denominator *Node
 	if o.config.adamax {
@@ -358,9 +322,7 @@ func (o *adam) getMomentVariables(ctx *context.Context, trainable *context.Varia
 	shape := trainable.Shape().Clone()
 	shape.DType = dtype
 	ctx = ctx.Checked(false) // It shouldn't matter if it's the first time or not creating the variable.
-	if !o.config.rmsProp {
-		m1 = ctx.InAbsPath(scopePath).WithInitializer(initializers.Zero).VariableWithShape(m1Name, shape).SetTrainable(false)
-	}
+	m1 = ctx.InAbsPath(scopePath).WithInitializer(initializers.Zero).VariableWithShape(m1Name, shape).SetTrainable(false)
 	m2 = ctx.InAbsPath(scopePath).WithInitializer(initializers.Zero).VariableWithShape(m2Name, shape).SetTrainable(false)
 	return
 }

--- a/ml/train/optimizers/adam.go
+++ b/ml/train/optimizers/adam.go
@@ -251,9 +251,10 @@ func (o *adam) applyAdamGraph(ctx *context.Context, g *Graph, v *context.Variabl
 	if grad.DType() != dtype {
 		grad = ConvertDType(grad, dtype)
 	}
+	TraceNaNInGradients(ctx, v, grad)
 	grad = ClipNaNsInGradients(ctx, grad)
 
-	// Do gradient step with momentum.
+	// Do the gradient step with momentum.
 	moment1 = Add(
 		Mul(beta1, moment1),
 		Mul(OneMinus(beta1), grad))

--- a/ml/train/optimizers/adam.go
+++ b/ml/train/optimizers/adam.go
@@ -48,17 +48,20 @@ const (
 	ParamAdamWeightDecay = "adam_weight_decay"
 )
 
-// Adam optimization is a stochastic gradient descent method that is based on adaptive estimation of first-order and
+// Adam optimization is a stochastic gradient descent method based on an adaptive estimation of first-order and
 // second-order moments. According to [Kingma et al., 2014](http://arxiv.org/abs/1412.6980),
 // the method is "*computationally efficient, has little memory requirement, invariant to diagonal rescaling of
 // gradients, and is well suited for problems that are large in terms of data/parameters*".
 //
-// It returns a configuration object that can be used to set its parameters. Once configured call IsNil, and it
-// will return an optimizer.Interface.
+// It returns a configuration object that can be used to set its parameters. Once configured, call AdamConfig.Done,
+// and it will return an optimizer.Interface that can be used with the `train.Trainer` or directly in a custom
+// optimization loop.
 //
 // See [AdamConfig.FromContext] to configure it from the context hyperparameters.
 //
-// Clipping of the gradient updates available by setting the context hyperparameter [ParamClipStepByValue]("clip_step_by_value").
+// Clipping of the gradient updates available by setting the context hyperparameters ParamClipStepByValue("clip_step_by_value")
+// and ParamClipNaN ("clip_nan"). NaN in gradients can be reported by assigning a `nanlogger.NanLogger` to the parameter
+// ParamNanLogger.
 func Adam() *AdamConfig {
 	return &AdamConfig{
 		scopeName:    AdamDefaultScope,
@@ -71,8 +74,31 @@ func Adam() *AdamConfig {
 	}
 }
 
+// RMSProp is an optimizer that divides the learning rate for a weight by a running average
+// of the recent gradients magnitudes (L2) for that weight.
+//
+// It uses Adam to implement it -- it's somewhat equivalent to an Adam without the 1st moment
+// of the gradients.
+//
+// It was described first in the following sources:
+// * https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf (Hinton)
+// * https://arxiv.org/pdf/1308.0850 (Graves)
+//
+// It returns a configuration object that can be used to set its parameters. Once configured, call AdamConfig.Done,
+// and it will return an optimizer.Interface that can be used with the `train.Trainer` or directly in a custom
+// optimization loop.
+//
+// Clipping of the gradient updates available by setting the context hyperparameters ParamClipStepByValue("clip_step_by_value")
+// and ParamClipNaN ("clip_nan"). NaN in gradients can be reported by assigning a `nanlogger.NanLogger` to the parameter
+// ParamNanLogger.
+func RMSProp() *AdamConfig {
+	c := Adam()
+	c.rmsProp = true
+	return c
+}
+
 // AdamConfig holds the configuration for an Adam configuration, create using Adam(), and once configured
-// call Done to create an Adam based optimizer.Interface.
+// call Done to create an Adam-based optimizer.Interface.
 type AdamConfig struct {
 	scopeName    string
 	dtype        dtypes.DType // If invalid, use the loss type instead.
@@ -82,6 +108,7 @@ type AdamConfig struct {
 	amsGrad      bool
 	adamax       bool    // Works as Adamax.
 	weightDecay  float64 // Works as AdamW.
+	rmsProp      bool    // Works as RMSProp.
 }
 
 // FromContext will configure Adam with hyperparameters set in the given context.
@@ -243,8 +270,13 @@ func (o *adam) UpdateGraphWithGradients(ctx *context.Context, grads []*Node, los
 // If `Adamax` is set, we use instead moment2 to store the L-infinity (the max) of the gradient.
 func (o *adam) applyAdamGraph(ctx *context.Context, g *Graph, v *context.Variable, dtype dtypes.DType, grad *Node,
 	learningRate, beta1, debiasTermBeta1, beta2, debiasTermBeta2, epsilon *Node) {
+	rmsProp := o.config.rmsProp // If set, don't use 1st momentum.
 	m1Var, m2Var := o.getMomentVariables(ctx, v, dtype)
-	moment1, moment2 := m1Var.ValueGraph(g), m2Var.ValueGraph(g)
+	var moment1 *Node
+	if !rmsProp {
+		moment1 = m1Var.ValueGraph(g)
+	}
+	moment2 := m2Var.ValueGraph(g)
 
 	// Adam runs on a fixed dtype -- defaults to the dtype of the loss, but it can be configured.
 	// We convert the grad to the dtype used by Adam for its computation.
@@ -255,11 +287,15 @@ func (o *adam) applyAdamGraph(ctx *context.Context, g *Graph, v *context.Variabl
 	grad = ClipNaNsInGradients(ctx, grad)
 
 	// Do the gradient step with momentum.
-	moment1 = Add(
-		Mul(beta1, moment1),
-		Mul(OneMinus(beta1), grad))
-	m1Var.SetValueGraph(moment1)
-	debiasedMoment1 := Mul(moment1, debiasTermBeta1)
+	// The momentum is disabled (we simply take the gradien) if rmsProp is set.
+	debiasedMoment1 := grad
+	if !rmsProp {
+		moment1 = Add(
+			Mul(beta1, moment1),
+			Mul(OneMinus(beta1), grad))
+		m1Var.SetValueGraph(moment1)
+		debiasedMoment1 = Mul(moment1, debiasTermBeta1)
+	}
 
 	var denominator *Node
 	if o.config.adamax {
@@ -322,7 +358,9 @@ func (o *adam) getMomentVariables(ctx *context.Context, trainable *context.Varia
 	shape := trainable.Shape().Clone()
 	shape.DType = dtype
 	ctx = ctx.Checked(false) // It shouldn't matter if it's the first time or not creating the variable.
-	m1 = ctx.InAbsPath(scopePath).WithInitializer(initializers.Zero).VariableWithShape(m1Name, shape).SetTrainable(false)
+	if !o.config.rmsProp {
+		m1 = ctx.InAbsPath(scopePath).WithInitializer(initializers.Zero).VariableWithShape(m1Name, shape).SetTrainable(false)
+	}
 	m2 = ctx.InAbsPath(scopePath).WithInitializer(initializers.Zero).VariableWithShape(m2Name, shape).SetTrainable(false)
 	return
 }

--- a/ml/train/optimizers/optimizers.go
+++ b/ml/train/optimizers/optimizers.go
@@ -86,11 +86,29 @@ var (
 	// Defaults to no clipping, and values are expected to be float64.
 	ParamClipStepByValue = "clip_step_by_value"
 
-	// ParamClipNaN will drop any updates to variables that leads to NaN.
+	// ParamClipNaN will drop any updates with NaNs.
 	// This is a double-edged option: it keeps training running, but probably it will replace NaNs with bad training results.
+	// It works well to handle spurious results.
+	//
+	// See also ParamNanLogger to help debug it.
 	//
 	// The default is false.
 	ParamClipNaN = "clip_nan"
+
+	// ParamNanLogger configures a nanlogger to use to report NaNs in gradients updates for example. See TraceNaNInGradients.
+	// This value is not saved in a checkpoint.
+	// It should be set to a Tracer (which a *nanlogger.NanLogger is).
+	//
+	// Typical use:
+	//
+	//	var nanLogger *nanlogger.NanLogger
+	//	if debugNaNs {
+	//		nanLogger = nanlogger.New()
+	//		ctx.SetParam(optimizers.ParamNanLogger, nanLogger)
+	//	}
+	//	trainer := train.NewTrainer(…)
+	//	nanLogger.AttachToTrainer(trainer)
+	ParamNanLogger = "nanlogger"
 )
 
 const (
@@ -203,6 +221,25 @@ func ClipStepByValue(ctx *context.Context, step *Node) *Node {
 		return step
 	}
 	return ClipScalar(step, -clipByValue, clipByValue)
+}
+
+// Tracer can trace a node with a scope. Used to represent a nanlogger.NanLogger.
+type Tracer interface {
+	Trace(node *Node, scopes ...string)
+}
+
+// TraceNaNInGradients will report a NaN/Inf value in a gradient for the given variable, is a "Tracer" (typically a nanlogger.NanLogger)
+// has been configured in the context.
+func TraceNaNInGradients(ctx *context.Context, variable *context.Variable, gradients *Node) {
+	lAny, found := ctx.GetParam(ParamNanLogger)
+	if !found {
+		return
+	}
+	l, ok := lAny.(Tracer)
+	if !ok {
+		return
+	}
+	l.Trace(gradients, "Gradients", variable.ScopeAndName())
 }
 
 // ClipNaNsInGradients will replace the gradient tensor by zeros if there are any NaNs or +/-Inf values.
@@ -339,6 +376,8 @@ func addGradientsToVariablesGraph(ctx *context.Context, grads []*Node, learningR
 		}
 		scaledGradient := Mul(grads[ii], lrCast)
 		scaledGradient = ClipStepByValue(ctx, scaledGradient)
+		TraceNaNInGradients(ctx, v, scaledGradient)
+
 		vNode := v.ValueGraph(g)
 		updatedValue := Sub(vNode, scaledGradient)
 		updatedValue = ClipNaNsInUpdates(ctx, vNode, updatedValue)

--- a/ml/train/optimizers/optimizers.go
+++ b/ml/train/optimizers/optimizers.go
@@ -61,11 +61,10 @@ var (
 	// This provides an easy quick start point. One can hyperparameter-tune the optimizers
 	// for usually slightly better results.
 	KnownOptimizers = map[string]func(ctx *context.Context) Interface{
-		"sgd":     func(ctx *context.Context) Interface { return StochasticGradientDescent() },
-		"adam":    func(ctx *context.Context) Interface { return Adam().FromContext(ctx).Done() },
-		"adamax":  func(ctx *context.Context) Interface { return Adam().Adamax().FromContext(ctx).Done() },
-		"adamw":   func(ctx *context.Context) Interface { return Adam().WeightDecay(0.004).FromContext(ctx).Done() },
-		"rmsprop": func(ctx *context.Context) Interface { return RMSProp().FromContext(ctx).Done() },
+		"sgd":    func(ctx *context.Context) Interface { return StochasticGradientDescent() },
+		"adam":   func(ctx *context.Context) Interface { return Adam().FromContext(ctx).Done() },
+		"adamax": func(ctx *context.Context) Interface { return Adam().Adamax().FromContext(ctx).Done() },
+		"adamw":  func(ctx *context.Context) Interface { return Adam().WeightDecay(0.004).FromContext(ctx).Done() },
 	}
 
 	// ParamOptimizer is the context parameter with the name of the optimizer.

--- a/ml/train/optimizers/optimizers.go
+++ b/ml/train/optimizers/optimizers.go
@@ -61,10 +61,11 @@ var (
 	// This provides an easy quick start point. One can hyperparameter-tune the optimizers
 	// for usually slightly better results.
 	KnownOptimizers = map[string]func(ctx *context.Context) Interface{
-		"sgd":    func(ctx *context.Context) Interface { return StochasticGradientDescent() },
-		"adam":   func(ctx *context.Context) Interface { return Adam().FromContext(ctx).Done() },
-		"adamax": func(ctx *context.Context) Interface { return Adam().Adamax().FromContext(ctx).Done() },
-		"adamw":  func(ctx *context.Context) Interface { return Adam().WeightDecay(0.004).FromContext(ctx).Done() },
+		"sgd":     func(ctx *context.Context) Interface { return StochasticGradientDescent() },
+		"adam":    func(ctx *context.Context) Interface { return Adam().FromContext(ctx).Done() },
+		"adamax":  func(ctx *context.Context) Interface { return Adam().Adamax().FromContext(ctx).Done() },
+		"adamw":   func(ctx *context.Context) Interface { return Adam().WeightDecay(0.004).FromContext(ctx).Done() },
+		"rmsprop": func(ctx *context.Context) Interface { return RMSProp().FromContext(ctx).Done() },
 	}
 
 	// ParamOptimizer is the context parameter with the name of the optimizer.


### PR DESCRIPTION
Version bump.

* Package `nanlogger`:
    * Allow traces that only report also.
    * Created context parameter `optimizer.ParamNanLogger`: if set to NanLogger, it will trace all occurrences of of NaN values in gradient: great to debug where are the NaN appearing in the model first.

* Package `optimizer`:
   * Added `RMSProp()` optimizer.

* Package `context`:
  * Allow VariableInitializers to use the `context.Context` itself, with its own random initializer.
  * `DefaultInitializer` now creates an initializer. The new default uses He initializer, the same used in PyTorch.
  * Package `initializers`:
    * They now use the `context` random number generator state, which simplifies things. 
    * `ParamInitialSeed` removed, since the RNG is initialized by `Context.RngStateWithSeed()`.

* Fixed some flaky tests.

