### PR TITLE
Adam optimizer: new `backoff steps` to pre-calculate momentum and variance before applying gradients.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Package `backends`:
   * Method **`New()` will return an error (as opposed to panic)**.
     The temporarily `NewOrErr` was marked as deprecated, use `New` instead.
+* Package `optimizers`:
+  * New `AdamConfig.WithBackoffSteps()` (or the hyperparameter `adam_backoff`) that prevents gradient steps
+    from being taken until the given number of steps has executed. This allows a better estimate (moving average) of
+    the gradients ("momentum") and their variances to be calculated before applying them. 
 
 # v0.21.0: 2025/07/01 🌞 Summer Edition 🌞
 

--- a/ml/train/optimizers/cosineschedule/schedules.go
+++ b/ml/train/optimizers/cosineschedule/schedules.go
@@ -21,13 +21,14 @@
 package cosineschedule
 
 import (
+	"math"
+
 	. "github.com/gomlx/exceptions"
 	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/ml/context"
 	"github.com/gomlx/gomlx/ml/train"
 	"github.com/gomlx/gomlx/ml/train/optimizers"
 	"github.com/gomlx/gopjrt/dtypes"
-	"math"
 )
 
 var (
@@ -144,9 +145,6 @@ func (opt *Config) Done() {
 	if !ctx.IsTraining(opt.graph) || opt.periodNumSteps == 0 {
 		return
 	}
-	//if opt.periodNumSteps < 0 {
-	//	Panicf("period of the New in number of steps was not set, or set to < 0")
-	//}
 
 	lrValue := opt.learningRate
 	if lrValue == 0 {
@@ -163,7 +161,7 @@ func (opt *Config) Done() {
 	cosineStep := optimizers.IncrementGlobalStepGraph(ctx.In(optimizers.Scope).In(Scope), graph, opt.dtype)
 	cosineStep = MinusOne(cosineStep) // Since the count starts at 1.
 
-	// Calculate fraction of the cycle we are in.
+	// Calculate the fraction of the cycle we are in.
 	var cycle *Node
 	if opt.periodNumSteps > 0 {
 		cycle = DivScalar(cosineStep, float64(opt.periodNumSteps))


### PR DESCRIPTION
  * New `AdamConfig.WithBackoffSteps()` (or the hyperparameter `adam_backoff`) that prevents gradient steps
    from being taken until the given number of steps has executed. This allows a better estimate (moving average) of
    the gradients ("momentum") and their variances to be calculated before applying them.