### PR TITLE
Added -perturb to add perturbation to `gomlx_checkpoints`.

### DIFF
--- a/cmd/gomlx_checkpoints/main.go
+++ b/cmd/gomlx_checkpoints/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	if *flagPerturbVars > 0 {
-		PerturbVars(args[0])
+		PerturbVars(args[0], *flagPerturbVars)
 	}
 
 	if *flagAll {

--- a/cmd/gomlx_checkpoints/main.go
+++ b/cmd/gomlx_checkpoints/main.go
@@ -9,19 +9,14 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"slices"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/dustin/go-humanize"
-	"github.com/gomlx/gomlx/backends"
-	. "github.com/gomlx/gomlx/graph"
 	"github.com/gomlx/gomlx/ml/context"
 	"github.com/gomlx/gomlx/ml/context/checkpoints"
 	"github.com/gomlx/gomlx/ml/train/optimizers"
 	"github.com/gomlx/gomlx/ui/plots"
-	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/janpfeifer/must"
 	"k8s.io/klog/v2"
 
@@ -37,15 +32,13 @@ var (
 	flagSummary = flag.Bool("summary", false, "Display a summary of the model sizes (for variables"+
 		" under --scope and the global step.")
 	flagParams  = flag.Bool("params", false, "Lists the hyperparameters.")
-	flagVars    = flag.Bool("vars", false, "Lists the variables under --scope.")
 	flagMetrics = flag.Bool("metrics", false,
 		fmt.Sprintf("Lists the metrics collected for plotting in file %q", plots.TrainingPlotFileName))
 	flagMetricsLabels = flag.Bool("metrics_labels", false,
 		fmt.Sprintf("Lists the metrics labels (short names) with their full description from file %q", plots.TrainingPlotFileName))
 
-	flagBackup     = flag.Bool("backup", false, "Set to true to make a backup of the most recent checkpoint, under the 'backup' subdirectory.")
-	flagDeleteVars = flag.String("delete_vars", "", "Delete variables under the given scope(s). Useful for instance to remove training temporary data.")
-	flagGlossary   = flag.Bool("glossary", true, "Whether to list glossary of abbreviation on the bottom of tables.")
+	flagBackup   = flag.Bool("backup", false, "Set to true to make a backup of the most recent checkpoint, under the 'backup' subdirectory.")
+	flagGlossary = flag.Bool("glossary", true, "Whether to list glossary of abbreviation on the bottom of tables.")
 
 	flagLoop = flag.Duration("loop", 0, "Sets looping with the given period. "+
 		"This is used to monitor the training of a program, usually used in conjunction with --metrics. "+
@@ -80,6 +73,10 @@ func main() {
 
 	if *flagDeleteVars != "" {
 		DeleteVars(args[0], strings.Split(*flagDeleteVars, ",")...)
+	}
+
+	if *flagPerturbVars > 0 {
+		PerturbVars(args[0])
 	}
 
 	if *flagAll {
@@ -152,88 +149,6 @@ func Reports(checkpointPaths []string) {
 		ListVariables(scopedCtxs[0])
 	}
 
-}
-
-// ListVariables list the variables of a model, with their shape and MAV (max absolute value), RMS (root mean square) and MaxAV (max absolute value) values.
-func ListVariables(ctx *context.Context) {
-	fmt.Println(titleStyle.Render(fmt.Sprintf("Variables in scope %q", ctx.Scope())))
-	metricsFn := NewExec(backends.MustNew(), func(x *Node) (mav, rms, maxAV *Node) {
-		x = ConvertDType(x, dtypes.Float64)
-		mav = ReduceAllMean(Abs(x))
-		rms = Sqrt(ReduceAllMean(Square(x)))
-		maxAV = ReduceAllMax(Abs(x))
-		return
-	}).SetMaxCache(-1)
-	table := newPlainTable(true)
-	table.Headers("Scope", "Name", "Shape", "Size", "Bytes", "Scalar/MAV", "RMS", "MaxAV")
-	var rows [][]string
-	ctx.EnumerateVariablesInScope(func(v *context.Variable) {
-		if !v.IsValid() {
-			rows = append(rows, []string{v.Scope(), v.Name(), "<invalid>", "", "", "", "", ""})
-			return
-		}
-		shape := v.Shape()
-		var mav, rms, maxAV string
-		if shape.Size() == 1 {
-			mav = fmt.Sprintf("%8v", v.Value().Value())
-		} else if shape.DType.IsFloat() {
-			metrics := metricsFn.Call(v.Value())
-			mav = fmt.Sprintf("%.3g", metrics[0].Value().(float64))
-			rms = fmt.Sprintf("%.3g", metrics[1].Value().(float64))
-			maxAV = fmt.Sprintf("%.3g", metrics[2].Value().(float64))
-		}
-		rows = append(rows, []string{
-			v.Scope(), v.Name(), shape.String(),
-			humanize.Comma(int64(shape.Size())),
-			humanize.Bytes(uint64(shape.Memory())),
-			mav, rms, maxAV,
-		})
-	})
-	slices.SortFunc(rows, func(a, b []string) int {
-		cmp := strings.Compare(a[0], b[0])
-		if cmp != 0 {
-			return cmp
-		}
-		return strings.Compare(a[1], b[1])
-	})
-	for _, row := range rows {
-		table.Row(row...)
-	}
-	fmt.Println(table.Render())
-	if *flagGlossary {
-		fmt.Printf("  %s:\n", sectionStyle.Render("Glossary"))
-		fmt.Printf("   ◦ %s: %s\n", emphasisStyle.Render("Scalar/MAV"), italicStyle.Render("If variable is a scalar then the value itself, else the Mean Absolute Value"))
-		fmt.Printf("   ◦ %s: %s\n", emphasisStyle.Render("RMS"), italicStyle.Render("Root Mean Square"))
-		fmt.Printf("   ◦ %s: %s\n", emphasisStyle.Render("MaxAV"), italicStyle.Render("Max Absolute Value"))
-	}
-}
-
-// DeleteVars on the given scopes.
-func DeleteVars(checkpointPath string, scopes ...string) {
-	ctx := context.New()
-	checkpoint := must.M1(checkpoints.Build(ctx).
-		Dir(checkpointPath).Keep(-1).Immediate().Done())
-	var varsToDelete []*context.Variable
-	for _, scope := range scopes {
-		if scope == "" {
-			continue
-		}
-		scopePrefix := scope + context.ScopeSeparator
-		ctx.EnumerateVariables(func(v *context.Variable) {
-			if v.Scope() == scope || strings.HasPrefix(v.Scope(), scopePrefix) {
-				varsToDelete = append(varsToDelete, v)
-			}
-		})
-	}
-	if len(varsToDelete) == 0 {
-		// No changes needed.
-		return
-	}
-	for _, v := range varsToDelete {
-		ctx.DeleteVariable(v.Scope(), v.Name())
-	}
-	must.M(checkpoint.Save())
-	fmt.Printf("%d deleted vars under scopes %v, new checkpoint saved.\n", len(varsToDelete), scopes)
 }
 
 func Backup(checkpointPath string) {

--- a/cmd/gomlx_checkpoints/variables.go
+++ b/cmd/gomlx_checkpoints/variables.go
@@ -107,7 +107,7 @@ func DeleteVars(checkpointPath string, scopes ...string) {
 	fmt.Printf("%d deleted vars under scopes %v, new checkpoint saved.\n", len(varsToDelete), scopes)
 }
 
-func PerturbVars(checkpointPath string) {
+func PerturbVars(checkpointPath string, x float64) {
 	backend := must.M1(simplego.New(""))
 	ctx := context.New()
 	checkpoint := must.M1(checkpoints.Build(ctx).
@@ -121,8 +121,8 @@ func PerturbVars(checkpointPath string) {
 			value := v.ValueGraph(g)
 			// Perturbation from -1 to 1
 			perturbation := OneMinus(MulScalar(ctx.RandomUniform(g, value.Shape()), 2))
-			perturbation = MulScalar(perturbation, *flagPerturbVars) // [-x, +x], -perturb=x
-			perturbation = OnePlus(perturbation)                     // [1-x, 1+x]
+			perturbation = MulScalar(perturbation, x) // [-x, +x], -perturb=x
+			perturbation = OnePlus(perturbation)      // [1-x, 1+x]
 			return Mul(value, perturbation)
 		})
 		v.SetValue(newValue)

--- a/cmd/gomlx_checkpoints/variables.go
+++ b/cmd/gomlx_checkpoints/variables.go
@@ -119,9 +119,10 @@ func PerturbVars(checkpointPath string) {
 		}
 		newValue := context.ExecOnce(backend, ctx, func(ctx *context.Context, g *Graph) *Node {
 			value := v.ValueGraph(g)
-			perturbation := ctx.RandomUniform(g, value.Shape())
-			perturbation = MulScalar(perturbation, 2*(*flagPerturbVars))
-			perturbation = AddScalar(perturbation, -(*flagPerturbVars))
+			// Perturbation from -1 to 1
+			perturbation := OneMinus(MulScalar(ctx.RandomUniform(g, value.Shape()), 2))
+			perturbation = MulScalar(perturbation, *flagPerturbVars) // [-x, +x], -perturb=x
+			perturbation = OnePlus(perturbation)                     // [1-x, 1+x]
 			return Mul(value, perturbation)
 		})
 		v.SetValue(newValue)

--- a/cmd/gomlx_checkpoints/variables.go
+++ b/cmd/gomlx_checkpoints/variables.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/gomlx/gomlx/backends"
+	"github.com/gomlx/gomlx/backends/simplego"
+	. "github.com/gomlx/gomlx/graph"
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/gomlx/gomlx/ml/context/checkpoints"
+	"github.com/gomlx/gopjrt/dtypes"
+	"github.com/janpfeifer/must"
+)
+
+var (
+	flagVars        = flag.Bool("vars", false, "Lists the variables under --scope.")
+	flagDeleteVars  = flag.String("delete_vars", "", "Delete variables under the given scope(s). Useful for instance to remove training temporary data.")
+	flagPerturbVars = flag.Float64("perturb", 0,
+		"Perturbs trainable variables by <x>: it multiplies the weights by 1.0+(RandomUniform(-1, 1)*x). "+
+			"If using Adam optimizer (or other optimizers) remember to clear their running moving averages with -delete_vars. "+
+			"Only variables that are both trainable and float are modified.")
+)
+
+// ListVariables list the variables of a model, with their shape and MAV (max absolute value), RMS (root-mean-square) and MaxAV (max absolute value) values.
+func ListVariables(ctx *context.Context) {
+	fmt.Println(titleStyle.Render(fmt.Sprintf("Variables in scope %q", ctx.Scope())))
+	metricsFn := NewExec(backends.MustNew(), func(x *Node) (mav, rms, maxAV *Node) {
+		x = ConvertDType(x, dtypes.Float64)
+		mav = ReduceAllMean(Abs(x))
+		rms = Sqrt(ReduceAllMean(Square(x)))
+		maxAV = ReduceAllMax(Abs(x))
+		return
+	}).SetMaxCache(-1)
+	table := newPlainTable(true)
+	table.Headers("Scope", "Name", "Shape", "Size", "Bytes", "Scalar/MAV", "RMS", "MaxAV")
+	var rows [][]string
+	ctx.EnumerateVariablesInScope(func(v *context.Variable) {
+		if !v.IsValid() {
+			rows = append(rows, []string{v.Scope(), v.Name(), "<invalid>", "", "", "", "", ""})
+			return
+		}
+		shape := v.Shape()
+		var mav, rms, maxAV string
+		if shape.Size() == 1 {
+			mav = fmt.Sprintf("%8v", v.Value().Value())
+		} else if shape.DType.IsFloat() {
+			metrics := metricsFn.Call(v.Value())
+			mav = fmt.Sprintf("%.3g", metrics[0].Value().(float64))
+			rms = fmt.Sprintf("%.3g", metrics[1].Value().(float64))
+			maxAV = fmt.Sprintf("%.3g", metrics[2].Value().(float64))
+		}
+		rows = append(rows, []string{
+			v.Scope(), v.Name(), shape.String(),
+			humanize.Comma(int64(shape.Size())),
+			humanize.Bytes(uint64(shape.Memory())),
+			mav, rms, maxAV,
+		})
+	})
+	slices.SortFunc(rows, func(a, b []string) int {
+		cmp := strings.Compare(a[0], b[0])
+		if cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a[1], b[1])
+	})
+	for _, row := range rows {
+		table.Row(row...)
+	}
+	fmt.Println(table.Render())
+	if *flagGlossary {
+		fmt.Printf("  %s:\n", sectionStyle.Render("Glossary"))
+		fmt.Printf("   ◦ %s: %s\n", emphasisStyle.Render("Scalar/MAV"), italicStyle.Render("If variable is a scalar then the value itself, else the Mean Absolute Value"))
+		fmt.Printf("   ◦ %s: %s\n", emphasisStyle.Render("RMS"), italicStyle.Render("Root Mean Square"))
+		fmt.Printf("   ◦ %s: %s\n", emphasisStyle.Render("MaxAV"), italicStyle.Render("Max Absolute Value"))
+	}
+}
+
+// DeleteVars on the given scopes.
+func DeleteVars(checkpointPath string, scopes ...string) {
+	ctx := context.New()
+	checkpoint := must.M1(checkpoints.Build(ctx).
+		Dir(checkpointPath).Keep(-1).Immediate().Done())
+	var varsToDelete []*context.Variable
+	for _, scope := range scopes {
+		if scope == "" {
+			continue
+		}
+		scopePrefix := scope + context.ScopeSeparator
+		for v := range ctx.IterVariables() {
+			if v.Scope() == scope || strings.HasPrefix(v.Scope(), scopePrefix) {
+				varsToDelete = append(varsToDelete, v)
+			}
+		}
+	}
+	if len(varsToDelete) == 0 {
+		// No changes needed.
+		return
+	}
+	for _, v := range varsToDelete {
+		ctx.DeleteVariable(v.Scope(), v.Name())
+	}
+	must.M(checkpoint.Save())
+	fmt.Printf("%d deleted vars under scopes %v, new checkpoint saved.\n", len(varsToDelete), scopes)
+}
+
+func PerturbVars(checkpointPath string) {
+	backend := must.M1(simplego.New(""))
+	ctx := context.New()
+	checkpoint := must.M1(checkpoints.Build(ctx).
+		Dir(checkpointPath).Keep(-1).Immediate().Done())
+	var numUpdates int
+	for v := range ctx.IterVariables() {
+		if !v.Trainable || !(v.DType().IsFloat() || v.DType().IsComplex()) {
+			continue
+		}
+		newValue := context.ExecOnce(backend, ctx, func(ctx *context.Context, g *Graph) *Node {
+			value := v.ValueGraph(g)
+			perturbation := ctx.RandomUniform(g, value.Shape())
+			perturbation = MulScalar(perturbation, 2*(*flagPerturbVars))
+			perturbation = AddScalar(perturbation, -(*flagPerturbVars))
+			return Mul(value, perturbation)
+		})
+		v.SetValue(newValue)
+		numUpdates++
+	}
+	must.M(checkpoint.Save())
+	fmt.Printf("%d variables updated new checkpoint saved.\n", numUpdates)
+}

--- a/cmd/gomlx_checkpoints/variables_test.go
+++ b/cmd/gomlx_checkpoints/variables_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gomlx/gomlx/ml/context"
+	"github.com/gomlx/gomlx/ml/context/checkpoints"
+	"github.com/gomlx/gomlx/types/tensors"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestPerturbVars(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test_perturb")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create context and add variable.
+	ctx := context.New()
+	_ = ctx.VariableWithValue("test_var", tensors.FromScalarAndDimensions(1.0, 100, 100))
+	checkpoint, err := checkpoints.Build(ctx).Dir(tmpDir).Keep(-1).Done()
+	require.NoError(t, err)
+	require.NoError(t, checkpoint.Save())
+
+	// Perturb variables.
+	const perturbAmount = 0.1
+	PerturbVars(tmpDir, perturbAmount)
+
+	// Load and check perturbed values.
+	newCtx := context.New()
+	_, err = checkpoints.Build(newCtx).Dir(tmpDir).Immediate().Done()
+	require.NoError(t, err)
+	perturbedT := newCtx.GetVariable("test_var").Value()
+	var lowerCount, higherCount int
+	tensors.ConstFlatData(perturbedT, func(flat []float64) {
+		for _, v := range flat {
+			require.Greater(t, v, 1.0-perturbAmount)
+			require.Less(t, v, 1.0+perturbAmount)
+			if v < 1.0 {
+				lowerCount++
+			} else if v > 1.0 {
+				higherCount++
+			}
+		}
+	})
+	var totalCount = perturbedT.Shape().Size()
+	fmt.Printf("Total count: %d\n", totalCount)
+	fmt.Printf("Lower count: %d\n", lowerCount)
+	fmt.Printf("Higher count: %d\n", higherCount)
+	// At least 99% of the values must have changed.
+	require.Greater(t, lowerCount+higherCount, 99*totalCount/100)
+
+	// The difference of values moving up and down < 10%.
+	diffCount := lowerCount - higherCount
+	if diffCount < 0 {
+		diffCount = -diffCount
+	}
+	require.Less(t, diffCount, 10*totalCount/100)
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@
   * New `AdamConfig.WithBackoffSteps()` (or the hyperparameter `adam_backoff`) that prevents gradient steps
     from being taken until the given number of steps has executed. This allows a better estimate (moving average) of
     the gradients ("momentum") and their variances to be calculated before applying them. 
+* Package `context`:
+  * Added `Variable.DType()`.
 
 # v0.21.0: 2025/07/01 🌞 Summer Edition 🌞
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # GoMLX changelog
 
 # Next
+
 * Package `backends`:
   * Method **`New()` will return an error (as opposed to panic)**.
     The temporarily `NewOrErr` was marked as deprecated, use `New` instead.
@@ -10,6 +11,8 @@
     the gradients ("momentum") and their variances to be calculated before applying them. 
 * Package `context`:
   * Added `Variable.DType()`.
+* `gomlx_checkpoints`:
+  * Added `-perturb`.
 
 # v0.21.0: 2025/07/01 🌞 Summer Edition 🌞
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,12 @@
 * Package `optimizers`:
   * New `AdamConfig.WithBackoffSteps()` (or the hyperparameter `adam_backoff`) that prevents gradient steps
     from being taken until the given number of steps has executed. This allows a better estimate (moving average) of
-    the gradients ("momentum") and their variances to be calculated before applying them. 
+    the gradients ("momentum") and their variances to be calculated before applying them.
+  * New `optimizers.ParamAdamBeta1` and `optimizers.ParamAdamBeta2` hyperparameters to control Adam beta1 and beta2
+    hyperparameters.
 * Package `context`:
   * Added `Variable.DType()`.
+  * Variable `#rngstate` marked as non-trainable during creation.
 * `gomlx_checkpoints`:
   * Added `-perturb`.
 

--- a/ml/context/random.go
+++ b/ml/context/random.go
@@ -36,6 +36,7 @@ func (ctx *Context) getRngStateVar() *Variable {
 		}
 		rngStateVar = ctx.InAbsPath(RootScope).Checked(false).
 			VariableWithValue(RngStateVariableName, randomState).SetTrainable(false)
+		rngStateVar.SetTrainable(false)
 	} else if rngStateVar.Trainable {
 		klog.Warningf("Variable %q was trainable, marking it as non-trainable.", rngStateVar.ParameterName())
 		rngStateVar.SetTrainable(false)

--- a/ml/context/variable.go
+++ b/ml/context/variable.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gomlx/gomlx/types/shapes"
 	"github.com/gomlx/gomlx/types/tensors"
 	"github.com/gomlx/gomlx/types/xsync"
+	"github.com/gomlx/gopjrt/dtypes"
 )
 
 // Variable is a value shared among computation graphs, or across multiple executions of the same graph.
@@ -144,6 +145,14 @@ func (v *Variable) Shape() shapes.Shape {
 		return shapes.Shape{}
 	}
 	return v.shape
+}
+
+// DType returns the variable DType.
+func (v *Variable) DType() dtypes.DType {
+	if v == nil {
+		return dtypes.InvalidDType
+	}
+	return v.shape.DType
 }
 
 // VariableParameterPrefix is used to prefix Graph parameter names for variablesMap.

--- a/ml/train/optimizers/adam.go
+++ b/ml/train/optimizers/adam.go
@@ -47,6 +47,14 @@ const (
 	// ParamAdamWeightDecay defaults to 0.0. See AdamConfig.WeightDecay.
 	ParamAdamWeightDecay = "adam_weight_decay"
 
+	// ParamAdamBeta1 is the moving average coefficient for the gradient (momentum), the numerator.
+	// The default value is 0.9
+	ParamAdamBeta1 = "adam_beta1"
+
+	// ParamAdamBeta2 is the moving average coefficient for the variance, the denominator.
+	// The default value is 0.999
+	ParamAdamBeta2 = "adam_beta2"
+
 	// ParamAdamBackoffSteps default to 0. Values > 0 prevents any gradient steps to be taken
 	// for those many steps, to allow a better estimate of the momentum and variance.
 	// See AdamConfig.WithBackoffSteps.
@@ -130,6 +138,8 @@ func (c *AdamConfig) FromContext(ctx *context.Context) *AdamConfig {
 		c.DType(dtype)
 	}
 	c.WeightDecay(context.GetParamOr(ctx, ParamAdamWeightDecay, 0.0))
+	c.beta1 = context.GetParamOr(ctx, ParamAdamBeta1, 0.9)
+	c.beta2 = context.GetParamOr(ctx, ParamAdamBeta2, 0.999)
 	return c
 }
 


### PR DESCRIPTION
* Package `backends`:
  * Method **`New()` will return an error (as opposed to panic)**.
    The temporarily `NewOrErr` was marked as deprecated, use `New` instead.
* Package `optimizers`:
  * New `AdamConfig.WithBackoffSteps()` (or the hyperparameter `adam_backoff`) that prevents gradient steps
    from being taken until the given number of steps has executed. This allows a better estimate (moving average) of
    the gradients ("momentum") and their variances to be calculated before applying them.
  * New `optimizers.ParamAdamBeta1` and `optimizers.ParamAdamBeta2` hyperparameters to control Adam beta1 and beta2
    hyperparameters.
* Package `context`:
  * Added `Variable.DType()`.
  * Variable `#rngstate` marked as non-trainable during creation.
* `gomlx_checkpoints`:
  * Added `-perturb`.
