### PR TITLE
Remove op `Broadcast` from backends API: not needed.

### DIFF
--- a/backends/notimplemented/gen_standard_ops.go
+++ b/backends/notimplemented/gen_standard_ops.go
@@ -30,7 +30,7 @@ func (b Builder) Add(lhs backends.Op, rhs backends.Op) (backends.Op, error) {
 // Examples:
 //
 //	ArgMinMax(x={{2, 0, 7}, {-3, 4, 2}}, axis=1, isMin=true) -> {1, 0}  // (it chooses the 0 and the -3)
-//	ArgMinMax(x={{2, 0, 7}, {-3, 4, 2}}, axis=0, isMin=false) -> {0, 1, 0} // (it choose the 2, 4, and 7)
+//	ArgMinMax(x={{2, 0, 7}, {-3, 4, 2}}, axis=0, isMin=false) -> {0, 1, 0} // (it chooses the 2, 4, and 7)
 func (b Builder) ArgMinMax(x backends.Op, axis int, outputDType dtypes.DType, isMin bool) (backends.Op, error) {
 	return nil, b.baseErrFn(backends.OpTypeArgMinMax)
 }
@@ -77,19 +77,6 @@ func (b Builder) BitwiseOr(lhs backends.Op, rhs backends.Op) (backends.Op, error
 // BitwiseXor returns the element-wise bitwise XOR operator.
 func (b Builder) BitwiseXor(lhs backends.Op, rhs backends.Op) (backends.Op, error) {
 	return nil, b.baseErrFn(backends.OpTypeBitwiseXor)
-}
-
-// Broadcast prefixes dimensions to an array by duplicating the data in the array.
-// See BroadcastInDim for a broadcast in between the axes.
-// The new dimensions dims are inserted on the left, i.e., if
-// prefixDims has values `{a0, ..., aN}` and the operand shape
-// has dimensions {b0, ..., bM}, then the shape of the output has
-// dimensions {a0, ..., aN, b0, ..., bM}.
-// The new dimensions id into copies of the operand, i.e.
-//
-//	output[i0, ..., iN, j0, ..., jM] = operand[j0, ..., jM]
-func (b Builder) Broadcast(x backends.Op, prefixDims ...int) (backends.Op, error) {
-	return nil, b.baseErrFn(backends.OpTypeBroadcast)
 }
 
 // BroadcastInDim broadcasts x to an output with the given shape.

--- a/backends/stablehlo/ops.go
+++ b/backends/stablehlo/ops.go
@@ -63,33 +63,6 @@ func (b *Builder) BroadcastInDim(x backends.Op, outputShape shapes.Shape, broadc
 	return b.newNode(value), nil
 }
 
-// Broadcast implements the backends.Builder interface.
-func (b *Builder) Broadcast(x backends.Op, prefixDims ...int) (backends.Op, error) {
-	nodes, err := b.verifyAndCastValues("Broadcast", x)
-	if err != nil {
-		return nil, err
-	}
-	if len(prefixDims) == 0 {
-		return x, nil
-	}
-
-	xNode := nodes[0]
-	shape := xNode.shape
-	newDims := make([]int, shape.Rank()+len(prefixDims))
-	copy(newDims, prefixDims)
-	copy(newDims[len(prefixDims):], shape.Dimensions)
-	outputShape := shapes.Make(shape.DType, newDims...)
-	broadcastAxes := make([]int, shape.Rank())
-	for i := range shape.Rank() {
-		broadcastAxes[i] = i + len(prefixDims)
-	}
-	value, err := stablehlo.BroadcastInDim(xNode.value, ShapeToStableHLO(outputShape), broadcastAxes)
-	if err != nil {
-		return nil, err
-	}
-	return b.newNode(value), nil
-}
-
 // Iota implements backends.Builder interface.
 func (b *Builder) Iota(shape shapes.Shape, iotaAxis int) (backends.Op, error) {
 	value, err := b.fn.Iota(ShapeToStableHLO(shape), iotaAxis)

--- a/backends/standard_ops.go
+++ b/backends/standard_ops.go
@@ -90,16 +90,6 @@ type StandardOps interface {
 	// BitwiseXor returns the element-wise bitwise XOR operator.
 	BitwiseXor(lhs, rhs Op) (Op, error)
 
-	// Broadcast prefixes dimensions to an array by duplicating the data in the array.
-	// See BroadcastInDim for a broadcast in between the axes.
-	// The new dimensions dims are inserted on the left, i.e., if
-	// prefixDims has values `{a0, ..., aN}` and the operand shape
-	// has dimensions {b0, ..., bM}, then the shape of the output has
-	// dimensions {a0, ..., aN, b0, ..., bM}.
-	// The new dimensions id into copies of the operand, i.e.
-	// 	output[i0, ..., iN, j0, ..., jM] = operand[j0, ..., jM]
-	Broadcast(x Op, prefixDims ...int) (Op, error)
-
 	// BroadcastInDim broadcasts x to an output with the given shape.
 	// broadcastAxes has an output axes value for each x axes (len(broadcastAxes) == x.Shape.Rank()).
 	// The i-th axis of x is mapped to the broadcastAxes[i]-th dimension of the output.

--- a/cmd/gomlx_checkpoints/go.mod
+++ b/cmd/gomlx_checkpoints/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gomlx/exceptions v0.0.3 // indirect
-	github.com/gomlx/stablehlo v0.0.1 // indirect
+	github.com/gomlx/stablehlo v0.0.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/cmd/gomlx_checkpoints/go.sum
+++ b/cmd/gomlx_checkpoints/go.sum
@@ -32,6 +32,7 @@ github.com/gomlx/gopjrt v0.8.1 h1:Zks8sRqnYFMugQsF9nb1Q9E5qEHoZHCn5HPijQgfliw=
 github.com/gomlx/gopjrt v0.8.1/go.mod h1:PFS2tITbe94NfjY1mZkhCpGogn8R0bKi90aIr3g8dHw=
 github.com/gomlx/stablehlo v0.0.1 h1:j+euaFYW74Z78gOMM7Bn2Cv7sLBiXXRywZBo1qaCLEA=
 github.com/gomlx/stablehlo v0.0.1/go.mod h1:Lfc0mOGeR3NzeXMk3zeuKvegUC7UbG3gSjy32Rs9FRs=
+github.com/gomlx/stablehlo v0.0.2/go.mod h1:Lfc0mOGeR3NzeXMk3zeuKvegUC7UbG3gSjy32Rs9FRs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GoMLX changelog
 
+# Next:
+
+* Package `backends`:
+  * Removed op `Broadcast`: it was not needed, since `BroadcastInDim` is a superset.
+* Package `graph`:
+  * Backprop of `BroadcastPrefix` was not defined. Now that is uses `BroadcastInDim` instead, it works.
+
 # v0.23.0: 2025/09/21: beta `stablehlo` backend release
 
 * Package `shapes`:

--- a/graph/nodetype_enumer.go
+++ b/graph/nodetype_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _NodeTypeName = "InvalidSplitNodeAbsAddArgMinMaxBatchNormForInferenceBatchNormForTrainingBatchNormGradientBitCountBitcastBitwiseAndBitwiseNotBitwiseOrBitwiseXorBroadcastBroadcastInDimCeilClampClzComplexConcatenateConjConstantConvGeneralConvertDTypeCosDivDotDotGeneralDynamicSliceDynamicUpdateSliceEqualEqualTotalOrderErfExpExpm1FFTFloorGatherGreaterOrEqualGreaterOrEqualTotalOrderGreaterThanGreaterThanTotalOrderIdentityImagIotaIsFiniteIsNaNLessOrEqualLessOrEqualTotalOrderLessThanLessThanTotalOrderLogLog1pLogicalAndLogicalNotLogicalOrLogicalXorLogisticMaxMinMulNegNotEqualNotEqualTotalOrderPadParameterPowRealReduceBitwiseAndReduceBitwiseOrReduceBitwiseXorReduceLogicalAndReduceLogicalOrReduceLogicalXorReduceMaxReduceMinReduceProductReduceSumReduceWindowRemReshapeReverseRngBitGeneratorRoundRsqrtScatterMaxScatterMinScatterSumSelectAndScatterMaxSelectAndScatterMinShiftLeftShiftRightArithmeticShiftRightLogicalSignSinSliceSqrtSubTanhTransposeWhere"
+const _NodeTypeName = "InvalidSplitNodeAbsAddArgMinMaxBatchNormForInferenceBatchNormForTrainingBatchNormGradientBitCountBitcastBitwiseAndBitwiseNotBitwiseOrBitwiseXorBroadcastInDimCeilClampClzComplexConcatenateConjConstantConvGeneralConvertDTypeCosDivDotDotGeneralDynamicSliceDynamicUpdateSliceEqualEqualTotalOrderErfExpExpm1FFTFloorGatherGreaterOrEqualGreaterOrEqualTotalOrderGreaterThanGreaterThanTotalOrderIdentityImagIotaIsFiniteIsNaNLessOrEqualLessOrEqualTotalOrderLessThanLessThanTotalOrderLogLog1pLogicalAndLogicalNotLogicalOrLogicalXorLogisticMaxMinMulNegNotEqualNotEqualTotalOrderPadParameterPowRealReduceBitwiseAndReduceBitwiseOrReduceBitwiseXorReduceLogicalAndReduceLogicalOrReduceLogicalXorReduceMaxReduceMinReduceProductReduceSumReduceWindowRemReshapeReverseRngBitGeneratorRoundRsqrtScatterMaxScatterMinScatterSumSelectAndScatterMaxSelectAndScatterMinShiftLeftShiftRightArithmeticShiftRightLogicalSignSinSliceSqrtSubTanhTransposeWhere"
 
-var _NodeTypeIndex = [...]uint16{0, 7, 16, 19, 22, 31, 52, 72, 89, 97, 104, 114, 124, 133, 143, 152, 166, 170, 175, 178, 185, 196, 200, 208, 219, 231, 234, 237, 240, 250, 262, 280, 285, 300, 303, 306, 311, 314, 319, 325, 339, 363, 374, 395, 403, 407, 411, 419, 424, 435, 456, 464, 482, 485, 490, 500, 510, 519, 529, 537, 540, 543, 546, 549, 557, 575, 578, 587, 590, 594, 610, 625, 641, 657, 672, 688, 697, 706, 719, 728, 740, 743, 750, 757, 772, 777, 782, 792, 802, 812, 831, 850, 859, 879, 896, 900, 903, 908, 912, 915, 919, 928, 933}
+var _NodeTypeIndex = [...]uint16{0, 7, 16, 19, 22, 31, 52, 72, 89, 97, 104, 114, 124, 133, 143, 157, 161, 166, 169, 176, 187, 191, 199, 210, 222, 225, 228, 231, 241, 253, 271, 276, 291, 294, 297, 302, 305, 310, 316, 330, 354, 365, 386, 394, 398, 402, 410, 415, 426, 447, 455, 473, 476, 481, 491, 501, 510, 520, 528, 531, 534, 537, 540, 548, 566, 569, 578, 581, 585, 601, 616, 632, 648, 663, 679, 688, 697, 710, 719, 731, 734, 741, 748, 763, 768, 773, 783, 793, 803, 822, 841, 850, 870, 887, 891, 894, 899, 903, 906, 910, 919, 924}
 
-const _NodeTypeLowerName = "invalidsplitnodeabsaddargminmaxbatchnormforinferencebatchnormfortrainingbatchnormgradientbitcountbitcastbitwiseandbitwisenotbitwiseorbitwisexorbroadcastbroadcastindimceilclampclzcomplexconcatenateconjconstantconvgeneralconvertdtypecosdivdotdotgeneraldynamicslicedynamicupdatesliceequalequaltotalordererfexpexpm1fftfloorgathergreaterorequalgreaterorequaltotalordergreaterthangreaterthantotalorderidentityimagiotaisfiniteisnanlessorequallessorequaltotalorderlessthanlessthantotalorderloglog1plogicalandlogicalnotlogicalorlogicalxorlogisticmaxminmulnegnotequalnotequaltotalorderpadparameterpowrealreducebitwiseandreducebitwiseorreducebitwisexorreducelogicalandreducelogicalorreducelogicalxorreducemaxreduceminreduceproductreducesumreducewindowremreshapereverserngbitgeneratorroundrsqrtscattermaxscatterminscattersumselectandscattermaxselectandscatterminshiftleftshiftrightarithmeticshiftrightlogicalsignsinslicesqrtsubtanhtransposewhere"
+const _NodeTypeLowerName = "invalidsplitnodeabsaddargminmaxbatchnormforinferencebatchnormfortrainingbatchnormgradientbitcountbitcastbitwiseandbitwisenotbitwiseorbitwisexorbroadcastindimceilclampclzcomplexconcatenateconjconstantconvgeneralconvertdtypecosdivdotdotgeneraldynamicslicedynamicupdatesliceequalequaltotalordererfexpexpm1fftfloorgathergreaterorequalgreaterorequaltotalordergreaterthangreaterthantotalorderidentityimagiotaisfiniteisnanlessorequallessorequaltotalorderlessthanlessthantotalorderloglog1plogicalandlogicalnotlogicalorlogicalxorlogisticmaxminmulnegnotequalnotequaltotalorderpadparameterpowrealreducebitwiseandreducebitwiseorreducebitwisexorreducelogicalandreducelogicalorreducelogicalxorreducemaxreduceminreduceproductreducesumreducewindowremreshapereverserngbitgeneratorroundrsqrtscattermaxscatterminscattersumselectandscattermaxselectandscatterminshiftleftshiftrightarithmeticshiftrightlogicalsignsinslicesqrtsubtanhtransposewhere"
 
 func (i NodeType) String() string {
 	if i < 0 || i >= NodeType(len(_NodeTypeIndex)-1) {
@@ -43,97 +43,96 @@ func _NodeTypeNoOp() {
 	_ = x[NodeTypeBitwiseNot-(11)]
 	_ = x[NodeTypeBitwiseOr-(12)]
 	_ = x[NodeTypeBitwiseXor-(13)]
-	_ = x[NodeTypeBroadcast-(14)]
-	_ = x[NodeTypeBroadcastInDim-(15)]
-	_ = x[NodeTypeCeil-(16)]
-	_ = x[NodeTypeClamp-(17)]
-	_ = x[NodeTypeClz-(18)]
-	_ = x[NodeTypeComplex-(19)]
-	_ = x[NodeTypeConcatenate-(20)]
-	_ = x[NodeTypeConj-(21)]
-	_ = x[NodeTypeConstant-(22)]
-	_ = x[NodeTypeConvGeneral-(23)]
-	_ = x[NodeTypeConvertDType-(24)]
-	_ = x[NodeTypeCos-(25)]
-	_ = x[NodeTypeDiv-(26)]
-	_ = x[NodeTypeDot-(27)]
-	_ = x[NodeTypeDotGeneral-(28)]
-	_ = x[NodeTypeDynamicSlice-(29)]
-	_ = x[NodeTypeDynamicUpdateSlice-(30)]
-	_ = x[NodeTypeEqual-(31)]
-	_ = x[NodeTypeEqualTotalOrder-(32)]
-	_ = x[NodeTypeErf-(33)]
-	_ = x[NodeTypeExp-(34)]
-	_ = x[NodeTypeExpm1-(35)]
-	_ = x[NodeTypeFFT-(36)]
-	_ = x[NodeTypeFloor-(37)]
-	_ = x[NodeTypeGather-(38)]
-	_ = x[NodeTypeGreaterOrEqual-(39)]
-	_ = x[NodeTypeGreaterOrEqualTotalOrder-(40)]
-	_ = x[NodeTypeGreaterThan-(41)]
-	_ = x[NodeTypeGreaterThanTotalOrder-(42)]
-	_ = x[NodeTypeIdentity-(43)]
-	_ = x[NodeTypeImag-(44)]
-	_ = x[NodeTypeIota-(45)]
-	_ = x[NodeTypeIsFinite-(46)]
-	_ = x[NodeTypeIsNaN-(47)]
-	_ = x[NodeTypeLessOrEqual-(48)]
-	_ = x[NodeTypeLessOrEqualTotalOrder-(49)]
-	_ = x[NodeTypeLessThan-(50)]
-	_ = x[NodeTypeLessThanTotalOrder-(51)]
-	_ = x[NodeTypeLog-(52)]
-	_ = x[NodeTypeLog1p-(53)]
-	_ = x[NodeTypeLogicalAnd-(54)]
-	_ = x[NodeTypeLogicalNot-(55)]
-	_ = x[NodeTypeLogicalOr-(56)]
-	_ = x[NodeTypeLogicalXor-(57)]
-	_ = x[NodeTypeLogistic-(58)]
-	_ = x[NodeTypeMax-(59)]
-	_ = x[NodeTypeMin-(60)]
-	_ = x[NodeTypeMul-(61)]
-	_ = x[NodeTypeNeg-(62)]
-	_ = x[NodeTypeNotEqual-(63)]
-	_ = x[NodeTypeNotEqualTotalOrder-(64)]
-	_ = x[NodeTypePad-(65)]
-	_ = x[NodeTypeParameter-(66)]
-	_ = x[NodeTypePow-(67)]
-	_ = x[NodeTypeReal-(68)]
-	_ = x[NodeTypeReduceBitwiseAnd-(69)]
-	_ = x[NodeTypeReduceBitwiseOr-(70)]
-	_ = x[NodeTypeReduceBitwiseXor-(71)]
-	_ = x[NodeTypeReduceLogicalAnd-(72)]
-	_ = x[NodeTypeReduceLogicalOr-(73)]
-	_ = x[NodeTypeReduceLogicalXor-(74)]
-	_ = x[NodeTypeReduceMax-(75)]
-	_ = x[NodeTypeReduceMin-(76)]
-	_ = x[NodeTypeReduceProduct-(77)]
-	_ = x[NodeTypeReduceSum-(78)]
-	_ = x[NodeTypeReduceWindow-(79)]
-	_ = x[NodeTypeRem-(80)]
-	_ = x[NodeTypeReshape-(81)]
-	_ = x[NodeTypeReverse-(82)]
-	_ = x[NodeTypeRngBitGenerator-(83)]
-	_ = x[NodeTypeRound-(84)]
-	_ = x[NodeTypeRsqrt-(85)]
-	_ = x[NodeTypeScatterMax-(86)]
-	_ = x[NodeTypeScatterMin-(87)]
-	_ = x[NodeTypeScatterSum-(88)]
-	_ = x[NodeTypeSelectAndScatterMax-(89)]
-	_ = x[NodeTypeSelectAndScatterMin-(90)]
-	_ = x[NodeTypeShiftLeft-(91)]
-	_ = x[NodeTypeShiftRightArithmetic-(92)]
-	_ = x[NodeTypeShiftRightLogical-(93)]
-	_ = x[NodeTypeSign-(94)]
-	_ = x[NodeTypeSin-(95)]
-	_ = x[NodeTypeSlice-(96)]
-	_ = x[NodeTypeSqrt-(97)]
-	_ = x[NodeTypeSub-(98)]
-	_ = x[NodeTypeTanh-(99)]
-	_ = x[NodeTypeTranspose-(100)]
-	_ = x[NodeTypeWhere-(101)]
+	_ = x[NodeTypeBroadcastInDim-(14)]
+	_ = x[NodeTypeCeil-(15)]
+	_ = x[NodeTypeClamp-(16)]
+	_ = x[NodeTypeClz-(17)]
+	_ = x[NodeTypeComplex-(18)]
+	_ = x[NodeTypeConcatenate-(19)]
+	_ = x[NodeTypeConj-(20)]
+	_ = x[NodeTypeConstant-(21)]
+	_ = x[NodeTypeConvGeneral-(22)]
+	_ = x[NodeTypeConvertDType-(23)]
+	_ = x[NodeTypeCos-(24)]
+	_ = x[NodeTypeDiv-(25)]
+	_ = x[NodeTypeDot-(26)]
+	_ = x[NodeTypeDotGeneral-(27)]
+	_ = x[NodeTypeDynamicSlice-(28)]
+	_ = x[NodeTypeDynamicUpdateSlice-(29)]
+	_ = x[NodeTypeEqual-(30)]
+	_ = x[NodeTypeEqualTotalOrder-(31)]
+	_ = x[NodeTypeErf-(32)]
+	_ = x[NodeTypeExp-(33)]
+	_ = x[NodeTypeExpm1-(34)]
+	_ = x[NodeTypeFFT-(35)]
+	_ = x[NodeTypeFloor-(36)]
+	_ = x[NodeTypeGather-(37)]
+	_ = x[NodeTypeGreaterOrEqual-(38)]
+	_ = x[NodeTypeGreaterOrEqualTotalOrder-(39)]
+	_ = x[NodeTypeGreaterThan-(40)]
+	_ = x[NodeTypeGreaterThanTotalOrder-(41)]
+	_ = x[NodeTypeIdentity-(42)]
+	_ = x[NodeTypeImag-(43)]
+	_ = x[NodeTypeIota-(44)]
+	_ = x[NodeTypeIsFinite-(45)]
+	_ = x[NodeTypeIsNaN-(46)]
+	_ = x[NodeTypeLessOrEqual-(47)]
+	_ = x[NodeTypeLessOrEqualTotalOrder-(48)]
+	_ = x[NodeTypeLessThan-(49)]
+	_ = x[NodeTypeLessThanTotalOrder-(50)]
+	_ = x[NodeTypeLog-(51)]
+	_ = x[NodeTypeLog1p-(52)]
+	_ = x[NodeTypeLogicalAnd-(53)]
+	_ = x[NodeTypeLogicalNot-(54)]
+	_ = x[NodeTypeLogicalOr-(55)]
+	_ = x[NodeTypeLogicalXor-(56)]
+	_ = x[NodeTypeLogistic-(57)]
+	_ = x[NodeTypeMax-(58)]
+	_ = x[NodeTypeMin-(59)]
+	_ = x[NodeTypeMul-(60)]
+	_ = x[NodeTypeNeg-(61)]
+	_ = x[NodeTypeNotEqual-(62)]
+	_ = x[NodeTypeNotEqualTotalOrder-(63)]
+	_ = x[NodeTypePad-(64)]
+	_ = x[NodeTypeParameter-(65)]
+	_ = x[NodeTypePow-(66)]
+	_ = x[NodeTypeReal-(67)]
+	_ = x[NodeTypeReduceBitwiseAnd-(68)]
+	_ = x[NodeTypeReduceBitwiseOr-(69)]
+	_ = x[NodeTypeReduceBitwiseXor-(70)]
+	_ = x[NodeTypeReduceLogicalAnd-(71)]
+	_ = x[NodeTypeReduceLogicalOr-(72)]
+	_ = x[NodeTypeReduceLogicalXor-(73)]
+	_ = x[NodeTypeReduceMax-(74)]
+	_ = x[NodeTypeReduceMin-(75)]
+	_ = x[NodeTypeReduceProduct-(76)]
+	_ = x[NodeTypeReduceSum-(77)]
+	_ = x[NodeTypeReduceWindow-(78)]
+	_ = x[NodeTypeRem-(79)]
+	_ = x[NodeTypeReshape-(80)]
+	_ = x[NodeTypeReverse-(81)]
+	_ = x[NodeTypeRngBitGenerator-(82)]
+	_ = x[NodeTypeRound-(83)]
+	_ = x[NodeTypeRsqrt-(84)]
+	_ = x[NodeTypeScatterMax-(85)]
+	_ = x[NodeTypeScatterMin-(86)]
+	_ = x[NodeTypeScatterSum-(87)]
+	_ = x[NodeTypeSelectAndScatterMax-(88)]
+	_ = x[NodeTypeSelectAndScatterMin-(89)]
+	_ = x[NodeTypeShiftLeft-(90)]
+	_ = x[NodeTypeShiftRightArithmetic-(91)]
+	_ = x[NodeTypeShiftRightLogical-(92)]
+	_ = x[NodeTypeSign-(93)]
+	_ = x[NodeTypeSin-(94)]
+	_ = x[NodeTypeSlice-(95)]
+	_ = x[NodeTypeSqrt-(96)]
+	_ = x[NodeTypeSub-(97)]
+	_ = x[NodeTypeTanh-(98)]
+	_ = x[NodeTypeTranspose-(99)]
+	_ = x[NodeTypeWhere-(100)]
 }
 
-var _NodeTypeValues = []NodeType{NodeTypeInvalid, NodeTypeSplitNode, NodeTypeAbs, NodeTypeAdd, NodeTypeArgMinMax, NodeTypeBatchNormForInference, NodeTypeBatchNormForTraining, NodeTypeBatchNormGradient, NodeTypeBitCount, NodeTypeBitcast, NodeTypeBitwiseAnd, NodeTypeBitwiseNot, NodeTypeBitwiseOr, NodeTypeBitwiseXor, NodeTypeBroadcast, NodeTypeBroadcastInDim, NodeTypeCeil, NodeTypeClamp, NodeTypeClz, NodeTypeComplex, NodeTypeConcatenate, NodeTypeConj, NodeTypeConstant, NodeTypeConvGeneral, NodeTypeConvertDType, NodeTypeCos, NodeTypeDiv, NodeTypeDot, NodeTypeDotGeneral, NodeTypeDynamicSlice, NodeTypeDynamicUpdateSlice, NodeTypeEqual, NodeTypeEqualTotalOrder, NodeTypeErf, NodeTypeExp, NodeTypeExpm1, NodeTypeFFT, NodeTypeFloor, NodeTypeGather, NodeTypeGreaterOrEqual, NodeTypeGreaterOrEqualTotalOrder, NodeTypeGreaterThan, NodeTypeGreaterThanTotalOrder, NodeTypeIdentity, NodeTypeImag, NodeTypeIota, NodeTypeIsFinite, NodeTypeIsNaN, NodeTypeLessOrEqual, NodeTypeLessOrEqualTotalOrder, NodeTypeLessThan, NodeTypeLessThanTotalOrder, NodeTypeLog, NodeTypeLog1p, NodeTypeLogicalAnd, NodeTypeLogicalNot, NodeTypeLogicalOr, NodeTypeLogicalXor, NodeTypeLogistic, NodeTypeMax, NodeTypeMin, NodeTypeMul, NodeTypeNeg, NodeTypeNotEqual, NodeTypeNotEqualTotalOrder, NodeTypePad, NodeTypeParameter, NodeTypePow, NodeTypeReal, NodeTypeReduceBitwiseAnd, NodeTypeReduceBitwiseOr, NodeTypeReduceBitwiseXor, NodeTypeReduceLogicalAnd, NodeTypeReduceLogicalOr, NodeTypeReduceLogicalXor, NodeTypeReduceMax, NodeTypeReduceMin, NodeTypeReduceProduct, NodeTypeReduceSum, NodeTypeReduceWindow, NodeTypeRem, NodeTypeReshape, NodeTypeReverse, NodeTypeRngBitGenerator, NodeTypeRound, NodeTypeRsqrt, NodeTypeScatterMax, NodeTypeScatterMin, NodeTypeScatterSum, NodeTypeSelectAndScatterMax, NodeTypeSelectAndScatterMin, NodeTypeShiftLeft, NodeTypeShiftRightArithmetic, NodeTypeShiftRightLogical, NodeTypeSign, NodeTypeSin, NodeTypeSlice, NodeTypeSqrt, NodeTypeSub, NodeTypeTanh, NodeTypeTranspose, NodeTypeWhere}
+var _NodeTypeValues = []NodeType{NodeTypeInvalid, NodeTypeSplitNode, NodeTypeAbs, NodeTypeAdd, NodeTypeArgMinMax, NodeTypeBatchNormForInference, NodeTypeBatchNormForTraining, NodeTypeBatchNormGradient, NodeTypeBitCount, NodeTypeBitcast, NodeTypeBitwiseAnd, NodeTypeBitwiseNot, NodeTypeBitwiseOr, NodeTypeBitwiseXor, NodeTypeBroadcastInDim, NodeTypeCeil, NodeTypeClamp, NodeTypeClz, NodeTypeComplex, NodeTypeConcatenate, NodeTypeConj, NodeTypeConstant, NodeTypeConvGeneral, NodeTypeConvertDType, NodeTypeCos, NodeTypeDiv, NodeTypeDot, NodeTypeDotGeneral, NodeTypeDynamicSlice, NodeTypeDynamicUpdateSlice, NodeTypeEqual, NodeTypeEqualTotalOrder, NodeTypeErf, NodeTypeExp, NodeTypeExpm1, NodeTypeFFT, NodeTypeFloor, NodeTypeGather, NodeTypeGreaterOrEqual, NodeTypeGreaterOrEqualTotalOrder, NodeTypeGreaterThan, NodeTypeGreaterThanTotalOrder, NodeTypeIdentity, NodeTypeImag, NodeTypeIota, NodeTypeIsFinite, NodeTypeIsNaN, NodeTypeLessOrEqual, NodeTypeLessOrEqualTotalOrder, NodeTypeLessThan, NodeTypeLessThanTotalOrder, NodeTypeLog, NodeTypeLog1p, NodeTypeLogicalAnd, NodeTypeLogicalNot, NodeTypeLogicalOr, NodeTypeLogicalXor, NodeTypeLogistic, NodeTypeMax, NodeTypeMin, NodeTypeMul, NodeTypeNeg, NodeTypeNotEqual, NodeTypeNotEqualTotalOrder, NodeTypePad, NodeTypeParameter, NodeTypePow, NodeTypeReal, NodeTypeReduceBitwiseAnd, NodeTypeReduceBitwiseOr, NodeTypeReduceBitwiseXor, NodeTypeReduceLogicalAnd, NodeTypeReduceLogicalOr, NodeTypeReduceLogicalXor, NodeTypeReduceMax, NodeTypeReduceMin, NodeTypeReduceProduct, NodeTypeReduceSum, NodeTypeReduceWindow, NodeTypeRem, NodeTypeReshape, NodeTypeReverse, NodeTypeRngBitGenerator, NodeTypeRound, NodeTypeRsqrt, NodeTypeScatterMax, NodeTypeScatterMin, NodeTypeScatterSum, NodeTypeSelectAndScatterMax, NodeTypeSelectAndScatterMin, NodeTypeShiftLeft, NodeTypeShiftRightArithmetic, NodeTypeShiftRightLogical, NodeTypeSign, NodeTypeSin, NodeTypeSlice, NodeTypeSqrt, NodeTypeSub, NodeTypeTanh, NodeTypeTranspose, NodeTypeWhere}
 
 var _NodeTypeNameToValueMap = map[string]NodeType{
 	_NodeTypeName[0:7]:          NodeTypeInvalid,
@@ -164,182 +163,180 @@ var _NodeTypeNameToValueMap = map[string]NodeType{
 	_NodeTypeLowerName[124:133]: NodeTypeBitwiseOr,
 	_NodeTypeName[133:143]:      NodeTypeBitwiseXor,
 	_NodeTypeLowerName[133:143]: NodeTypeBitwiseXor,
-	_NodeTypeName[143:152]:      NodeTypeBroadcast,
-	_NodeTypeLowerName[143:152]: NodeTypeBroadcast,
-	_NodeTypeName[152:166]:      NodeTypeBroadcastInDim,
-	_NodeTypeLowerName[152:166]: NodeTypeBroadcastInDim,
-	_NodeTypeName[166:170]:      NodeTypeCeil,
-	_NodeTypeLowerName[166:170]: NodeTypeCeil,
-	_NodeTypeName[170:175]:      NodeTypeClamp,
-	_NodeTypeLowerName[170:175]: NodeTypeClamp,
-	_NodeTypeName[175:178]:      NodeTypeClz,
-	_NodeTypeLowerName[175:178]: NodeTypeClz,
-	_NodeTypeName[178:185]:      NodeTypeComplex,
-	_NodeTypeLowerName[178:185]: NodeTypeComplex,
-	_NodeTypeName[185:196]:      NodeTypeConcatenate,
-	_NodeTypeLowerName[185:196]: NodeTypeConcatenate,
-	_NodeTypeName[196:200]:      NodeTypeConj,
-	_NodeTypeLowerName[196:200]: NodeTypeConj,
-	_NodeTypeName[200:208]:      NodeTypeConstant,
-	_NodeTypeLowerName[200:208]: NodeTypeConstant,
-	_NodeTypeName[208:219]:      NodeTypeConvGeneral,
-	_NodeTypeLowerName[208:219]: NodeTypeConvGeneral,
-	_NodeTypeName[219:231]:      NodeTypeConvertDType,
-	_NodeTypeLowerName[219:231]: NodeTypeConvertDType,
-	_NodeTypeName[231:234]:      NodeTypeCos,
-	_NodeTypeLowerName[231:234]: NodeTypeCos,
-	_NodeTypeName[234:237]:      NodeTypeDiv,
-	_NodeTypeLowerName[234:237]: NodeTypeDiv,
-	_NodeTypeName[237:240]:      NodeTypeDot,
-	_NodeTypeLowerName[237:240]: NodeTypeDot,
-	_NodeTypeName[240:250]:      NodeTypeDotGeneral,
-	_NodeTypeLowerName[240:250]: NodeTypeDotGeneral,
-	_NodeTypeName[250:262]:      NodeTypeDynamicSlice,
-	_NodeTypeLowerName[250:262]: NodeTypeDynamicSlice,
-	_NodeTypeName[262:280]:      NodeTypeDynamicUpdateSlice,
-	_NodeTypeLowerName[262:280]: NodeTypeDynamicUpdateSlice,
-	_NodeTypeName[280:285]:      NodeTypeEqual,
-	_NodeTypeLowerName[280:285]: NodeTypeEqual,
-	_NodeTypeName[285:300]:      NodeTypeEqualTotalOrder,
-	_NodeTypeLowerName[285:300]: NodeTypeEqualTotalOrder,
-	_NodeTypeName[300:303]:      NodeTypeErf,
-	_NodeTypeLowerName[300:303]: NodeTypeErf,
-	_NodeTypeName[303:306]:      NodeTypeExp,
-	_NodeTypeLowerName[303:306]: NodeTypeExp,
-	_NodeTypeName[306:311]:      NodeTypeExpm1,
-	_NodeTypeLowerName[306:311]: NodeTypeExpm1,
-	_NodeTypeName[311:314]:      NodeTypeFFT,
-	_NodeTypeLowerName[311:314]: NodeTypeFFT,
-	_NodeTypeName[314:319]:      NodeTypeFloor,
-	_NodeTypeLowerName[314:319]: NodeTypeFloor,
-	_NodeTypeName[319:325]:      NodeTypeGather,
-	_NodeTypeLowerName[319:325]: NodeTypeGather,
-	_NodeTypeName[325:339]:      NodeTypeGreaterOrEqual,
-	_NodeTypeLowerName[325:339]: NodeTypeGreaterOrEqual,
-	_NodeTypeName[339:363]:      NodeTypeGreaterOrEqualTotalOrder,
-	_NodeTypeLowerName[339:363]: NodeTypeGreaterOrEqualTotalOrder,
-	_NodeTypeName[363:374]:      NodeTypeGreaterThan,
-	_NodeTypeLowerName[363:374]: NodeTypeGreaterThan,
-	_NodeTypeName[374:395]:      NodeTypeGreaterThanTotalOrder,
-	_NodeTypeLowerName[374:395]: NodeTypeGreaterThanTotalOrder,
-	_NodeTypeName[395:403]:      NodeTypeIdentity,
-	_NodeTypeLowerName[395:403]: NodeTypeIdentity,
-	_NodeTypeName[403:407]:      NodeTypeImag,
-	_NodeTypeLowerName[403:407]: NodeTypeImag,
-	_NodeTypeName[407:411]:      NodeTypeIota,
-	_NodeTypeLowerName[407:411]: NodeTypeIota,
-	_NodeTypeName[411:419]:      NodeTypeIsFinite,
-	_NodeTypeLowerName[411:419]: NodeTypeIsFinite,
-	_NodeTypeName[419:424]:      NodeTypeIsNaN,
-	_NodeTypeLowerName[419:424]: NodeTypeIsNaN,
-	_NodeTypeName[424:435]:      NodeTypeLessOrEqual,
-	_NodeTypeLowerName[424:435]: NodeTypeLessOrEqual,
-	_NodeTypeName[435:456]:      NodeTypeLessOrEqualTotalOrder,
-	_NodeTypeLowerName[435:456]: NodeTypeLessOrEqualTotalOrder,
-	_NodeTypeName[456:464]:      NodeTypeLessThan,
-	_NodeTypeLowerName[456:464]: NodeTypeLessThan,
-	_NodeTypeName[464:482]:      NodeTypeLessThanTotalOrder,
-	_NodeTypeLowerName[464:482]: NodeTypeLessThanTotalOrder,
-	_NodeTypeName[482:485]:      NodeTypeLog,
-	_NodeTypeLowerName[482:485]: NodeTypeLog,
-	_NodeTypeName[485:490]:      NodeTypeLog1p,
-	_NodeTypeLowerName[485:490]: NodeTypeLog1p,
-	_NodeTypeName[490:500]:      NodeTypeLogicalAnd,
-	_NodeTypeLowerName[490:500]: NodeTypeLogicalAnd,
-	_NodeTypeName[500:510]:      NodeTypeLogicalNot,
-	_NodeTypeLowerName[500:510]: NodeTypeLogicalNot,
-	_NodeTypeName[510:519]:      NodeTypeLogicalOr,
-	_NodeTypeLowerName[510:519]: NodeTypeLogicalOr,
-	_NodeTypeName[519:529]:      NodeTypeLogicalXor,
-	_NodeTypeLowerName[519:529]: NodeTypeLogicalXor,
-	_NodeTypeName[529:537]:      NodeTypeLogistic,
-	_NodeTypeLowerName[529:537]: NodeTypeLogistic,
-	_NodeTypeName[537:540]:      NodeTypeMax,
-	_NodeTypeLowerName[537:540]: NodeTypeMax,
-	_NodeTypeName[540:543]:      NodeTypeMin,
-	_NodeTypeLowerName[540:543]: NodeTypeMin,
-	_NodeTypeName[543:546]:      NodeTypeMul,
-	_NodeTypeLowerName[543:546]: NodeTypeMul,
-	_NodeTypeName[546:549]:      NodeTypeNeg,
-	_NodeTypeLowerName[546:549]: NodeTypeNeg,
-	_NodeTypeName[549:557]:      NodeTypeNotEqual,
-	_NodeTypeLowerName[549:557]: NodeTypeNotEqual,
-	_NodeTypeName[557:575]:      NodeTypeNotEqualTotalOrder,
-	_NodeTypeLowerName[557:575]: NodeTypeNotEqualTotalOrder,
-	_NodeTypeName[575:578]:      NodeTypePad,
-	_NodeTypeLowerName[575:578]: NodeTypePad,
-	_NodeTypeName[578:587]:      NodeTypeParameter,
-	_NodeTypeLowerName[578:587]: NodeTypeParameter,
-	_NodeTypeName[587:590]:      NodeTypePow,
-	_NodeTypeLowerName[587:590]: NodeTypePow,
-	_NodeTypeName[590:594]:      NodeTypeReal,
-	_NodeTypeLowerName[590:594]: NodeTypeReal,
-	_NodeTypeName[594:610]:      NodeTypeReduceBitwiseAnd,
-	_NodeTypeLowerName[594:610]: NodeTypeReduceBitwiseAnd,
-	_NodeTypeName[610:625]:      NodeTypeReduceBitwiseOr,
-	_NodeTypeLowerName[610:625]: NodeTypeReduceBitwiseOr,
-	_NodeTypeName[625:641]:      NodeTypeReduceBitwiseXor,
-	_NodeTypeLowerName[625:641]: NodeTypeReduceBitwiseXor,
-	_NodeTypeName[641:657]:      NodeTypeReduceLogicalAnd,
-	_NodeTypeLowerName[641:657]: NodeTypeReduceLogicalAnd,
-	_NodeTypeName[657:672]:      NodeTypeReduceLogicalOr,
-	_NodeTypeLowerName[657:672]: NodeTypeReduceLogicalOr,
-	_NodeTypeName[672:688]:      NodeTypeReduceLogicalXor,
-	_NodeTypeLowerName[672:688]: NodeTypeReduceLogicalXor,
-	_NodeTypeName[688:697]:      NodeTypeReduceMax,
-	_NodeTypeLowerName[688:697]: NodeTypeReduceMax,
-	_NodeTypeName[697:706]:      NodeTypeReduceMin,
-	_NodeTypeLowerName[697:706]: NodeTypeReduceMin,
-	_NodeTypeName[706:719]:      NodeTypeReduceProduct,
-	_NodeTypeLowerName[706:719]: NodeTypeReduceProduct,
-	_NodeTypeName[719:728]:      NodeTypeReduceSum,
-	_NodeTypeLowerName[719:728]: NodeTypeReduceSum,
-	_NodeTypeName[728:740]:      NodeTypeReduceWindow,
-	_NodeTypeLowerName[728:740]: NodeTypeReduceWindow,
-	_NodeTypeName[740:743]:      NodeTypeRem,
-	_NodeTypeLowerName[740:743]: NodeTypeRem,
-	_NodeTypeName[743:750]:      NodeTypeReshape,
-	_NodeTypeLowerName[743:750]: NodeTypeReshape,
-	_NodeTypeName[750:757]:      NodeTypeReverse,
-	_NodeTypeLowerName[750:757]: NodeTypeReverse,
-	_NodeTypeName[757:772]:      NodeTypeRngBitGenerator,
-	_NodeTypeLowerName[757:772]: NodeTypeRngBitGenerator,
-	_NodeTypeName[772:777]:      NodeTypeRound,
-	_NodeTypeLowerName[772:777]: NodeTypeRound,
-	_NodeTypeName[777:782]:      NodeTypeRsqrt,
-	_NodeTypeLowerName[777:782]: NodeTypeRsqrt,
-	_NodeTypeName[782:792]:      NodeTypeScatterMax,
-	_NodeTypeLowerName[782:792]: NodeTypeScatterMax,
-	_NodeTypeName[792:802]:      NodeTypeScatterMin,
-	_NodeTypeLowerName[792:802]: NodeTypeScatterMin,
-	_NodeTypeName[802:812]:      NodeTypeScatterSum,
-	_NodeTypeLowerName[802:812]: NodeTypeScatterSum,
-	_NodeTypeName[812:831]:      NodeTypeSelectAndScatterMax,
-	_NodeTypeLowerName[812:831]: NodeTypeSelectAndScatterMax,
-	_NodeTypeName[831:850]:      NodeTypeSelectAndScatterMin,
-	_NodeTypeLowerName[831:850]: NodeTypeSelectAndScatterMin,
-	_NodeTypeName[850:859]:      NodeTypeShiftLeft,
-	_NodeTypeLowerName[850:859]: NodeTypeShiftLeft,
-	_NodeTypeName[859:879]:      NodeTypeShiftRightArithmetic,
-	_NodeTypeLowerName[859:879]: NodeTypeShiftRightArithmetic,
-	_NodeTypeName[879:896]:      NodeTypeShiftRightLogical,
-	_NodeTypeLowerName[879:896]: NodeTypeShiftRightLogical,
-	_NodeTypeName[896:900]:      NodeTypeSign,
-	_NodeTypeLowerName[896:900]: NodeTypeSign,
-	_NodeTypeName[900:903]:      NodeTypeSin,
-	_NodeTypeLowerName[900:903]: NodeTypeSin,
-	_NodeTypeName[903:908]:      NodeTypeSlice,
-	_NodeTypeLowerName[903:908]: NodeTypeSlice,
-	_NodeTypeName[908:912]:      NodeTypeSqrt,
-	_NodeTypeLowerName[908:912]: NodeTypeSqrt,
-	_NodeTypeName[912:915]:      NodeTypeSub,
-	_NodeTypeLowerName[912:915]: NodeTypeSub,
-	_NodeTypeName[915:919]:      NodeTypeTanh,
-	_NodeTypeLowerName[915:919]: NodeTypeTanh,
-	_NodeTypeName[919:928]:      NodeTypeTranspose,
-	_NodeTypeLowerName[919:928]: NodeTypeTranspose,
-	_NodeTypeName[928:933]:      NodeTypeWhere,
-	_NodeTypeLowerName[928:933]: NodeTypeWhere,
+	_NodeTypeName[143:157]:      NodeTypeBroadcastInDim,
+	_NodeTypeLowerName[143:157]: NodeTypeBroadcastInDim,
+	_NodeTypeName[157:161]:      NodeTypeCeil,
+	_NodeTypeLowerName[157:161]: NodeTypeCeil,
+	_NodeTypeName[161:166]:      NodeTypeClamp,
+	_NodeTypeLowerName[161:166]: NodeTypeClamp,
+	_NodeTypeName[166:169]:      NodeTypeClz,
+	_NodeTypeLowerName[166:169]: NodeTypeClz,
+	_NodeTypeName[169:176]:      NodeTypeComplex,
+	_NodeTypeLowerName[169:176]: NodeTypeComplex,
+	_NodeTypeName[176:187]:      NodeTypeConcatenate,
+	_NodeTypeLowerName[176:187]: NodeTypeConcatenate,
+	_NodeTypeName[187:191]:      NodeTypeConj,
+	_NodeTypeLowerName[187:191]: NodeTypeConj,
+	_NodeTypeName[191:199]:      NodeTypeConstant,
+	_NodeTypeLowerName[191:199]: NodeTypeConstant,
+	_NodeTypeName[199:210]:      NodeTypeConvGeneral,
+	_NodeTypeLowerName[199:210]: NodeTypeConvGeneral,
+	_NodeTypeName[210:222]:      NodeTypeConvertDType,
+	_NodeTypeLowerName[210:222]: NodeTypeConvertDType,
+	_NodeTypeName[222:225]:      NodeTypeCos,
+	_NodeTypeLowerName[222:225]: NodeTypeCos,
+	_NodeTypeName[225:228]:      NodeTypeDiv,
+	_NodeTypeLowerName[225:228]: NodeTypeDiv,
+	_NodeTypeName[228:231]:      NodeTypeDot,
+	_NodeTypeLowerName[228:231]: NodeTypeDot,
+	_NodeTypeName[231:241]:      NodeTypeDotGeneral,
+	_NodeTypeLowerName[231:241]: NodeTypeDotGeneral,
+	_NodeTypeName[241:253]:      NodeTypeDynamicSlice,
+	_NodeTypeLowerName[241:253]: NodeTypeDynamicSlice,
+	_NodeTypeName[253:271]:      NodeTypeDynamicUpdateSlice,
+	_NodeTypeLowerName[253:271]: NodeTypeDynamicUpdateSlice,
+	_NodeTypeName[271:276]:      NodeTypeEqual,
+	_NodeTypeLowerName[271:276]: NodeTypeEqual,
+	_NodeTypeName[276:291]:      NodeTypeEqualTotalOrder,
+	_NodeTypeLowerName[276:291]: NodeTypeEqualTotalOrder,
+	_NodeTypeName[291:294]:      NodeTypeErf,
+	_NodeTypeLowerName[291:294]: NodeTypeErf,
+	_NodeTypeName[294:297]:      NodeTypeExp,
+	_NodeTypeLowerName[294:297]: NodeTypeExp,
+	_NodeTypeName[297:302]:      NodeTypeExpm1,
+	_NodeTypeLowerName[297:302]: NodeTypeExpm1,
+	_NodeTypeName[302:305]:      NodeTypeFFT,
+	_NodeTypeLowerName[302:305]: NodeTypeFFT,
+	_NodeTypeName[305:310]:      NodeTypeFloor,
+	_NodeTypeLowerName[305:310]: NodeTypeFloor,
+	_NodeTypeName[310:316]:      NodeTypeGather,
+	_NodeTypeLowerName[310:316]: NodeTypeGather,
+	_NodeTypeName[316:330]:      NodeTypeGreaterOrEqual,
+	_NodeTypeLowerName[316:330]: NodeTypeGreaterOrEqual,
+	_NodeTypeName[330:354]:      NodeTypeGreaterOrEqualTotalOrder,
+	_NodeTypeLowerName[330:354]: NodeTypeGreaterOrEqualTotalOrder,
+	_NodeTypeName[354:365]:      NodeTypeGreaterThan,
+	_NodeTypeLowerName[354:365]: NodeTypeGreaterThan,
+	_NodeTypeName[365:386]:      NodeTypeGreaterThanTotalOrder,
+	_NodeTypeLowerName[365:386]: NodeTypeGreaterThanTotalOrder,
+	_NodeTypeName[386:394]:      NodeTypeIdentity,
+	_NodeTypeLowerName[386:394]: NodeTypeIdentity,
+	_NodeTypeName[394:398]:      NodeTypeImag,
+	_NodeTypeLowerName[394:398]: NodeTypeImag,
+	_NodeTypeName[398:402]:      NodeTypeIota,
+	_NodeTypeLowerName[398:402]: NodeTypeIota,
+	_NodeTypeName[402:410]:      NodeTypeIsFinite,
+	_NodeTypeLowerName[402:410]: NodeTypeIsFinite,
+	_NodeTypeName[410:415]:      NodeTypeIsNaN,
+	_NodeTypeLowerName[410:415]: NodeTypeIsNaN,
+	_NodeTypeName[415:426]:      NodeTypeLessOrEqual,
+	_NodeTypeLowerName[415:426]: NodeTypeLessOrEqual,
+	_NodeTypeName[426:447]:      NodeTypeLessOrEqualTotalOrder,
+	_NodeTypeLowerName[426:447]: NodeTypeLessOrEqualTotalOrder,
+	_NodeTypeName[447:455]:      NodeTypeLessThan,
+	_NodeTypeLowerName[447:455]: NodeTypeLessThan,
+	_NodeTypeName[455:473]:      NodeTypeLessThanTotalOrder,
+	_NodeTypeLowerName[455:473]: NodeTypeLessThanTotalOrder,
+	_NodeTypeName[473:476]:      NodeTypeLog,
+	_NodeTypeLowerName[473:476]: NodeTypeLog,
+	_NodeTypeName[476:481]:      NodeTypeLog1p,
+	_NodeTypeLowerName[476:481]: NodeTypeLog1p,
+	_NodeTypeName[481:491]:      NodeTypeLogicalAnd,
+	_NodeTypeLowerName[481:491]: NodeTypeLogicalAnd,
+	_NodeTypeName[491:501]:      NodeTypeLogicalNot,
+	_NodeTypeLowerName[491:501]: NodeTypeLogicalNot,
+	_NodeTypeName[501:510]:      NodeTypeLogicalOr,
+	_NodeTypeLowerName[501:510]: NodeTypeLogicalOr,
+	_NodeTypeName[510:520]:      NodeTypeLogicalXor,
+	_NodeTypeLowerName[510:520]: NodeTypeLogicalXor,
+	_NodeTypeName[520:528]:      NodeTypeLogistic,
+	_NodeTypeLowerName[520:528]: NodeTypeLogistic,
+	_NodeTypeName[528:531]:      NodeTypeMax,
+	_NodeTypeLowerName[528:531]: NodeTypeMax,
+	_NodeTypeName[531:534]:      NodeTypeMin,
+	_NodeTypeLowerName[531:534]: NodeTypeMin,
+	_NodeTypeName[534:537]:      NodeTypeMul,
+	_NodeTypeLowerName[534:537]: NodeTypeMul,
+	_NodeTypeName[537:540]:      NodeTypeNeg,
+	_NodeTypeLowerName[537:540]: NodeTypeNeg,
+	_NodeTypeName[540:548]:      NodeTypeNotEqual,
+	_NodeTypeLowerName[540:548]: NodeTypeNotEqual,
+	_NodeTypeName[548:566]:      NodeTypeNotEqualTotalOrder,
+	_NodeTypeLowerName[548:566]: NodeTypeNotEqualTotalOrder,
+	_NodeTypeName[566:569]:      NodeTypePad,
+	_NodeTypeLowerName[566:569]: NodeTypePad,
+	_NodeTypeName[569:578]:      NodeTypeParameter,
+	_NodeTypeLowerName[569:578]: NodeTypeParameter,
+	_NodeTypeName[578:581]:      NodeTypePow,
+	_NodeTypeLowerName[578:581]: NodeTypePow,
+	_NodeTypeName[581:585]:      NodeTypeReal,
+	_NodeTypeLowerName[581:585]: NodeTypeReal,
+	_NodeTypeName[585:601]:      NodeTypeReduceBitwiseAnd,
+	_NodeTypeLowerName[585:601]: NodeTypeReduceBitwiseAnd,
+	_NodeTypeName[601:616]:      NodeTypeReduceBitwiseOr,
+	_NodeTypeLowerName[601:616]: NodeTypeReduceBitwiseOr,
+	_NodeTypeName[616:632]:      NodeTypeReduceBitwiseXor,
+	_NodeTypeLowerName[616:632]: NodeTypeReduceBitwiseXor,
+	_NodeTypeName[632:648]:      NodeTypeReduceLogicalAnd,
+	_NodeTypeLowerName[632:648]: NodeTypeReduceLogicalAnd,
+	_NodeTypeName[648:663]:      NodeTypeReduceLogicalOr,
+	_NodeTypeLowerName[648:663]: NodeTypeReduceLogicalOr,
+	_NodeTypeName[663:679]:      NodeTypeReduceLogicalXor,
+	_NodeTypeLowerName[663:679]: NodeTypeReduceLogicalXor,
+	_NodeTypeName[679:688]:      NodeTypeReduceMax,
+	_NodeTypeLowerName[679:688]: NodeTypeReduceMax,
+	_NodeTypeName[688:697]:      NodeTypeReduceMin,
+	_NodeTypeLowerName[688:697]: NodeTypeReduceMin,
+	_NodeTypeName[697:710]:      NodeTypeReduceProduct,
+	_NodeTypeLowerName[697:710]: NodeTypeReduceProduct,
+	_NodeTypeName[710:719]:      NodeTypeReduceSum,
+	_NodeTypeLowerName[710:719]: NodeTypeReduceSum,
+	_NodeTypeName[719:731]:      NodeTypeReduceWindow,
+	_NodeTypeLowerName[719:731]: NodeTypeReduceWindow,
+	_NodeTypeName[731:734]:      NodeTypeRem,
+	_NodeTypeLowerName[731:734]: NodeTypeRem,
+	_NodeTypeName[734:741]:      NodeTypeReshape,
+	_NodeTypeLowerName[734:741]: NodeTypeReshape,
+	_NodeTypeName[741:748]:      NodeTypeReverse,
+	_NodeTypeLowerName[741:748]: NodeTypeReverse,
+	_NodeTypeName[748:763]:      NodeTypeRngBitGenerator,
+	_NodeTypeLowerName[748:763]: NodeTypeRngBitGenerator,
+	_NodeTypeName[763:768]:      NodeTypeRound,
+	_NodeTypeLowerName[763:768]: NodeTypeRound,
+	_NodeTypeName[768:773]:      NodeTypeRsqrt,
+	_NodeTypeLowerName[768:773]: NodeTypeRsqrt,
+	_NodeTypeName[773:783]:      NodeTypeScatterMax,
+	_NodeTypeLowerName[773:783]: NodeTypeScatterMax,
+	_NodeTypeName[783:793]:      NodeTypeScatterMin,
+	_NodeTypeLowerName[783:793]: NodeTypeScatterMin,
+	_NodeTypeName[793:803]:      NodeTypeScatterSum,
+	_NodeTypeLowerName[793:803]: NodeTypeScatterSum,
+	_NodeTypeName[803:822]:      NodeTypeSelectAndScatterMax,
+	_NodeTypeLowerName[803:822]: NodeTypeSelectAndScatterMax,
+	_NodeTypeName[822:841]:      NodeTypeSelectAndScatterMin,
+	_NodeTypeLowerName[822:841]: NodeTypeSelectAndScatterMin,
+	_NodeTypeName[841:850]:      NodeTypeShiftLeft,
+	_NodeTypeLowerName[841:850]: NodeTypeShiftLeft,
+	_NodeTypeName[850:870]:      NodeTypeShiftRightArithmetic,
+	_NodeTypeLowerName[850:870]: NodeTypeShiftRightArithmetic,
+	_NodeTypeName[870:887]:      NodeTypeShiftRightLogical,
+	_NodeTypeLowerName[870:887]: NodeTypeShiftRightLogical,
+	_NodeTypeName[887:891]:      NodeTypeSign,
+	_NodeTypeLowerName[887:891]: NodeTypeSign,
+	_NodeTypeName[891:894]:      NodeTypeSin,
+	_NodeTypeLowerName[891:894]: NodeTypeSin,
+	_NodeTypeName[894:899]:      NodeTypeSlice,
+	_NodeTypeLowerName[894:899]: NodeTypeSlice,
+	_NodeTypeName[899:903]:      NodeTypeSqrt,
+	_NodeTypeLowerName[899:903]: NodeTypeSqrt,
+	_NodeTypeName[903:906]:      NodeTypeSub,
+	_NodeTypeLowerName[903:906]: NodeTypeSub,
+	_NodeTypeName[906:910]:      NodeTypeTanh,
+	_NodeTypeLowerName[906:910]: NodeTypeTanh,
+	_NodeTypeName[910:919]:      NodeTypeTranspose,
+	_NodeTypeLowerName[910:919]: NodeTypeTranspose,
+	_NodeTypeName[919:924]:      NodeTypeWhere,
+	_NodeTypeLowerName[919:924]: NodeTypeWhere,
 }
 
 var _NodeTypeNames = []string{
@@ -357,94 +354,93 @@ var _NodeTypeNames = []string{
 	_NodeTypeName[114:124],
 	_NodeTypeName[124:133],
 	_NodeTypeName[133:143],
-	_NodeTypeName[143:152],
-	_NodeTypeName[152:166],
-	_NodeTypeName[166:170],
-	_NodeTypeName[170:175],
-	_NodeTypeName[175:178],
-	_NodeTypeName[178:185],
-	_NodeTypeName[185:196],
-	_NodeTypeName[196:200],
-	_NodeTypeName[200:208],
-	_NodeTypeName[208:219],
-	_NodeTypeName[219:231],
-	_NodeTypeName[231:234],
-	_NodeTypeName[234:237],
-	_NodeTypeName[237:240],
-	_NodeTypeName[240:250],
-	_NodeTypeName[250:262],
-	_NodeTypeName[262:280],
-	_NodeTypeName[280:285],
-	_NodeTypeName[285:300],
-	_NodeTypeName[300:303],
-	_NodeTypeName[303:306],
-	_NodeTypeName[306:311],
-	_NodeTypeName[311:314],
-	_NodeTypeName[314:319],
-	_NodeTypeName[319:325],
-	_NodeTypeName[325:339],
-	_NodeTypeName[339:363],
-	_NodeTypeName[363:374],
-	_NodeTypeName[374:395],
-	_NodeTypeName[395:403],
-	_NodeTypeName[403:407],
-	_NodeTypeName[407:411],
-	_NodeTypeName[411:419],
-	_NodeTypeName[419:424],
-	_NodeTypeName[424:435],
-	_NodeTypeName[435:456],
-	_NodeTypeName[456:464],
-	_NodeTypeName[464:482],
-	_NodeTypeName[482:485],
-	_NodeTypeName[485:490],
-	_NodeTypeName[490:500],
-	_NodeTypeName[500:510],
-	_NodeTypeName[510:519],
-	_NodeTypeName[519:529],
-	_NodeTypeName[529:537],
+	_NodeTypeName[143:157],
+	_NodeTypeName[157:161],
+	_NodeTypeName[161:166],
+	_NodeTypeName[166:169],
+	_NodeTypeName[169:176],
+	_NodeTypeName[176:187],
+	_NodeTypeName[187:191],
+	_NodeTypeName[191:199],
+	_NodeTypeName[199:210],
+	_NodeTypeName[210:222],
+	_NodeTypeName[222:225],
+	_NodeTypeName[225:228],
+	_NodeTypeName[228:231],
+	_NodeTypeName[231:241],
+	_NodeTypeName[241:253],
+	_NodeTypeName[253:271],
+	_NodeTypeName[271:276],
+	_NodeTypeName[276:291],
+	_NodeTypeName[291:294],
+	_NodeTypeName[294:297],
+	_NodeTypeName[297:302],
+	_NodeTypeName[302:305],
+	_NodeTypeName[305:310],
+	_NodeTypeName[310:316],
+	_NodeTypeName[316:330],
+	_NodeTypeName[330:354],
+	_NodeTypeName[354:365],
+	_NodeTypeName[365:386],
+	_NodeTypeName[386:394],
+	_NodeTypeName[394:398],
+	_NodeTypeName[398:402],
+	_NodeTypeName[402:410],
+	_NodeTypeName[410:415],
+	_NodeTypeName[415:426],
+	_NodeTypeName[426:447],
+	_NodeTypeName[447:455],
+	_NodeTypeName[455:473],
+	_NodeTypeName[473:476],
+	_NodeTypeName[476:481],
+	_NodeTypeName[481:491],
+	_NodeTypeName[491:501],
+	_NodeTypeName[501:510],
+	_NodeTypeName[510:520],
+	_NodeTypeName[520:528],
+	_NodeTypeName[528:531],
+	_NodeTypeName[531:534],
+	_NodeTypeName[534:537],
 	_NodeTypeName[537:540],
-	_NodeTypeName[540:543],
-	_NodeTypeName[543:546],
-	_NodeTypeName[546:549],
-	_NodeTypeName[549:557],
-	_NodeTypeName[557:575],
-	_NodeTypeName[575:578],
-	_NodeTypeName[578:587],
-	_NodeTypeName[587:590],
-	_NodeTypeName[590:594],
-	_NodeTypeName[594:610],
-	_NodeTypeName[610:625],
-	_NodeTypeName[625:641],
-	_NodeTypeName[641:657],
-	_NodeTypeName[657:672],
-	_NodeTypeName[672:688],
+	_NodeTypeName[540:548],
+	_NodeTypeName[548:566],
+	_NodeTypeName[566:569],
+	_NodeTypeName[569:578],
+	_NodeTypeName[578:581],
+	_NodeTypeName[581:585],
+	_NodeTypeName[585:601],
+	_NodeTypeName[601:616],
+	_NodeTypeName[616:632],
+	_NodeTypeName[632:648],
+	_NodeTypeName[648:663],
+	_NodeTypeName[663:679],
+	_NodeTypeName[679:688],
 	_NodeTypeName[688:697],
-	_NodeTypeName[697:706],
-	_NodeTypeName[706:719],
-	_NodeTypeName[719:728],
-	_NodeTypeName[728:740],
-	_NodeTypeName[740:743],
-	_NodeTypeName[743:750],
-	_NodeTypeName[750:757],
-	_NodeTypeName[757:772],
-	_NodeTypeName[772:777],
-	_NodeTypeName[777:782],
-	_NodeTypeName[782:792],
-	_NodeTypeName[792:802],
-	_NodeTypeName[802:812],
-	_NodeTypeName[812:831],
-	_NodeTypeName[831:850],
-	_NodeTypeName[850:859],
-	_NodeTypeName[859:879],
-	_NodeTypeName[879:896],
-	_NodeTypeName[896:900],
-	_NodeTypeName[900:903],
-	_NodeTypeName[903:908],
-	_NodeTypeName[908:912],
-	_NodeTypeName[912:915],
-	_NodeTypeName[915:919],
-	_NodeTypeName[919:928],
-	_NodeTypeName[928:933],
+	_NodeTypeName[697:710],
+	_NodeTypeName[710:719],
+	_NodeTypeName[719:731],
+	_NodeTypeName[731:734],
+	_NodeTypeName[734:741],
+	_NodeTypeName[741:748],
+	_NodeTypeName[748:763],
+	_NodeTypeName[763:768],
+	_NodeTypeName[768:773],
+	_NodeTypeName[773:783],
+	_NodeTypeName[783:793],
+	_NodeTypeName[793:803],
+	_NodeTypeName[803:822],
+	_NodeTypeName[822:841],
+	_NodeTypeName[841:850],
+	_NodeTypeName[850:870],
+	_NodeTypeName[870:887],
+	_NodeTypeName[887:891],
+	_NodeTypeName[891:894],
+	_NodeTypeName[894:899],
+	_NodeTypeName[899:903],
+	_NodeTypeName[903:906],
+	_NodeTypeName[906:910],
+	_NodeTypeName[910:919],
+	_NodeTypeName[919:924],
 }
 
 // NodeTypeString retrieves an enum value from the enum constants string name.

--- a/graph/ops.go
+++ b/graph/ops.go
@@ -372,8 +372,17 @@ func Mod(x, y *Node) *Node {
 // The new dimensions id into copies of the operand, i.e.
 //
 //	output[i0, ..., iN, j0, ..., jM] = operand[j0, ..., jM]
-func BroadcastPrefix(x *Node, dims ...int) *Node {
-	return backendBroadcast(x, dims...)
+func BroadcastPrefix(x *Node, prefixDims ...int) *Node {
+	shape := x.Shape()
+	newDims := make([]int, shape.Rank()+len(prefixDims))
+	copy(newDims, prefixDims)
+	copy(newDims[len(prefixDims):], shape.Dimensions)
+	broadcastAxes := make([]int, shape.Rank())
+	for i := range shape.Rank() {
+		broadcastAxes[i] = i + len(prefixDims)
+	}
+	outputShape := shapes.Make(x.DType(), newDims...)
+	return backendBroadcastInDim(x, outputShape, broadcastAxes)
 }
 
 // ExpandAndBroadcast combines ExpandAxes and broadcast of axes of `x`, the returned shape will be newDimensions.

--- a/graph/rev_autodiff.go
+++ b/graph/rev_autodiff.go
@@ -932,7 +932,7 @@ func batchNormForTrainingVJP(node *Node, vjps []*Node, _ shapes.Shape) []*Node {
 	//variance.SetLogged("variance")
 	//fmt.Printf("batchNormForTrainingVJP: epsilon=%g\n", params.epsilon)
 	gradOperand, gradScale, gradOffset := InternalBatchNormGradient(
-		params.operand, params.scale, mean, variance, gradOutput, params.epsilon, params.axis)
+		params.operand, params.scale, mean, variance, gradOutput, params.epsilon, params.featureAxis)
 	return []*Node{gradOperand, gradScale, gradOffset}
 }
 
@@ -948,7 +948,7 @@ func transposeVJP(node, v *Node, _ shapes.Shape) []*Node {
 	return []*Node{vjp}
 }
 
-// broadcastInDimVJP generates the "vector dot jacobian" w.r.t. the input of broadcast.
+// broadcastInDimVJP generates the "vector dot jacobian" w.r.t. the input of BroadcastInDim.
 // One just needs to reduce the broadcast dimensions.
 func broadcastInDimVJP(node, v *Node, _ shapes.Shape) []*Node {
 	params := node.inputs.(*nodeInputsBroadcastInDim)


### PR DESCRIPTION
* Package `backends`:
  * Removed op `Broadcast`: it was not needed, since `BroadcastInDim` is a superset.
* Package `graph`:
  * Backprop of `BroadcastPrefix` was not defined. Now that is uses `BroadcastInDim` instead, it works.
  * Fixed name of params fields for BrachNormForTraining.