### PR TITLE
Only log simplego convgeneral info on error

### DIFF
--- a/backends/simplego/convgeneral.go
+++ b/backends/simplego/convgeneral.go
@@ -49,11 +49,10 @@ func (b *Builder) ConvGeneral(inputOp, kernelOp backends.Op, axes backends.Convo
 
 	outputShape, err := shapeinference.ConvGeneralOp(input.shape, kernel.shape, axes, strides, paddings, inputDilations, kernelDilations, channelGroupCount, batchGroupCount)
 	if err != nil {
+		fmt.Printf("ConvGeneral: input=%s, kernel=%s, output=%s, axes=%+v, strides=%v, paddings=%v, inputDilations=%v, kernelDilations=%v, channelGroupCount=%d, batchGroupCount=%d\n",
+			input.shape, kernel.shape, outputShape, axes, strides, paddings, inputDilations, kernelDilations, channelGroupCount, batchGroupCount)
 		return nil, err
 	}
-
-	fmt.Printf("ConvGeneral: input=%s, kernel=%s, output=%s, axes=%+v, strides=%v, paddings=%v, inputDilations=%v, kernelDilations=%v, channelGroupCount=%d, batchGroupCount=%d\n",
-		input.shape, kernel.shape, outputShape, axes, strides, paddings, inputDilations, kernelDilations, channelGroupCount, batchGroupCount)
 
 	node := b.newNode(opType, outputShape, input, kernel)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Removed op `Broadcast`: it was not needed, since `BroadcastInDim` is a superset.
 * Package `graph`:
   * Backprop of `BroadcastPrefix` was not defined. Now that is uses `BroadcastInDim` instead, it works.
+* Package `simplego`:
+  * Only log ConvGeneral statistics on error.
 
 # v0.23.0: 2025/09/21: beta `stablehlo` backend release
 


### PR DESCRIPTION
This silences log messages like 

ConvGeneral: input=(Float32)[2 3 224 224], kernel=(Float32)[64 3 7 7], output=(Float32)[2 64 112 112], axes={InputBatch:0 InputChannels:1 InputSpatial:[2 3] KernelInputChannels:1 KernelOutputChannels:0 KernelSpatial:[2 3] OutputBatch:0 OutputChannels:1 OutputSpatial:[2 3]}, strides=[2 2], paddings=[[3 3] [3 3]], inputDilations=[], kernelDilations=[1 1], channelGroupCount=1, batchGroupCount=1 

in normal operation