### PR TITLE
fix: possible path traversal in huggingface downloader; added arg injection guards in HDF5 and preventive path validation in NPZ reader

### DIFF
--- a/ml/data/hdf5/hdf5.go
+++ b/ml/data/hdf5/hdf5.go
@@ -61,9 +61,14 @@ func ParseFile(filePath string) (contents Hdf5Contents, err error) {
 	matches := regexpH5Datasets.FindAllStringSubmatch(string(contentsBytes), -1)
 	contents = make(Hdf5Contents, len(matches))
 	for _, match := range matches {
-		contents[match[1]] = &Hdf5Dataset{
+		groupPath := match[1]
+		//in case someone inserted args into dataset name('--help', etc)
+		if strings.HasPrefix(groupPath, "-") {
+			return nil, errors.Errorf("invalid dataset name starting with '-': %q", groupPath)
+		}
+		contents[groupPath] = &Hdf5Dataset{
 			FilePath:  filePath,
-			GroupPath: match[1],
+			GroupPath: groupPath,
 		}
 	}
 


### PR DESCRIPTION
Hello! Thank you for such a wonderful project!
I was digging through your code and noticed a couple of issues in the ml data loaders. Here are my fixes.
- HuggingFace downloader (ml/data/huggingface/huggingface.go): The old check for ".." in filenames was easy to dodge (in theory, it's difficult to do anything here, but Unicode processing varies across different systems). Now it normalizes paths with path.Clean(), blocks absolute paths or traversal attempts, and double-checks the final path stays in the base dir (if there was a theoretical possibility to bypass the protection before, now there isn't. I hope). Stops malicious models from spilling files outside the target folder.
- HDF5 parser (ml/data/hdf5/hdf5.go): Dataset names passed straight to h5dump args. If it started with "-", it could trick it into flags like --help. Added a check to reject those. Not full injection (as i know, Go exec is safe), but no more weird behavior or randomness.
- NumPy NPZ reader (types/tensors/numpy/numpy.go): Currently memory-only, but ZIP entries had no path checks. Added path.Clean() validation to reject traversal or absolute paths upfront. Prevents Zip Slip if anyone tweaks it later to write files.
This should make things safer.

