### PR TITLE
SimpleGo race alert analysis.

### DIFF
--- a/backends/simplego/dotgeneral_normalized.go
+++ b/backends/simplego/dotgeneral_normalized.go
@@ -241,6 +241,14 @@ func execDotGeneralNormalized(backend *Backend, lhs, rhs *Buffer, params *dotGen
 		wg.Wait()
 	}
 
+	// Free temporary normalized buffers, if they were used.
+	if lhs != lhsNormalized {
+		backend.putBuffer(lhsNormalized)
+	}
+	if rhs != rhsNormalized {
+		backend.putBuffer(rhsNormalized)
+	}
+
 	// If we created a temporary float32 output, convert it back to the original dtype.
 	if castToFloat32 {
 		convertFnAny, err := convertDTypePairMap.Get(dtypes.Float32, output.shape.DType) //nolint:errcheck

--- a/backends/simplego/function_exec.go
+++ b/backends/simplego/function_exec.go
@@ -444,6 +444,15 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 			fe.numUses[inputIdx]-int(execBuf.numUsed[inputIdx].Load()) == 1
 	}
 
+	// lockIfNeededFn should be called before the execBuf slices are updated.
+	// It's refactored here is a closure so the code doens't need to be duplicated in the
+	// switch clause below.
+	lockIfNeededFn := func() {
+		if execBuf.opsExecutionType == opsExecutionParallel {
+			execBuf.mu.Lock()
+		}
+	}
+
 	// Check for closure executor first (If, While, Sort).
 	// Closure executors receive captured inputs separately with explicit ownership tracking.
 	closureExecutor := nodeClosureExecutors[node.opType]
@@ -484,7 +493,9 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 			}
 		}
 
-		// Handle outputs (closure ops are always multi-output style)
+		// Write outputs to execBuf (closure ops are always multi-output style), or free those no longer
+		// needed.
+		lockIfNeededFn()
 		for outputIdx, outputBuf := range outputBuffers {
 			outputNode := node.multiOutputsNodes[outputIdx]
 			outputNodeIdx := outputNode.idx
@@ -495,6 +506,7 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 			execBuf.results[outputNodeIdx] = outputBuf
 			execBuf.owned[outputNodeIdx] = true
 		}
+
 	case node.IsMultiOutputs():
 		// Execute the node
 		multiExecutor := multiOutputsNodeExecutors[node.opType]
@@ -507,6 +519,9 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 			return errors.WithMessagef(err, "executing multi-output %s", node.opType)
 		}
 
+		// Write outputs to execBuf (multi-output ops are always multi-output style), or free those no longer
+		// needed.
+		lockIfNeededFn()
 		for outputIdx, outputBuf := range outputBuffers {
 			outputNode := node.multiOutputsNodes[outputIdx]
 			outputNodeIdx := outputNode.idx
@@ -518,7 +533,9 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 			execBuf.results[outputNodeIdx] = outputBuf
 			execBuf.owned[outputNodeIdx] = true
 		}
+
 	default:
+		// Single output node:
 		executor := nodeExecutors[node.opType]
 		if executor == nil {
 			return errors.Errorf("no executor for op %s", node.opType)
@@ -528,15 +545,16 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 		if err != nil {
 			return errors.WithMessagef(err, "executing %s", node.opType)
 		}
+
+		// Write result to execBuf (single output node), or free it if not needed.
+		lockIfNeededFn()
 		execBuf.results[nodeIdx] = result
 		execBuf.owned[nodeIdx] = true
 	}
+	// At the exit of the switch statement, lockIfNeededFn() must have been called,
+	// so we can write further updates to execBuf
 
 	// Update usage counts and free unused buffers.
-	// The lock protects results in parallel mode; numUsed uses atomics for safe reads.
-	if execBuf.opsExecutionType == opsExecutionParallel {
-		execBuf.mu.Lock()
-	}
 	for i, input := range node.inputs {
 		inputIdx := input.idx
 		newCount := execBuf.numUsed[inputIdx].Add(1) // Mark this input as used.

--- a/backends/simplego/function_exec.go
+++ b/backends/simplego/function_exec.go
@@ -320,8 +320,11 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 		stopExecutionFn()
 	}
 
+	var wg sync.WaitGroup
 	for nodeIdx := range readyToExecute {
+		// Closure that executes one node.
 		nodeExecFn := func() {
+			defer wg.Done()
 			node := fe.function.nodes[nodeIdx]
 
 			defer func(nodeIdx int) {
@@ -379,8 +382,13 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 			}
 		}
 
+		wg.Add(1)
 		backend.workers.WaitToStart(nodeExecFn)
 	}
+
+	// Wait for all nodes to complete before exit (to avoid race condition where some execution
+	// is cleaning up while execBuf is being reused).
+	wg.Wait()
 
 	if len(collectErrors) > 0 {
 		return collectErrors[0]
@@ -573,7 +581,7 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 				continue
 			}
 			if int(newCount) == fe.numUses[capturedIdx] && execBuf.owned[capturedIdx] {
-				// Release the captured buffer - all users have finished.
+				// Release the captured buffer - all uses have finished.
 				backend.putBuffer(capturedBuf)
 				execBuf.results[capturedIdx] = nil
 			}

--- a/backends/simplego/function_exec.go
+++ b/backends/simplego/function_exec.go
@@ -125,6 +125,12 @@ type funcExecBuffers struct {
 	numUsed []atomic.Int32
 
 	// owned indicates whether the corresponding buffer is owned by the executor.
+	//
+	// Notice different rows are written by different threads in parallel mode, but since
+	// each row is 1 byte, and Go's thread sanitizer has an 8-bytes resolution, it may trigger
+	// false race conditions. See discussion in github.com/gomlx/gomlx/issues/387
+	//
+	// Future: use a []int (int is 64 bits/8 bytes) instead of bool to avoid the issue?
 	owned []bool
 
 	// remainingDeps is the number of remaining dependencies for each node.
@@ -330,8 +336,8 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 					return
 				}
 
-				// Handle multi-output nodes
 				if node.IsMultiOutputs() {
+					// Handle multi-output nodes: update dependents of each output.
 					for _, outputNode := range node.multiOutputsNodes {
 						outputIdx := outputNode.idx
 						if outputIdx >= fe.numNodesToProcess || fe.numUses[outputIdx] == 0 {
@@ -350,6 +356,7 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 						}
 					}
 				} else {
+					// Single output node.
 					for _, depIdx := range fe.dependents[nodeIdx] {
 						execBuf.remainingDeps[depIdx]--
 						if execBuf.remainingDeps[depIdx] == 0 {
@@ -573,8 +580,11 @@ func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf 
 		}
 	}
 	if execBuf.opsExecutionType == opsExecutionParallel {
+		// Unlock if it's a parallel execution.
 		execBuf.mu.Unlock()
 	} else {
+		// For sequential execution, we store the input buffers and ownership slices
+		// to save an allocation for these slices in the next time it is executed.
 		execBuf.opInputBuffers = inputBuffers
 		execBuf.opInputsOwned = inputsOwned
 	}


### PR DESCRIPTION
- Fixed buffer leak in `execDotGeneralNormalized`, see #387.
- Updated comments while analysing #387
- Make `FunctionExecutable.executeParallel` adhere to proper "structured concurrency": it only exits once 
  all its goroutines exit.
  And with that fix a potential race condition where straggling goroutines could be cleaning up stuff that is 
  already being recycled to the next execution.