### PR TITLE
Added CrossCosineSimilarity operation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@
   - Added `ByteSize()` method, with proper support for packed dtypes.
   - Deprecated `shapes.Memory()`.
 - Package `graph`
-  - Added `CrossCompileSimilarity()` operation.
+  - Added `CrossCosineSimilarity()` operation.
 
 ### Packages in `pkg/ml`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Package `shapes`
   - Added `ByteSize()` method, with proper support for packed dtypes.
   - Deprecated `shapes.Memory()`.
+- Package `graph`
+  - Added `CrossCompileSimilarity()` operation.
+
 ### Packages in `pkg/ml`
 
 - Package `activations`

--- a/pkg/core/graph/ops_util.go
+++ b/pkg/core/graph/ops_util.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gomlx/gomlx/pkg/core/dtypes"
 	"github.com/gomlx/gomlx/pkg/core/shapes"
 	"github.com/gomlx/gomlx/pkg/core/tensors"
+	"github.com/gomlx/gomlx/pkg/support/exceptions"
 	. "github.com/gomlx/gomlx/pkg/support/exceptions"
 	"github.com/gomlx/gomlx/pkg/support/xslices"
 )
@@ -1015,9 +1016,17 @@ func Skewness(x *Node, axes ...int) *Node {
 // A typical value for axis is -1, it calculates the cosine similarity for the last dimension.
 //
 // The output will have the same rank, but the axis is contracted to 1, and will hold the similarity.
+//
+// Notice, this expects both lhs and rhs to have the same shape, it's a "element-wise" cosine similarity
+// of lhs and rhs.
+// See also CrossCosineSimilarity to calculate the cosine similarty "of all elements of lhs x all elements of rhs"
 func CosineSimilarity(lhs *Node, rhs *Node, axis int) *Node {
 	g := lhs.Graph()
 	dtype := lhs.DType()
+	if !lhs.Shape().Equal(rhs.Shape()) {
+		exceptions.Panicf("CosineSimilarity expects lhs and rhs to have the same shape, got %s and %s -- "+
+			"maybe you want to do CrossCosineSimilarity ?", lhs.Shape(), rhs.Shape())
+	}
 
 	// Mask for rows that are fully zero, for which cosine similary is not normally defined.
 	lhsAxisZeroMask := ReduceAndKeep(IsZero(lhs), ReduceLogicalAnd, axis)
@@ -1053,5 +1062,76 @@ func CosineSimilarity(lhs *Node, rhs *Node, axis int) *Node {
 	// Arbitrarily set the similarity of the zero-rows (lhsMask or rhsMask) to zero.
 	zero := ScalarZero(g, dtype)
 	similarity = Where(LogicalOr(lhsAxisZeroMask, rhsAxisZeroMask), zero, similarity)
+	return similarity
+}
+
+// CrossCosineSimilarity calculates the cosine similarity on the cross of the elements of lhs and rhs.
+//
+// Let's say lhs has shape [BatchSize, NumLHS, EmbeddingDim) and rhs has shape [BatchSize, NumRHS, EmbeddingDim).
+// The output of CrossCosineSimilarity(lhs, rhs, contractingAxis=-1, crossAxis=1) will have shape
+// [BatchSize, NumLHS, NumRHS] (the cosine similariy of all LHS elements cross all RHS elements).
+//
+// Notice axes that are not contracting or cross are considered "batch" and preserved in the output.
+//
+// The rank and the order of the axes of lhs and rhs must match -- so the contracting axis is the
+// same on both.
+//
+// A typical value for axis is -1, it calculates the cosine similarity for the last dimension.
+//
+// The output will have the same rank, but the axis is contracted to 1, and will hold the similarity.
+//
+// See also CosineSimilarity if you want to do element-wise cosine similarity.
+func CrossCosineSimilarity(lhs *Node, rhs *Node, constractingAxis, crossAxis int) *Node {
+	g := lhs.Graph()
+	dtype := lhs.DType()
+	if lhs.Rank() != rhs.Rank() {
+		exceptions.Panicf("CrossCosineSimilarity expects lhs and rhs to have the same rank, got %s and %s -- ",
+			lhs.Shape(), rhs.Shape())
+	}
+
+	// Mask for rows that are fully zero, for which cosine similary is not normally defined.
+	lhsAxisZeroMask := ReduceAndKeep(IsZero(lhs), ReduceLogicalAnd, constractingAxis)
+	rhsAxisZeroMask := ReduceAndKeep(IsZero(rhs), ReduceLogicalAnd, constractingAxis)
+
+	// Recover original shape, by broadcasting the mask where we just reduced.
+	lhsMask := BroadcastToShape(ConvertDType(lhsAxisZeroMask, dtypes.Bool), lhs.Shape())
+	rhsMask := BroadcastToShape(ConvertDType(rhsAxisZeroMask, dtypes.Bool), rhs.Shape())
+
+	// Replace rows with all zeroes (lhsMask/rhsMask) with 1.
+	// Any positive numerical safe number would work, since the final computation for
+	// those rows won't be used, as long as they are not NaNs.
+	one := ScalarOne(g, dtype)
+	lhs = Where(lhsMask, one, lhs)
+	rhs = Where(rhsMask, one, rhs)
+
+	// Set up contracting axis and the remaining batch axes.
+	adjustedContractingAxis := MustAdjustAxis(constractingAxis, lhs)
+	adjustedCrossAxis := MustAdjustAxis(crossAxis, lhs)
+	contractingAxes := [][2]int{{adjustedContractingAxis, adjustedContractingAxis}}
+	var batchAxes [][2]int
+	if lhs.Rank() > 2 {
+		batchAxes = make([][2]int, 0, lhs.Rank()-2)
+		for batchAxis := range lhs.Rank() {
+			if batchAxis == adjustedContractingAxis || batchAxis == adjustedCrossAxis {
+				continue
+			}
+			batchAxes = append(batchAxes, [2]int{batchAxis, batchAxis})
+		}
+	}
+	dotProduct := EinsumAxes(lhs, rhs, contractingAxes, batchAxes) // Shaped [...batchDims..., lhsCrossDim, rhsCrossDim, ...batchDims...]
+
+	// Normalization
+	lhsNorm := L2Norm(lhs, adjustedContractingAxis)                                      // Same shape as LHS, but for contracting axis is 1
+	rhsNorm := L2Norm(rhs, adjustedContractingAxis)                                      // Same shape as RHS, but for contracting axis is 1
+	normalisationDenominator := EinsumAxes(lhsNorm, rhsNorm, contractingAxes, batchAxes) // Shaped [...batchDims..., lhsCrossDim, rhsCrossDim, ...batchDims...]
+
+	similarity := Div(dotProduct, normalisationDenominator)
+
+	// Arbitrarily set the similarity of the zero-rows (lhsMask or rhsMask) to zero.
+	zero := ScalarZero(g, dtype)
+	lhsNotZeros := ConvertDType(LogicalNot(lhsAxisZeroMask), dtypes.Int8)
+	rhsNotZeros := ConvertDType(LogicalNot(rhsAxisZeroMask), dtypes.Int8)
+	crossMaskNotZeros := EinsumAxes(lhsNotZeros, rhsNotZeros, contractingAxes, batchAxes)
+	similarity = Where(ConvertDType(crossMaskNotZeros, dtypes.Bool), similarity, zero)
 	return similarity
 }

--- a/pkg/core/graph/ops_util_test.go
+++ b/pkg/core/graph/ops_util_test.go
@@ -545,37 +545,78 @@ func TestL2Normalize(t *testing.T) {
 }
 
 func TestCosineSimilarity(t *testing.T) {
-	graphtest.RunTestGraphFn(t, t.Name(),
-		func(g *Graph) (inputs, outputs []*Node) {
-			x := Const(g, [][]float32{
-				{0, 0, 0},
-				{7, 0, 0},
-				{0, 0, 13},
-			})
-			y := Const(g, [][]float32{
-				{10, 20, 30},
-				{2, 0, 0},
-				{0, 0, -11},
-			})
-			inputs = []*Node{x, y}
-			outputs = []*Node{
-				CosineSimilarity(x, y, -1), // Rows: Axis -1
-				CosineSimilarity(x, y, 0),  // Columns: Axis 0
-			}
-			return
-		}, []any{
-			[][]float32{{0}, {1}, {-1}},
-			[][]float32{{0.19611612, 0, -0.34425467}},
-		}, 0.0001)
+	graphtest.TestOfficialBackends(t, func(t *testing.T, backend backends.Backend) {
+		graphtest.RunTestGraphFnWithBackend(t, t.Name(), backend,
+			func(g *Graph) (inputs, outputs []*Node) {
+				x := Const(g, [][]float32{
+					{0, 0, 0},
+					{7, 0, 0},
+					{0, 0, 13},
+				})
+				y := Const(g, [][]float32{
+					{10, 20, 30},
+					{2, 0, 0},
+					{0, 0, -11},
+				})
+				inputs = []*Node{x, y}
+				outputs = []*Node{
+					CosineSimilarity(x, y, -1), // Rows: Axis -1
+					CosineSimilarity(x, y, 0),  // Columns: Axis 0
+				}
+				return
+			}, []any{
+				[][]float32{{0}, {1}, {-1}},
+				[][]float32{{0.19611612, 0, -0.34425467}},
+			}, 0.0001)
 
-	// Check the gradient of zero vectors won't yield NaNs.
-	testGradients(t, "CosineSimilarity Gradient", func(g *Graph) (output *Node, nodesForGrad []*Node) {
-		x := Const(g, [][]float32{{0, 0, 0}})
-		y := Const(g, [][]float32{{10, 20, 30}})
-		output = CosineSimilarity(x, y, -1)
-		return output, []*Node{x}
-	}, []any{
-		[][]float32{{0, 0, 0}},
+		// Check the gradient of zero vectors won't yield NaNs.
+		testGradientsWithBackend(t, "CosineSimilarity Gradient", backend, func(g *Graph) (output *Node, nodesForGrad []*Node) {
+			x := Const(g, [][]float32{{0, 0, 0}})
+			y := Const(g, [][]float32{{10, 20, 30}})
+			output = CosineSimilarity(x, y, -1)
+			return output, []*Node{x}
+		}, []any{
+			[][]float32{{0, 0, 0}},
+		})
+	})
+}
+
+func TestCrossCosineSimilarity(t *testing.T) {
+	graphtest.TestOfficialBackends(t, func(t *testing.T, backend backends.Backend) {
+		graphtest.RunTestGraphFnWithBackend(t, t.Name(), backend,
+			func(g *Graph) (inputs, outputs []*Node) {
+				x := Const(g, [][]float32{
+					{0, 0, 0},
+					{7, 0, 0},
+					{0, 0, 13},
+				})
+				y := Const(g, [][]float32{
+					{10, 20, 30},
+					{0, 0, 0},
+					{0, 0, -11},
+				})
+				inputs = []*Node{x, y}
+				outputs = []*Node{
+					CrossCosineSimilarity(x, y, -1, 0),
+				}
+				return
+			}, []any{
+				[][]float32{
+					{0, 0, 0},
+					{0.26726124, 0, 0},
+					{0.8017837, 0, -1},
+				},
+			}, 0.0001)
+
+		// Check the gradient of zero vectors won't yield NaNs.
+		testGradientsWithBackend(t, "CrossCosineSimilarity Gradient", backend, func(g *Graph) (output *Node, nodesForGrad []*Node) {
+			x := Const(g, [][]float32{{0, 0, 0}})
+			y := Const(g, [][]float32{{10, 20, 30}})
+			output = CrossCosineSimilarity(x, y, -1, 0)
+			return output, []*Node{x}
+		}, []any{
+			[][]float32{{0, 0, 0}},
+		})
 	})
 }
 

--- a/pkg/core/graph/rev_autodiff_test.go
+++ b/pkg/core/graph/rev_autodiff_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/gomlx/gomlx/backends"
 	"github.com/gomlx/gomlx/pkg/core/dtypes"
 	. "github.com/gomlx/gomlx/pkg/core/graph"
 	"github.com/gomlx/gomlx/pkg/core/graph/graphtest"
@@ -131,16 +132,24 @@ type gradTestFunc func(g *Graph) (output *Node, nodesForGrad []*Node)
 //
 // It will print out the inputNodes and outputs to help debugging.
 func testGradients(t *testing.T, name string, testFn gradTestFunc, wantForGrad []any) {
-	testGradientsInDelta(t, name, testFn, wantForGrad, Epsilon)
+	backend := graphtest.BuildTestBackend()
+	testGradientsInDelta(t, name, backend, testFn, wantForGrad, Epsilon)
+}
+
+// testGradients run testFn to build a graph, calculates the gradients of the ReduceAllSum(output) with respect
+// to the nodesForGrad, and check that it gets close to the corresponding values in wantForGrad.
+//
+// It will print out the inputNodes and outputs to help debugging.
+func testGradientsWithBackend(t *testing.T, name string, backend backends.Backend, testFn gradTestFunc, wantForGrad []any) {
+	testGradientsInDelta(t, name, backend, testFn, wantForGrad, Epsilon)
 }
 
 // testGradientsInDelta run testFn to build a graph, calculates the gradients of the ReduceAllSum(output) with respect
 // to the nodesForGrad, and check that it gets the corresponding values in wantForGrad, withing a delta-margin (at every element).
 //
 // It will print out the inputNodes and outputs to help debugging.
-func testGradientsInDelta(t *testing.T, name string, testFn gradTestFunc, wantForGrad []any, delta float64) {
+func testGradientsInDelta(t *testing.T, name string, backend backends.Backend, testFn gradTestFunc, wantForGrad []any, delta float64) {
 	t.Run(name, func(t *testing.T) {
-		backend := graphtest.BuildTestBackend()
 		// Create a function that can be used by computation.Exec.
 		fn := func(g *Graph) []*Node {
 			output, nodesForGrad := testFn(g)
@@ -277,9 +286,10 @@ func TestGradientExp(t *testing.T) {
 }
 
 func TestGradientPow(t *testing.T) {
+	backend := graphtest.BuildTestBackend()
 	a := []float64{3, 1, 0.5}
 	b := []float64{3, 1, -2}
-	testGradientsInDelta(t, "gradient_of_pow",
+	testGradientsInDelta(t, "gradient_of_pow", backend,
 		func(g *Graph) (output *Node, nodesForGrad []*Node) {
 			aNode, bNode := Const(g, a), Const(g, b)
 			aNode = BroadcastToDims(Reshape(aNode, 1, 3), 3, 3)


### PR DESCRIPTION
This PR adds the `CrossCosineSimilarity` operation to the `graph` package, allowing the calculation of cosine similarity between all pairs of vectors from two input nodes (cross-product), while preserving batch dimensions.

### Changes:
- **Package `graph`**:
  - Implemented `CrossCosineSimilarity(lhs, rhs, contractingAxis, crossAxis)`.
  - Added a shape check to `CosineSimilarity` to ensure it's used for element-wise similarity and suggest `CrossCosineSimilarity` if shapes differ.
  - Refactored `rev_autodiff_test.go` to support testing gradients across different backends with `testGradientsWithBackend`.
  - Added comprehensive tests for `CrossCosineSimilarity` and updated existing `CosineSimilarity` tests to run on all official backends.
- **Documentation**:
  - Updated `CHANGELOG.md` with the new operation.

### Testing:
- Verified the operation with new test cases in `ops_util_test.go`.
- Ensured that gradients are correctly calculated without generating NaNs for zero vectors.
- Verified across official backends.