### PR TITLE
Fix handling of zero-sized tensors and 0-length shapes

### DIFF
--- a/pkg/core/dtypes/slices.go
+++ b/pkg/core/dtypes/slices.go
@@ -50,6 +50,9 @@ func UnsafeByteSliceFromAny(flatAny any) []byte {
 
 // UnsafeByteSlice casts a slice of any of the supported Go types to a slice of bytes.
 func UnsafeByteSlice[E Supported](flat []E) []byte {
+	if len(flat) == 0 {
+		return nil
+	}
 	var e E
 	elementSize := int(unsafe.Sizeof(e))
 	return unsafe.Slice((*byte)(unsafe.Pointer(&flat[0])), len(flat)*elementSize)

--- a/pkg/core/tensors/local.go
+++ b/pkg/core/tensors/local.go
@@ -181,6 +181,10 @@ func ConstFlatData[T dtypes.Supported](t *Tensor, accessFn func(flat []T)) error
 		return errors.Errorf("MustConstFlatData[%T] is incompatible with Tensor's dtype %s -- expected dtype %s",
 			v, t.shape.DType, dtypes.FromGenericsType[T]())
 	}
+	if t.shape.Size() == 0 {
+		accessFn(nil)
+		return nil
+	}
 	return t.ConstFlatData(func(anyFlat any) {
 		flat := anyFlat.([]T)
 		accessFn(flat)
@@ -310,6 +314,11 @@ func (t *Tensor) lockedMutableFlatData(accessFn func(flat any)) error {
 // See Tensor.ConstBytes for constant access to the data as bytes -- that doesn't invalidate the device storage.
 func (t *Tensor) MutableBytes(accessFn func(data []byte)) error {
 	return t.MutableFlatData(func(flat any) {
+		if flat == nil {
+			// For empty sized tensors, the flat data is nil.
+			accessFn(nil)
+			return
+		}
 		accessFn(dtypes.UnsafeByteSliceFromAny(flat))
 	})
 }
@@ -339,6 +348,10 @@ func MustMutableFlatData[T dtypes.Supported](t *Tensor, accessFn func(flat []T))
 // This returns the actual Tensor data (not a copy), and the data owned by the Tensor, and should only be changed
 // inside accessFn.
 func MutableFlatData[T dtypes.Supported](t *Tensor, accessFn func(flat []T)) error {
+	if t.shape.Size() == 0 {
+		accessFn(nil)
+		return nil
+	}
 	if t.shape.DType != dtypes.FromGenericsType[T]() {
 		var v T
 		return errors.Errorf("MustMutableFlatData[%T] is incompatible with Tensor's dtype %s",
@@ -378,6 +391,9 @@ func AssignFlatData[T dtypes.Supported](toTensor *Tensor, fromFlat []T) error {
 			)
 			return
 		}
+		if len(toFlat) == 0 {
+			return // Empty tensors.
+		}
 		copy(toFlat, fromFlat)
 	})
 	if accessErr != nil {
@@ -396,14 +412,14 @@ func ToScalar[T dtypes.Supported](t *Tensor) T {
 	defer t.mu.Unlock()
 	t.AssertValid()
 	t.mustLockedMaterializeLocal()
+	if !t.shape.IsScalar() {
+		var v T
+		exceptions.Panicf("ToScalar[%T] requires scalar Tensor, got shape %s instead", v, t.shape)
+	}
 	if t.shape.DType != dtypes.FromGenericsType[T]() {
 		var v T
 		exceptions.Panicf("ToScalar[%T] is incompatible with Tensor's dtype %s",
 			v, t.shape.DType)
-	}
-	if !t.shape.IsScalar() {
-		var v T
-		exceptions.Panicf("ToScalar[%T] requires scalar Tensor, got shape %s instead", v, t.shape)
 	}
 	return t.local.flat.([]T)[0]
 }

--- a/pkg/core/tensors/local_test.go
+++ b/pkg/core/tensors/local_test.go
@@ -484,3 +484,77 @@ func TestFromShape(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptySizeAccess(t *testing.T) {
+	testCases := []struct {
+		dtype dtypes.DType
+	}{
+		{dtypes.Float32},
+		{dtypes.Int8},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.dtype), func(t *testing.T) {
+			shape := shapes.Make(tc.dtype, 10, 0, 3)
+			tensor := FromShape(shape)
+
+			// t.MutableFlatData
+			err := tensor.MutableFlatData(func(flat any) {
+				switch tc.dtype {
+				case dtypes.Float32:
+					slice := flat.([]float32)
+					require.Len(t, slice, 0)
+				case dtypes.Int8:
+					slice := flat.([]int8)
+					require.Len(t, slice, 0)
+				}
+			})
+			require.NoError(t, err)
+
+			// t.ConstFlatData
+			err = tensor.ConstFlatData(func(flat any) {
+				switch tc.dtype {
+				case dtypes.Float32:
+					slice := flat.([]float32)
+					require.Len(t, slice, 0)
+				case dtypes.Int8:
+					slice := flat.([]int8)
+					require.Len(t, slice, 0)
+				}
+			})
+			require.NoError(t, err)
+
+			// t.MutableBytes
+			err = tensor.MutableBytes(func(data []byte) {
+				require.Len(t, data, 0)
+			})
+			require.NoError(t, err)
+
+			// tensors.MutableFlatData[T]
+			if tc.dtype == dtypes.Float32 {
+				err = MutableFlatData(tensor, func(flat []float32) {
+					require.Len(t, flat, 0)
+				})
+				require.NoError(t, err)
+			} else if tc.dtype == dtypes.Int8 {
+				err = MutableFlatData(tensor, func(flat []int8) {
+					require.Len(t, flat, 0)
+				})
+				require.NoError(t, err)
+			}
+
+			// tensors.ConstFlatData[T]
+			if tc.dtype == dtypes.Float32 {
+				err = ConstFlatData(tensor, func(flat []float32) {
+					require.Len(t, flat, 0)
+				})
+				require.NoError(t, err)
+			} else if tc.dtype == dtypes.Int8 {
+				err = ConstFlatData(tensor, func(flat []int8) {
+					require.Len(t, flat, 0)
+				})
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/core/tensors/ondevice.go
+++ b/pkg/core/tensors/ondevice.go
@@ -643,10 +643,13 @@ func FromShapeForBackend(backend backends.Backend, deviceNum backends.DeviceNum,
 		return nil, err
 	}
 
-	// Initialize the shared memory with zeros to match FromShape.
-	t.MutableBytes(func(buf []byte) {
-		clear(buf)
-	})
+	// If not shared, it's already initialized with zeros by FromShape.
+	if t.isShared && t.Size() > 0 {
+		// Initialize the shared memory with zeros to match FromShape.
+		t.MutableBytes(func(buf []byte) {
+			clear(buf)
+		})
+	}
 	return t, nil
 }
 


### PR DESCRIPTION
This PR addresses issues when creating or handling tensors with zero-sized dimensions or 0-length shapes. It ensures that FromShape and other creation functions properly manage these edge cases, particularly when interacting with backend-specific requirements.

**Summary of changes:**
- Updated `pkg/core/dtypes/slices.go` for slice handling improvements.
- Enhanced `pkg/core/tensors/local.go` and `pkg/core/tensors/ondevice.go` to support zero-sized tensors.
- Added comprehensive unit tests in `pkg/core/tensors/local_test.go` to cover these scenarios.