### PR TITLE
feat: add WithEnsembleSize to layers/fnn for parallel independent execution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,7 +38,7 @@
   - Split `Encoder` API into `QKEncoder` and `PreEncoder`, to support different types of positional encoders.
   - Added `WithSlidingWindow` to support "sliding attention" (the slow way).
 - Package `layers/fnn`:
-  - Added `WithEnsembleSize` method for configuring parallel independent executions via ensembles.
+  - Added `WithEnsembleSize` and `WithEnsembleAxis` methods for configuring parallel independent executions via ensembles.
 - Package `transfromers`:
   - Updates and fixes to the API; Added methods to build partial models: `AllLayers`, `ForwardLayer`, `LogitsFromEmbeddings`, `EmbedTokesn`, etc.
   - Updated positional-encoder support.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,8 @@
 - Package `attention/pos`:
   - Split `Encoder` API into `QKEncoder` and `PreEncoder`, to support different types of positional encoders.
   - Added `WithSlidingWindow` to support "sliding attention" (the slow way).
+- Package `layers/fnn`:
+  - Added `WithEnsembleSize` method for configuring parallel independent executions via ensembles.
 - Package `transfromers`:
   - Updates and fixes to the API; Added methods to build partial models: `AllLayers`, `ForwardLayer`, `LogitsFromEmbeddings`, `EmbedTokesn`, etc.
   - Updated positional-encoder support.

--- a/pkg/ml/context/context.go
+++ b/pkg/ml/context/context.go
@@ -389,6 +389,11 @@ func (ctx *Context) WithInitializer(initializer VariableInitializer) *Context {
 	return ctx2
 }
 
+// Initializer returns the initializer configured for the context.
+func (ctx *Context) Initializer() VariableInitializer {
+	return ctx.initializer
+}
+
 // GetParam returns the value for the given param key, searching successively from
 // the current scope back to the root scope ("/"), in case the key is not found.
 //
@@ -1115,7 +1120,7 @@ func (ctx *Context) EnumerateVariablesInScope(fn func(v *Variable)) {
 }
 
 // IterVariablesInScope is similar to IterVariables, but enumerate only those under the current
-// context scope.
+// context scope -- including sub-scopes.
 func (ctx *Context) IterVariablesInScope() iter.Seq[*Variable] {
 	baseScope := ctx.Scope()
 	return func(yield func(*Variable) bool) {

--- a/pkg/ml/layers/fnn/fnn.go
+++ b/pkg/ml/layers/fnn/fnn.go
@@ -69,6 +69,7 @@ type Config struct {
 	input                           *Node
 	outputDimensions                []int
 	numHiddenLayers, numHiddenNodes int
+	ensembleSize                    int
 	activation                      activations.Type
 	normalization                   string
 	dropoutRatio                    float64
@@ -134,6 +135,13 @@ func New(ctx *context.Context, input *Node, outputDimensions ...int) *Config {
 	if c.dropoutRatio < 0 {
 		c.dropoutRatio = context.GetParamOr(ctx, layers.ParamDropoutRate, 0.0)
 	}
+	return c
+}
+
+// WithEnsembleSize configure an ensemble size greater than 1, which adds an extra "ensemble axis"
+// to the variables and intermediary layers, executing the FNN as an ensemble.
+func (c *Config) WithEnsembleSize(ensembleSize int) *Config {
+	c.ensembleSize = ensembleSize
 	return c
 }
 
@@ -228,6 +236,8 @@ func (c *Config) Done() *Node {
 	g := x.Graph()
 	dtype := x.DType()
 
+	isEnsemble := c.ensembleSize > 1
+
 	var dropoutRatio *Node
 	if c.dropoutRatio > 0.0 {
 		dropoutRatio = Scalar(g, dtype, c.dropoutRatio)
@@ -266,13 +276,31 @@ func (c *Config) Done() *Node {
 				x = Add(x, residual)
 			}
 			residual = x
+
+			// Adjust residual shape alignment to match the structural shape
+			// transition executed by DotGeneral for layers passing from ii=1 to ii>1
+			if isEnsemble && ii == 1 {
+				perm := make([]int, residual.Rank())
+				batchRank := residual.Rank() - 1 - len(outputDims)
+				perm[0] = batchRank
+				for j := 0; j < batchRank; j++ {
+					perm[j+1] = j
+				}
+				for j := batchRank + 1; j < residual.Rank(); j++ {
+					perm[j] = j
+				}
+				residual = TransposeAllAxes(residual, perm...)
+			}
 		}
 
 		// Linear transformation
 		inputLastDimension := x.Shape().Dimensions[x.Rank()-1]
-		weightsDims := make([]int, 1+len(outputDims))
-		weightsDims[0] = inputLastDimension
-		copy(weightsDims[1:], outputDims)
+		weightsDims := make([]int, 0, 2+len(outputDims))
+		if isEnsemble {
+			weightsDims = append(weightsDims, c.ensembleSize)
+		}
+		weightsDims = append(weightsDims, inputLastDimension)
+		weightsDims = append(weightsDims, outputDims...)
 		weightsVar := layerCtx.VariableWithShape("weights", shapes.Make(dtype, weightsDims...))
 		if c.regularizer != nil {
 			// Only for the weights, not for the bias.
@@ -281,10 +309,62 @@ func (c *Config) Done() *Node {
 		weights := weightsVar.ValueGraph(g)
 		var biasNode *Node
 		if c.useBias {
-			biasVar := layerCtx.VariableWithShape("biases", shapes.Make(dtype, outputDims...))
+			biasDims := make([]int, 0, 1+len(outputDims))
+			if isEnsemble {
+				biasDims = append(biasDims, c.ensembleSize)
+			}
+			biasDims = append(biasDims, outputDims...)
+			biasVar := layerCtx.VariableWithShape("biases", shapes.Make(dtype, biasDims...))
 			biasNode = biasVar.ValueGraph(g)
 		}
-		x = nn.Dense(x, weights, biasNode)
+
+		if !isEnsemble {
+			x = nn.Dense(x, weights, biasNode)
+		} else {
+			switch ii {
+			case 0:
+				x = Dot(x, weights).General([]int{x.Rank() - 1}, nil, []int{1}, nil)
+				if biasNode != nil {
+					x = Add(x, ExpandLeftToRank(biasNode, x.Rank()))
+				}
+			case 1:
+				x = Dot(x, weights).General([]int{x.Rank() - 1}, []int{x.Rank() - 2}, []int{1}, []int{0})
+				if biasNode != nil {
+					batchRank := x.Rank() - 1 - len(outputDims)
+					axesToInsert := make([]int, batchRank)
+					for j := 0; j < batchRank; j++ {
+						axesToInsert[j] = 1 + j
+					}
+					x = Add(x, ExpandAxes(biasNode, axesToInsert...))
+				}
+			default:
+				x = Dot(x, weights).General([]int{x.Rank() - 1}, []int{0}, []int{1}, []int{0})
+				if biasNode != nil {
+					batchRank := x.Rank() - 1 - len(outputDims)
+					axesToInsert := make([]int, batchRank)
+					for j := 0; j < batchRank; j++ {
+						axesToInsert[j] = 1 + j
+					}
+					x = Add(x, ExpandAxes(biasNode, axesToInsert...))
+				}
+			}
+		}
 	}
+
+	if isEnsemble && c.numHiddenLayers > 0 {
+		// x is currently [E, B..., Out...].
+		// Transpose back to [B..., E, Out...]
+		perm := make([]int, x.Rank())
+		batchRank := x.Rank() - 1 - len(c.outputDimensions)
+		for j := 0; j < batchRank; j++ {
+			perm[j] = j + 1
+		}
+		perm[batchRank] = 0
+		for j := batchRank + 1; j < x.Rank(); j++ {
+			perm[j] = j
+		}
+		x = TransposeAllAxes(x, perm...)
+	}
+
 	return x
 }

--- a/pkg/ml/layers/fnn/fnn.go
+++ b/pkg/ml/layers/fnn/fnn.go
@@ -213,8 +213,8 @@ func (c *Config) Regularizer(regularizer regularizers.Regularizer) *Config {
 // The default is 0.0, but it can be overridden by setting the hyperparameter layers.ParamDropoutRate (="dropout_rate")
 // in the context.
 func (c *Config) Dropout(ratio float64) *Config {
-	if ratio < 0 || ratio >= 1.0 {
-		exceptions.Panicf("fnn: invalid dropout ratio %f -- set to 0.0 to disable it, and it must be < 1.0 otherwise everything is dropped out",
+	if ratio >= 1.0 {
+		exceptions.Panicf("fnn: invalid dropout ratio %f -- set to <= 0.0 to disable it, and it must be < 1.0 otherwise everything is dropped out",
 			ratio)
 	}
 	c.dropoutRatio = ratio

--- a/pkg/ml/layers/fnn/fnn.go
+++ b/pkg/ml/layers/fnn/fnn.go
@@ -70,6 +70,7 @@ type Config struct {
 	outputDimensions                []int
 	numHiddenLayers, numHiddenNodes int
 	ensembleSize                    int
+	ensembleAxis                    int
 	activation                      activations.Type
 	normalization                   string
 	dropoutRatio                    float64
@@ -118,6 +119,7 @@ func New(ctx *context.Context, input *Node, outputDimensions ...int) *Config {
 		ctx:              ctx,
 		input:            input,
 		outputDimensions: outputDimensions,
+		ensembleAxis:     -1,
 		numHiddenLayers:  context.GetParamOr(ctx, ParamNumHiddenLayers, 0),
 		numHiddenNodes:   context.GetParamOr(ctx, ParamNumHiddenNodes, 10),
 		activation:       activations.FromName(context.GetParamOr(ctx, activations.ParamActivation, "relu")),
@@ -140,8 +142,35 @@ func New(ctx *context.Context, input *Node, outputDimensions ...int) *Config {
 
 // WithEnsembleSize configure an ensemble size greater than 1, which adds an extra "ensemble axis"
 // to the variables and intermediary layers, executing the FNN as an ensemble.
+//
+// See WithEnsembleAxis for an alternative way to configure ensembles, when your input is already
+// split into the ensemble.
 func (c *Config) WithEnsembleSize(ensembleSize int) *Config {
 	c.ensembleSize = ensembleSize
+	return c
+}
+
+// WithEnsembleAxis defined an axis from the input operand that should be
+// considered as separate per model of the ensemble.
+//
+// It initializes the ensemble size from the input shape's given axis.
+//
+// This is used when constructing upper layers of an ensemble model, when the input has
+// already been transformer be per model of the ensemble -- hence it already has an ensemble axis.
+//
+// See WithEnsembleSize if you want to configure an ensemble for a plain input, which hasn't been
+// transformed per model of the ensemble, and hence doesn't have an ensemble axis.
+func (c *Config) WithEnsembleAxis(ensembleAxis int) *Config {
+	if ensembleAxis < 0 {
+		ensembleAxis = MustAdjustAxis(ensembleAxis, c.input)
+	}
+	c.ensembleAxis = ensembleAxis
+	dim := c.input.Shape().Dimensions[ensembleAxis]
+	if c.ensembleSize > 0 && c.ensembleSize != dim {
+		exceptions.Panicf("fnn: WithEnsembleAxis(%d), input shape is %s, corresponding dimension is %d, but ensembleSize is already %d",
+			ensembleAxis, c.input.Shape(), dim, c.ensembleSize)
+	}
+	c.ensembleSize = dim
 	return c
 }
 
@@ -279,7 +308,7 @@ func (c *Config) Done() *Node {
 
 			// Adjust residual shape alignment to match the structural shape
 			// transition executed by DotGeneral for layers passing from ii=1 to ii>1
-			if isEnsemble && ii == 1 {
+			if isEnsemble && c.ensembleAxis < 0 && ii == 1 {
 				perm := make([]int, residual.Rank())
 				batchRank := residual.Rank() - 1 - len(outputDims)
 				perm[0] = batchRank
@@ -320,6 +349,20 @@ func (c *Config) Done() *Node {
 
 		if !isEnsemble {
 			x = nn.Dense(x, weights, biasNode)
+		} else if c.ensembleAxis >= 0 {
+			if ii == 0 {
+				x = Dot(x, weights).General([]int{x.Rank() - 1}, []int{c.ensembleAxis}, []int{1}, []int{0})
+			} else {
+				x = Dot(x, weights).General([]int{x.Rank() - 1}, []int{0}, []int{1}, []int{0})
+			}
+			if biasNode != nil {
+				batchRank := x.Rank() - 1 - len(outputDims)
+				axesToInsert := make([]int, batchRank)
+				for j := 0; j < batchRank; j++ {
+					axesToInsert[j] = 1 + j
+				}
+				x = Add(x, ExpandAxes(biasNode, axesToInsert...))
+			}
 		} else {
 			switch ii {
 			case 0:
@@ -351,19 +394,27 @@ func (c *Config) Done() *Node {
 		}
 	}
 
-	if isEnsemble && c.numHiddenLayers > 0 {
-		// x is currently [E, B..., Out...].
-		// Transpose back to [B..., E, Out...]
-		perm := make([]int, x.Rank())
-		batchRank := x.Rank() - 1 - len(c.outputDimensions)
-		for j := 0; j < batchRank; j++ {
-			perm[j] = j + 1
+	if isEnsemble {
+		needsTranspose := false
+		pos := x.Rank() - 1 - len(c.outputDimensions)
+		if c.ensembleAxis >= 0 {
+			pos = c.ensembleAxis
+			needsTranspose = true
+		} else if c.numHiddenLayers > 0 {
+			needsTranspose = true
 		}
-		perm[batchRank] = 0
-		for j := batchRank + 1; j < x.Rank(); j++ {
-			perm[j] = j
+
+		if needsTranspose {
+			perm := make([]int, x.Rank())
+			for j := 0; j < pos; j++ {
+				perm[j] = j + 1
+			}
+			perm[pos] = 0
+			for j := pos + 1; j < x.Rank(); j++ {
+				perm[j] = j
+			}
+			x = TransposeAllAxes(x, perm...)
 		}
-		x = TransposeAllAxes(x, perm...)
 	}
 
 	return x

--- a/pkg/ml/layers/fnn/fnn_test.go
+++ b/pkg/ml/layers/fnn/fnn_test.go
@@ -203,3 +203,29 @@ func TestFNNRegularized(t *testing.T) {
 		numZeros,
 	)
 }
+
+func TestFNNEnsembleShapes(t *testing.T) {
+	backend := graphtest.BuildTestBackend()
+
+	for _, numHiddenLayers := range []int{0, 1, 2} {
+		for _, useBias := range []bool{false, true} {
+			for _, useResidual := range []bool{false, true} {
+				t.Run(fmt.Sprintf("hidden=%d_bias=%t_residual=%t", numHiddenLayers, useBias, useResidual), func(t *testing.T) {
+					ctx := context.New()
+					g := NewGraph(backend, "test_ensemble_shapes")
+					input := Ones(g, shapes.Make(dtypes.Float32, 3, 2, 4)) // batch=[3, 2], F=4
+
+					fnnOutput := New(ctx.In("model"), input, 5, 6).
+						NumHiddenLayers(numHiddenLayers, 8). // 8 nodes in hidden layers
+						WithEnsembleSize(7).
+						UseBias(useBias).
+						Residual(useResidual).
+						Done()
+
+					assert.Equal(t, shapes.Make(dtypes.Float32, 3, 2, 7, 5, 6), fnnOutput.Shape())
+					ctx.Finalize()
+				})
+			}
+		}
+	}
+}

--- a/pkg/ml/layers/fnn/fnn_test.go
+++ b/pkg/ml/layers/fnn/fnn_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/gomlx/gomlx/backends"
 	"github.com/gomlx/gomlx/pkg/core/dtypes"
 	. "github.com/gomlx/gomlx/pkg/core/graph"
 	"github.com/gomlx/gomlx/pkg/core/graph/graphtest"
@@ -186,7 +187,7 @@ func TestFNNRegularized(t *testing.T) {
 		require.NotNilf(t, v, "failed to inspect variable scope=%q, name=%q", scope, vName)
 		tensor := v.MustValue()
 		fmt.Printf("\t%s : %s -> %v\n", v.Scope(), v.Name(), tensor)
-		tensors.MustConstFlatData[float64](tensor, func(flat []float64) {
+		tensors.MustConstFlatData(tensor, func(flat []float64) {
 			for _, element := range flat {
 				if element == 0.0 {
 					numZeros++
@@ -205,27 +206,48 @@ func TestFNNRegularized(t *testing.T) {
 }
 
 func TestFNNEnsembleShapes(t *testing.T) {
-	backend := graphtest.BuildTestBackend()
+	graphtest.TestOfficialBackends(t, func(t *testing.T, backend backends.Backend) {
+		for _, hasEnsembleAxis := range []bool{false, true} {
+			for _, numHiddenLayers := range []int{0, 1, 2} {
+				for _, useBias := range []bool{false, true} {
+					for _, useResidual := range []bool{false, true} {
+						t.Run(fmt.Sprintf("ensembleAxis=%t_hidden=%d_bias=%t_residual=%t", hasEnsembleAxis, numHiddenLayers, useBias, useResidual), func(t *testing.T) {
+							ctx := context.New()
+							g := NewGraph(backend, "test_ensemble_shapes")
 
-	for _, numHiddenLayers := range []int{0, 1, 2} {
-		for _, useBias := range []bool{false, true} {
-			for _, useResidual := range []bool{false, true} {
-				t.Run(fmt.Sprintf("hidden=%d_bias=%t_residual=%t", numHiddenLayers, useBias, useResidual), func(t *testing.T) {
-					ctx := context.New()
-					g := NewGraph(backend, "test_ensemble_shapes")
-					input := Ones(g, shapes.Make(dtypes.Float32, 3, 2, 4)) // batch=[3, 2], F=4
+							var input *Node
+							if hasEnsembleAxis {
+								// Insert ensemble axis at index 1 -> [3, 7, 2, 4]
+								input = Ones(g, shapes.Make(dtypes.Float32, 3, 7, 2, 4))
+							} else {
+								input = Ones(g, shapes.Make(dtypes.Float32, 3, 2, 4)) // batch=[3, 2], F=4
+							}
 
-					fnnOutput := New(ctx.In("model"), input, 5, 6).
-						NumHiddenLayers(numHiddenLayers, 8). // 8 nodes in hidden layers
-						WithEnsembleSize(7).
-						UseBias(useBias).
-						Residual(useResidual).
-						Done()
+							config := New(ctx.In("model"), input, 5, 6).
+								NumHiddenLayers(numHiddenLayers, 8). // 8 nodes in hidden layers
+								UseBias(useBias).
+								Residual(useResidual)
 
-					assert.Equal(t, shapes.Make(dtypes.Float32, 3, 2, 7, 5, 6), fnnOutput.Shape())
-					ctx.Finalize()
-				})
+							if hasEnsembleAxis {
+								config.WithEnsembleAxis(1)
+							} else {
+								config.WithEnsembleSize(7)
+							}
+
+							fnnOutput := config.Done()
+
+							var expectedShape shapes.Shape
+							if hasEnsembleAxis {
+								expectedShape = shapes.Make(dtypes.Float32, 3, 7, 2, 5, 6)
+							} else {
+								expectedShape = shapes.Make(dtypes.Float32, 3, 2, 7, 5, 6)
+							}
+							assert.Equal(t, expectedShape, fnnOutput.Shape())
+							ctx.Finalize()
+						})
+					}
+				}
 			}
 		}
-	}
+	}, "xla:cuda") // No need to test xla:cuda, we are only checking the shape logic.
 }


### PR DESCRIPTION
## Summary
This PR introduces support for ensemble training and execution in the `layers/fnn` package by adding a `WithEnsembleSize(ensembleSize)` configuration method. This allows running multiple independent instances of an FNN in parallel, with an additional "ensemble dimension" added to the weights, biases, and outputs.

### Changes
- **`pkg/ml/layers/fnn`**:
    - Added `WithEnsembleSize(ensembleSize int)` and `WithEnsembleAxis` to `Config` (alternative ways to defined ensemble usage).
    - Updated `Dropout(ratio float64)` to accept values <= 0.0 to disable it.
    - Implemented logic in `Done()` to handle the ensemble dimension across multiple layers, including residual connections and shape transformations.
    - Added `TestFNNEnsembleShapes` to verify output shapes for various ensemble configurations (hidden layers, bias, residuals).
- **`pkg/ml/context`**:
    - Added `Initializer()` accessor to `Context` to allow retrieving the configured variable initializer.
    - Updated `IterVariablesInScope` documentation for clarity.
- **`docs/CHANGELOG.md`**:
    - Documented the addition of `WithEnsembleSize` in the `layers/fnn` package.

### Verification
- Added `TestFNNEnsembleShapes` in `pkg/ml/layers/fnn/fnn_test.go` which covers various combinations of pre-existance of ensemble axis, hidden layers, bias, and residuals with an ensemble size > 1.
- All existing tests in `pkg/ml/layers/fnn` and `pkg/ml/context` pass.