### PR TITLE
docs: complete AI SKILL.md guide for GoMLX and add PyTorch reference tables

### DIFF
--- a/.agents/skills/golang-gomlx/SKILL.md
+++ b/.agents/skills/golang-gomlx/SKILL.md
@@ -115,7 +115,7 @@ func DenseLayer(ctx *context.Context, x *Node, outputDim int) *Node {
 	weightsVar := ctx.VariableWithShape("weights", shapes.Make(x.DType(), inputDim, outputDim))
 	biasVar := ctx.VariableWithShape("bias", shapes.Make(x.DType(), outputDim))
 
-	x = Dot(x, weightsVar.ValueGraph(x.Graph()))
+	x = Dot(x, weightsVar.ValueGraph(x.Graph())).Product()
 	return Add(x, biasVar.ValueGraph(x.Graph()))
 }
 ```
@@ -136,5 +136,34 @@ func DenseLayer(ctx *context.Context, x *Node, outputDim int) *Node {
   - Metrics are provided as lists during `train.NewTrainer` initialization (one list for train metrics, one for eval metrics).
   - Common metrics include `metrics.NewMeanBinaryLogitsAccuracy()`, `metrics.NewSparseCategoricalAccuracy()`.
 - `train.Loop` manages the iterative process, feeding datasets to the `Trainer` and calling callbacks (e.g., checkpoint saving, plotting).
-  - Use `loop.RunSteps(...)` or `loop.RunEpochs(...)` to execute the training process.
+
+Example Training Pipeline:
+
+```go
+// 1. Create dataset
+trainDS := CreateDataset(...)
+
+// 2. Metrics we are interested in.
+meanAccuracyMetric := metrics.NewMeanBinaryLogitsAccuracy("Mean Accuracy", "#acc")
+movingAccuracyMetric := metrics.NewMovingAverageBinaryLogitsAccuracy("Moving Average Accuracy", "~acc", 0.01)
+
+// 3. Create a train.Trainer: orchestrates running the model, feeding results to the optimizer, evaluating metrics.
+trainer := train.NewTrainer(backend, ctx, Model, losses.BinaryCrossentropyLogits,
+	optimizers.FromContext(ctx),
+	[]metrics.Interface{movingAccuracyMetric}, // trainMetrics
+	[]metrics.Interface{meanAccuracyMetric})   // evalMetrics
+
+// 4. Create a standard training loop
+loop := train.NewLoop(trainer)
+
+// 5. Attach a progress bar to the loop.
+commandline.AttachProgressBar(loop)
+
+// 6. Get hyperparameters and run the training loop
+trainSteps := context.GetParamOr(ctx, "train_steps", 1000)
+_, err := loop.RunToGlobalStep(trainDS, trainSteps)
+if err != nil {
+	return err
+}
+```
 

--- a/.agents/skills/golang-gomlx/SKILL.md
+++ b/.agents/skills/golang-gomlx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: golang-gomlx
-description: Machine learning models training and inference using GoMLX for Go. It provides an abstraction to create vectorized computation graphs, that can then be JIT-compiled (Just-In-Time) and executed very fast, with backends using XLA (for CPU/CUDA/TPU), Go and others. Includes a reach set of vector (tensors) operations on the graph, a rich ML library with various type of layers, support for training variables, optimizers, training loops, dataset iterators and more. Apply this skill when working ML projects, or needing to do very efficient vectorized (tensor) computations, like image processing, physics or chemestry simulation, etc."
+description: "Machine learning models training and inference using GoMLX for Go. It provides an abstraction to create vectorized computation graphs, that can then be JIT-compiled (Just-In-Time) and executed very fast, with backends using XLA (for CPU/CUDA/TPU), Go and others. Includes a reach set of vector (tensors) operations on the graph, a rich ML library with various type of layers, support for training variables, optimizers, training loops, dataset iterators and more. Apply this skill when working ML projects, or needing to do very efficient vectorized (tensor) computations, like image processing, physics or chemestry simulation, etc."
 user-invocable: true
 license: MIT
 compatibility: Designed for Claude Code or similar AI coding agents, and for projects using Golang.
@@ -25,7 +25,7 @@ allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(g
 
 **Official Resources:**
 
-- [pkg.go.dev/github.com/gomlx/gomlx](pkg.go.dev/github.com/gomlx/gomlx)
+- [pkg.go.dev/github.com/gomlx/gomlx](https://pkg.go.dev/github.com/gomlx/gomlx)
 - [github.com/gomlx/gomlx](https://github.com/gomlx/gomlx)
 
 This skill is not exhaustive. Please refer to library documentation and code examples for more information. 
@@ -36,22 +36,26 @@ go get -u github.com/gomlx/gomlx
 
 ## Core Concepts
 
-- Shapes and Data Types (DTypes) (`github.com/gomlx/gomlx/pkg/core/dtypes` and `github.com/gomlx/gomlx/pkg/core/shapes`): ...
-- Computation Graph (`github.com/gomlx/gomlx/pkg/core/graph`): The `Graph` object...
-  - Executor:...
+- Shapes and Data Types (DTypes) (`github.com/gomlx/gomlx/pkg/core/dtypes` and `github.com/gomlx/gomlx/pkg/core/shapes`):
+  - `dtypes` define the underlying type of the data (e.g. `dtypes.Float32`, `dtypes.Int64`, `dtypes.Bool`).
+  - `shapes.Shape` represents the multi-dimensional structure of a tensor, including its `DType` and its `Dimensions` (a slice of integers). Shapes are strictly checked during graph building.
+- Computation Graph (`github.com/gomlx/gomlx/pkg/core/graph`): The `Graph` object is the container for computation nodes.
+  - Computations are built using `*Node` objects. Each node represents an operation or a value.
+  - The graph building phase is separate from the execution phase. You build the graph first, then execute it.
+  - Executor: (`graph.Exec` or `context.Exec`) takes a graph-building function, JIT-compiles it, and provides methods to execute it.
 - Backends (`github.com/gomlx/gomlx/backends`): It abstracts backend engines to execute computations on devices (accelerators or the CPU itself). 
   One doesn't need to interact with it directly except if implementing one, just need to pass it around, and know that they exist.
   Usually, one imports (`import _ "github.com/gomlx/gomlx/backends/default"`) to include support for the default backends.
   And the end user can set the environment variable `GOMLX_BACKEND` to specify in runtime a different backend, if they want.
   The default backend uses XLA for GPU/TPU is available.
-- Tensors: (`github.com/gomlx/gomlx/tensors`): These represent actual values, that can have local storage or "on-device" (accelerator) storage.
+- Tensors: (`github.com/gomlx/gomlx/pkg/core/tensors`): These represent actual values, that can have local storage or "on-device" (accelerator) storage.
   Usually, they are only used as inputs and outputs of computations, or to save, load or print values. Most methods are about conversion or
-  access to the underlying data.
-- Context: (`github.com/gomlx/gomlx/pkg/ml/context`): ...
+  access to the underlying data (e.g., `tensor.Value()` returns a generic value, or `tensor.Local().Copy()` for moving back to CPU memory).
+- Context: (`github.com/gomlx/gomlx/pkg/ml/context`): A container for stateful variables (like model weights) and hyperparameters. It has reference semantics.
 
 ### Creating a graph computation -- package `github.com/gomlx/gomlx/pkg/core/graph`
 
-- Computation building functions usually take only `*graph.Node` as input and outputs. 
+- Computation building functions usually take only `*Node` as input and outputs.
 - Computation building functions are never concurrent: they are always meant to be executed sequentially. 
   Later the JIT-compiled graph is executed with concurrency, but it's building is always sequential.
 - Errors are returned with "execeptions" (panics with an error), not to clutter the math with contant error checking.
@@ -61,6 +65,7 @@ go get -u github.com/gomlx/gomlx
   than one shape.
 - For files that define large or various computations, it's common practice to "dot import" the `graph` package
   with `import . "github.com/gomlx/gomlx/pkg/core/graph"`, and move all graph computation building functions in its own `.go` file. 
+- **See [`graph` package reference](./references/graph.md)** for a list of common functions and their PyTorch equivalents.
 
 Example:
 
@@ -79,39 +84,57 @@ func EuclideanDistance(a, b *Node) *Node {
 
 ### Executing a graph -- the `graph.Exec` object
 
-- ... New, Exec, Exec1, Exec... methods.
+- It is created with `graph.NewExec(backend, fn)`, where `fn` is the graph-building function.
+- `exec.Call(inputs...)` is used to execute the compiled graph, taking `tensors.Tensor` or standard Go values (slices of slices) and returning `tensors.Tensor`.
 - Inputs are concrete `tensors.Tensor`, but can be any value that can be converted automatically (so slices or slice or slices).
 - The Exec object will automatically recompile the graph, calling again the graph building function, if the shape of the inputs changes.
   It has a limited cache size for different shapes, and compiling a graph is orders of magnitude slower than executing it, so it's better to reuse the same input shapes where possible, using padding to fixed sizes.
-- ... ExecOnce ... ExecN
 
 
-### Tensors
+### Tensors -- package `github.com/gomlx/gomlx/pkg/core/tensors`
 
-- Local/On-Device ...
-- Constructors ...
-- Donation for execution...
-- Automatic 
+- Local/On-Device: Tensors can be instantiated on the local CPU (`tensors.FromValue(...)`) or directly on the backend device device (usually happens automatically for outputs of executions).
+- Constructors: Use `tensors.FromValue(any)` or `tensors.FromShape(shape)` to create tensors.
+- Donation for execution: You can "donate" a tensor to an execution to allow XLA to reuse its memory for outputs using `exec.Call(input1, input2)`. The donated tensor's memory will be overwritten, so it shouldn't be used afterward.
 
 ### Context: container for variables and hyperparameters -- package `github.com/gomlx/gomlx/pkg/ml/context`
 
-- Scope:...
+- Scope: A context represents a hierarchical scope (e.g., `/model/layer1`). You can enter sub-scopes via `ctx.In("layer1")`.
 - `context.Context` has a reference semantics and works as a "current scope path", and can cheaply be copied.
-- Variables:....
-- Hyperparameters:...
-- Checkpointing
-- Trainable
-- `Exec`: ... similar to `graph.Exec` but takes an extra `context.Context` parameter. Variables can be used and set in the graph building,
-  it will handle the passing of its values as inputs and outputs (when updated)...
+- Variables: Are created using `ctx.VariableWithValue(name, value)` or `ctx.VariableWithShape(name, shape)`. Once created, they persist in the context and can be retrieved using `ctx.InspectVariable(...)`.
+- Hyperparameters: Set with `ctx.SetParam("key", value)` and retrieved with `context.GetParamOr(ctx, "key", defaultValue)`.
+- Checkpointing: `checkpoints.New(ctx, dir)` helps save and load the state of all variables in a context.
+- Trainable: Variables are by default trainable.
+- `Exec`: `context.Exec` is similar to `graph.Exec` but designed for ML models. Its builder function takes an extra `*context.Context` parameter. Variables can be used and set in the graph building, and `context.Exec` will handle passing their values as inputs and outputs.
 
 Example:
 
+```go
+func DenseLayer(ctx *context.Context, x *Node, outputDim int) *Node {
+	inputDim := x.Shape().Dimensions[len(x.Shape().Dimensions)-1]
+	weightsVar := ctx.VariableWithShape("weights", shapes.Make(x.DType(), inputDim, outputDim))
+	biasVar := ctx.VariableWithShape("bias", shapes.Make(x.DType(), outputDim))
+
+	x = Dot(x, weightsVar.ValueGraph(x.Graph()))
+	return Add(x, biasVar.ValueGraph(x.Graph()))
+}
+```
 
 ### Machine Learning Layers -- package `github.com/gomlx/gomlx/pkg/ml/layers` and sub-packages
 
-
+- The `layers` package provides standard higher-level building blocks for ML models.
+- Uses `*context.Context` extensively to manage the weights/biases for each layer.
+- Sub-packages include `activations` (Relu, Swish, etc.), `fnn` (feed-forward neural networks), `kan` (Kolmogorov-Arnold Networks), `regularizers`, etc.
+- **See [`layers` package reference](./references/layers.md)** for a list of common layers and their PyTorch equivalents.
 
 ### Training loop -- package `github.com/gomlx/gomlx/pkg/ml/train`
 
-- Example from `examples/adult`...
+- Example from `examples/adult/demo`: Shows a full ML pipeline.
+- `train.Trainer` orchestrates the model function, the loss function, and the optimizer.
+  - Needs `context.Context`, a model function, a loss function (e.g., `losses.BinaryCrossentropyLogits`), and an optimizer (e.g., `optimizers.Adam`).
+- Metrics (`pkg/ml/train/metrics`): Used to evaluate model performance during training and evaluation.
+  - Metrics are provided as lists during `train.NewTrainer` initialization (one list for train metrics, one for eval metrics).
+  - Common metrics include `metrics.NewMeanBinaryLogitsAccuracy()`, `metrics.NewSparseCategoricalAccuracy()`.
+- `train.Loop` manages the iterative process, feeding datasets to the `Trainer` and calling callbacks (e.g., checkpoint saving, plotting).
+  - Use `loop.RunSteps(...)` or `loop.RunEpochs(...)` to execute the training process.
 

--- a/.agents/skills/golang-gomlx/references/graph.md
+++ b/.agents/skills/golang-gomlx/references/graph.md
@@ -44,8 +44,8 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `ReduceMin(x, axes...)` | Computes the minimum along the specified axes. | `torch.amin(x, dim=axes)` |
 | `ArgMax(x, axis)` | Returns the index of the maximum value along an axis. | `torch.argmax(x, dim=axis)` |
 | **Linear Algebra** | | |
-| `Dot(a, b)` | Matrix multiplication (or dot product for 1D). | `torch.matmul(a, b)` or `a @ b` |
-| `DotGeneral(a, axesA, b, axesB)` | Generalized dot product / tensor contraction. | `torch.tensordot(a, b, dims)` |
+| `Dot(a, b).Product()` | Matrix multiplication (or dot product for 1D). Uses the `Dot` builder pattern. | `torch.matmul(a, b)` or `a @ b` |
+| `Dot(a, b).General(aContAxes, aBatchAxes, bContAxes, bBatchAxes)` | Generalized dot product / tensor contraction. Uses the `Dot` builder pattern. | `torch.tensordot(a, b, dims)` |
 | `Einsum(equation, operands...)` | Einstein summation convention. | `torch.einsum(equation, operands)` |
 | **Constants & Generation** | | |
 | `Scalar(g, dtype, value)` | Creates a scalar node in the graph `g`. | `torch.tensor(value, dtype=dtype)` |
@@ -63,4 +63,7 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `LogicalAnd(a, b)` | Element-wise logical AND. | `torch.logical_and(a, b)` |
 | `LogicalOr(a, b)` | Element-wise logical OR. | `torch.logical_or(a, b)` |
 | `LogicalNot(x)` | Element-wise logical NOT. | `torch.logical_not(x)` |
+| `If(pred, trueBranch, falseBranch)` | Conditional execution inside the graph. `trueBranch` and `falseBranch` are `*Function` instances (e.g. from `NewClosure`). | `torch.cond(pred, trueBranch, falseBranch)` |
+| `While(cond, body, initialState...)` | Loop execution inside the graph. `cond` and `body` are `*Function` instances. | `torch.while_loop` equivalent / native Python `while` |
+| `NewClosure(g, func)` | Creates a `*Function` representing a sub-graph computation, used for `If` and `While`. | N/A (Tracing/JIT captures Python functions directly in PyTorch) |
 | `StopGradient(x)` | Prevents gradients from flowing through `x` during backpropagation. | `x.detach()` |

--- a/.agents/skills/golang-gomlx/references/graph.md
+++ b/.agents/skills/golang-gomlx/references/graph.md
@@ -1,0 +1,66 @@
+# GoMLX `graph` Package Reference
+
+This table maps common functions from the `pkg/core/graph` package to their PyTorch equivalents, to help AI agents understand their purpose.
+
+**Note**: It is assumed that the `graph` package is dot-imported (`import . "github.com/gomlx/gomlx/pkg/core/graph"`), so these functions can be called directly without the `graph.` prefix.
+
+| GoMLX `graph` Function | Description | PyTorch Equivalent |
+|---|---|---|
+| **Element-wise Math** | | |
+| `Add(a, b)` | Adds two nodes element-wise. Supports broadcasting. | `a + b` |
+| `Sub(a, b)` | Subtracts `b` from `a` element-wise. | `a - b` |
+| `Mul(a, b)` | Multiplies two nodes element-wise. | `a * b` |
+| `Div(a, b)` | Divides `a` by `b` element-wise. | `a / b` |
+| `Abs(x)` | Element-wise absolute value. | `torch.abs(x)` |
+| `Exp(x)` | Element-wise exponential. | `torch.exp(x)` |
+| `Log(x)` | Element-wise natural logarithm. | `torch.log(x)` |
+| `Log1p(x)` | Element-wise `log(1 + x)`. | `torch.log1p(x)` |
+| `Sqrt(x)` | Element-wise square root. | `torch.sqrt(x)` |
+| `Square(x)` | Element-wise square. | `torch.square(x)` |
+| `Pow(x, y)` | Element-wise power `x^y`. | `torch.pow(x, y)` |
+| `Max(a, b)` | Element-wise maximum of two nodes. | `torch.maximum(a, b)` |
+| `Min(a, b)` | Element-wise minimum of two nodes. | `torch.minimum(a, b)` |
+| `Sin(x)`, `Cos(x)`, `Tanh(x)` | Element-wise trigonometric functions. | `torch.sin(x)`, `torch.cos(x)`, `torch.tanh(x)` |
+| **Shape & Tensor Manipulation** | | |
+| `Reshape(x, dims...)` | Reshapes a node to the given dimensions. | `torch.reshape(x, dims)` or `x.view(dims)` |
+| `TransposeAllDims(x)` | Reverses the order of all dimensions (similar to `.T` in 2D). | `x.T` (for 2D) |
+| `Transpose(x, axes...)` | Permutes the dimensions according to the given axes. | `torch.permute(x, axes)` |
+| `ExpandDims(x, axes...)` | Inserts dimensions of size 1 at the specified axes. | `torch.unsqueeze(x, axis)` |
+| `Squeeze(x, axes...)` | Removes dimensions of size 1 at the specified axes. | `torch.squeeze(x, axis)` |
+| `Slice(x, start, end)` | Slices a tensor along dimensions. | `x[start:end]` |
+| `Concat(axis, nodes...)` | Concatenates a list of nodes along the specified axis. | `torch.cat(nodes, dim=axis)` |
+| `Stack(axis, nodes...)` | Stacks a list of nodes along a new axis. | `torch.stack(nodes, dim=axis)` |
+| `BroadcastToShape(x, shape)` | Broadcasts a node to a target shape. | `x.expand(shape)` |
+| `BroadcastToDims(x, dims...)` | Broadcasts a node to target dimensions. | `x.expand(dims...)` |
+| `Pad(x, padding...)` | Pads a tensor. | `torch.nn.functional.pad(x, ...)` |
+| **Reduction** | | |
+| `ReduceAllSum(x)` | Computes the sum of all elements. | `torch.sum(x)` |
+| `ReduceSum(x, axes...)` | Computes the sum along the specified axes. | `torch.sum(x, dim=axes)` |
+| `ReduceAllMean(x)` | Computes the mean of all elements. | `torch.mean(x)` |
+| `ReduceMean(x, axes...)` | Computes the mean along the specified axes. | `torch.mean(x, dim=axes)` |
+| `ReduceAllMax(x)` | Computes the maximum of all elements. | `torch.max(x)` |
+| `ReduceMax(x, axes...)` | Computes the maximum along the specified axes. | `torch.amax(x, dim=axes)` |
+| `ReduceAllMin(x)` | Computes the minimum of all elements. | `torch.min(x)` |
+| `ReduceMin(x, axes...)` | Computes the minimum along the specified axes. | `torch.amin(x, dim=axes)` |
+| `ArgMax(x, axis)` | Returns the index of the maximum value along an axis. | `torch.argmax(x, dim=axis)` |
+| **Linear Algebra** | | |
+| `Dot(a, b)` | Matrix multiplication (or dot product for 1D). | `torch.matmul(a, b)` or `a @ b` |
+| `DotGeneral(a, axesA, b, axesB)` | Generalized dot product / tensor contraction. | `torch.tensordot(a, b, dims)` |
+| `Einsum(equation, operands...)` | Einstein summation convention. | `torch.einsum(equation, operands)` |
+| **Constants & Generation** | | |
+| `Scalar(g, dtype, value)` | Creates a scalar node in the graph `g`. | `torch.tensor(value, dtype=dtype)` |
+| `Zeros(g, shape)` | Creates a tensor of zeros. | `torch.zeros(shape)` |
+| `Ones(g, shape)` | Creates a tensor of ones. | `torch.ones(shape)` |
+| `ZerosLike(x)` | Creates a tensor of zeros with the same shape and dtype as `x`. | `torch.zeros_like(x)` |
+| `OnesLike(x)` | Creates a tensor of ones with the same shape and dtype as `x`. | `torch.ones_like(x)` |
+| `Iota(g, shape, axis)` | Creates a sequence along `axis`. | `torch.arange(...)` or `torch.linspace(...)` |
+| **Control Flow & Selection** | | |
+| `Where(condition, x, y)` | Selects elements from `x` or `y` based on `condition`. | `torch.where(condition, x, y)` |
+| `Equal(a, b)` | Element-wise equality check. | `a == b` |
+| `NotEqual(a, b)` | Element-wise inequality check. | `a != b` |
+| `GreaterThan(a, b)` | Element-wise greater than check. | `a > b` |
+| `LessThan(a, b)` | Element-wise less than check. | `a < b` |
+| `LogicalAnd(a, b)` | Element-wise logical AND. | `torch.logical_and(a, b)` |
+| `LogicalOr(a, b)` | Element-wise logical OR. | `torch.logical_or(a, b)` |
+| `LogicalNot(x)` | Element-wise logical NOT. | `torch.logical_not(x)` |
+| `StopGradient(x)` | Prevents gradients from flowing through `x` during backpropagation. | `x.detach()` |

--- a/.agents/skills/golang-gomlx/references/graph.md
+++ b/.agents/skills/golang-gomlx/references/graph.md
@@ -53,6 +53,7 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `MaxPool(x).Done()` | Max pooling operation using a builder API. Chain methods like `Window`, `Strides`, then `Done()`. | `torch.nn.functional.max_pool1d`, `max_pool2d`, `max_pool3d` |
 | `MeanPool(x).Done()` | Average pooling operation using a builder API. Chain methods like `Window`, `Strides`, then `Done()`. | `torch.nn.functional.avg_pool1d`, `avg_pool2d`, `avg_pool3d` |
 | **Constants & Generation** | | |
+| `Const(g, value)` | Creates a constant node in the graph `g` from a given value (scalar, slice, tensor, etc). | `torch.tensor(value)` |
 | `Scalar(g, dtype, value)` | Creates a scalar node in the graph `g`. | `torch.tensor(value, dtype=dtype)` |
 | `Zeros(g, shape)` | Creates a tensor of zeros. | `torch.zeros(shape)` |
 | `Ones(g, shape)` | Creates a tensor of ones. | `torch.ones(shape)` |
@@ -78,4 +79,6 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `If(pred, trueBranch, falseBranch)` | Conditional execution inside the graph. `trueBranch` and `falseBranch` are `*Function` instances (e.g. from `NewClosure`). | `torch.cond(pred, trueBranch, falseBranch)` |
 | `While(cond, body, initialState...)` | Loop execution inside the graph. `cond` and `body` are `*Function` instances. | `torch.while_loop` equivalent / native Python `while` |
 | `NewClosure(g, func)` | Creates a `*Function` representing a sub-graph computation, used for `If` and `While`. | N/A (Tracing/JIT captures Python functions directly in PyTorch) |
+| **Autograd / Differentiation** | | |
+| `Gradient(output, gradientNodes...)` | Computes the gradients of `output` with respect to the given `gradientNodes`. | `torch.autograd.grad(output, gradientNodes)` |
 | `StopGradient(x)` | Prevents gradients from flowing through `x` during backpropagation. | `x.detach()` |

--- a/.agents/skills/golang-gomlx/references/graph.md
+++ b/.agents/skills/golang-gomlx/references/graph.md
@@ -25,13 +25,14 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `Reshape(x, dims...)` | Reshapes a node to the given dimensions. | `torch.reshape(x, dims)` or `x.view(dims)` |
 | `TransposeAllDims(x)` | Reverses the order of all dimensions (similar to `.T` in 2D). | `x.T` (for 2D) |
 | `Transpose(x, axes...)` | Permutes the dimensions according to the given axes. | `torch.permute(x, axes)` |
-| `ExpandDims(x, axes...)` | Inserts dimensions of size 1 at the specified axes. | `torch.unsqueeze(x, axis)` |
+| `ExpandAxes(x, axes...)` | Inserts dimensions of size 1 at the specified axes. | `torch.unsqueeze(x, axis)` |
 | `Squeeze(x, axes...)` | Removes dimensions of size 1 at the specified axes. | `torch.squeeze(x, axis)` |
-| `Slice(x, start, end)` | Slices a tensor along dimensions. | `x[start:end]` |
-| `Concat(axis, nodes...)` | Concatenates a list of nodes along the specified axis. | `torch.cat(nodes, dim=axis)` |
+| `Slice(x, axisSpecs...)` | Slices a tensor. Uses `AxisElem(i)`, `AxisRange(start, end)`, or `AxisRangeFromStart()` for specs. | `x[start:end]` |
+| `Concatenate(nodes, axis)` | Concatenates a list of nodes along the specified axis. | `torch.cat(nodes, dim=axis)` |
 | `Stack(axis, nodes...)` | Stacks a list of nodes along a new axis. | `torch.stack(nodes, dim=axis)` |
 | `BroadcastToShape(x, shape)` | Broadcasts a node to a target shape. | `x.expand(shape)` |
 | `BroadcastToDims(x, dims...)` | Broadcasts a node to target dimensions. | `x.expand(dims...)` |
+| `BroadcastPrefix(x, prefixDims...)` | Broadcasts a node by adding the prefix dimensions. | `x.expand(prefixDims + x.shape)` |
 | `Pad(x, padding...)` | Pads a tensor. | `torch.nn.functional.pad(x, ...)` |
 | **Reduction** | | |
 | `ReduceAllSum(x)` | Computes the sum of all elements. | `torch.sum(x)` |
@@ -43,10 +44,14 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `ReduceAllMin(x)` | Computes the minimum of all elements. | `torch.min(x)` |
 | `ReduceMin(x, axes...)` | Computes the minimum along the specified axes. | `torch.amin(x, dim=axes)` |
 | `ArgMax(x, axis)` | Returns the index of the maximum value along an axis. | `torch.argmax(x, dim=axis)` |
-| **Linear Algebra** | | |
+| `ReduceAndKeep(x, reduceFn, axes...)` | Reduces along axes but keeps the reduced dimensions (with size 1). | `torch.sum(x, dim=axes, keepdim=True)` (if reduceFn is sum) |
+| **Linear Algebra & NN Ops** | | |
 | `Dot(a, b).Product()` | Matrix multiplication (or dot product for 1D). Uses the `Dot` builder pattern. | `torch.matmul(a, b)` or `a @ b` |
 | `Dot(a, b).General(aContAxes, aBatchAxes, bContAxes, bBatchAxes)` | Generalized dot product / tensor contraction. Uses the `Dot` builder pattern. | `torch.tensordot(a, b, dims)` |
 | `Einsum(equation, operands...)` | Einstein summation convention. | `torch.einsum(equation, operands)` |
+| `Convolve(x, kernel).Done()` | General convolution operation using a builder API. Chain methods like `Strides`, `PadSame`, then `Done()`. | `torch.nn.functional.conv1d`, `conv2d`, `conv3d` |
+| `MaxPool(x).Done()` | Max pooling operation using a builder API. Chain methods like `Window`, `Strides`, then `Done()`. | `torch.nn.functional.max_pool1d`, `max_pool2d`, `max_pool3d` |
+| `MeanPool(x).Done()` | Average pooling operation using a builder API. Chain methods like `Window`, `Strides`, then `Done()`. | `torch.nn.functional.avg_pool1d`, `avg_pool2d`, `avg_pool3d` |
 | **Constants & Generation** | | |
 | `Scalar(g, dtype, value)` | Creates a scalar node in the graph `g`. | `torch.tensor(value, dtype=dtype)` |
 | `Zeros(g, shape)` | Creates a tensor of zeros. | `torch.zeros(shape)` |
@@ -54,6 +59,7 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `ZerosLike(x)` | Creates a tensor of zeros with the same shape and dtype as `x`. | `torch.zeros_like(x)` |
 | `OnesLike(x)` | Creates a tensor of ones with the same shape and dtype as `x`. | `torch.ones_like(x)` |
 | `Iota(g, shape, axis)` | Creates a sequence along `axis`. | `torch.arange(...)` or `torch.linspace(...)` |
+| `IotaFull(g, shape)` | Creates a sequence taking the full flat length of the shape. | `torch.arange(np.prod(shape)).reshape(shape)` |
 | **Control Flow & Selection** | | |
 | `Where(condition, x, y)` | Selects elements from `x` or `y` based on `condition`. | `torch.where(condition, x, y)` |
 | `Equal(a, b)` | Element-wise equality check. | `a == b` |
@@ -63,6 +69,12 @@ This table maps common functions from the `pkg/core/graph` package to their PyTo
 | `LogicalAnd(a, b)` | Element-wise logical AND. | `torch.logical_and(a, b)` |
 | `LogicalOr(a, b)` | Element-wise logical OR. | `torch.logical_or(a, b)` |
 | `LogicalNot(x)` | Element-wise logical NOT. | `torch.logical_not(x)` |
+| `ReduceLogicalAnd(x, axes...)` | Logical AND reduction along the specified axes. | `torch.all(x, dim=axes)` |
+| `ReduceLogicalOr(x, axes...)` | Logical OR reduction along the specified axes. | `torch.any(x, dim=axes)` |
+| `ReduceLogicalXor(x, axes...)` | Logical XOR reduction along the specified axes. | `torch.bitwise_xor.reduce(x, dim=axes)` (custom) |
+| `ReduceBitwiseAnd(x, axes...)` | Bitwise AND reduction along the specified axes. | `torch.bitwise_and.reduce(x, dim=axes)` (custom) |
+| `ReduceBitwiseOr(x, axes...)` | Bitwise OR reduction along the specified axes. | `torch.bitwise_or.reduce(x, dim=axes)` (custom) |
+| `ReduceBitwiseXor(x, axes...)` | Bitwise XOR reduction along the specified axes. | `torch.bitwise_xor.reduce(x, dim=axes)` (custom) |
 | `If(pred, trueBranch, falseBranch)` | Conditional execution inside the graph. `trueBranch` and `falseBranch` are `*Function` instances (e.g. from `NewClosure`). | `torch.cond(pred, trueBranch, falseBranch)` |
 | `While(cond, body, initialState...)` | Loop execution inside the graph. `cond` and `body` are `*Function` instances. | `torch.while_loop` equivalent / native Python `while` |
 | `NewClosure(g, func)` | Creates a `*Function` representing a sub-graph computation, used for `If` and `While`. | N/A (Tracing/JIT captures Python functions directly in PyTorch) |

--- a/.agents/skills/golang-gomlx/references/layers.md
+++ b/.agents/skills/golang-gomlx/references/layers.md
@@ -1,0 +1,43 @@
+# GoMLX `layers` Package Reference
+
+This table maps common machine learning layers and functions from `pkg/ml/layers` and its sub-packages to their PyTorch equivalents.
+
+| GoMLX Function/Object | Description | PyTorch Equivalent |
+|---|---|---|
+| **Feed-Forward / Linear Layers** (`pkg/ml/layers/fnn`) | | |
+| `fnn.New(ctx, x, hiddenSizes...)` | Creates a multi-layer perceptron (feed-forward neural network) with the given hidden sizes. Often includes optional batch normalization, dropout, etc. depending on context settings. | `torch.nn.Sequential(torch.nn.Linear(...), ...)` |
+| `layers.Dense(ctx, x, true, outputDim)` | A single densely connected layer (linear transformation). The boolean flag dictates whether a bias term is used. | `torch.nn.Linear(in_features, out_features, bias=True)` |
+| **Activations** (`pkg/ml/layers/activations`) | | |
+| `activations.Apply(type, x)` | Applies an activation function specified by an `activations.Type`. | `torch.nn.functional.<activation>(x)` |
+| `activations.Relu(x)` | Applies Rectified Linear Unit activation. | `torch.nn.ReLU()` or `torch.nn.functional.relu(x)` |
+| `activations.Sigmoid(x)` | Applies Sigmoid activation. | `torch.nn.Sigmoid()` or `torch.nn.functional.sigmoid(x)` |
+| `activations.Tanh(x)` | Applies Hyperbolic Tangent activation. | `torch.nn.Tanh()` or `torch.nn.functional.tanh(x)` |
+| `activations.Swish(x)` | Applies Swish activation (`x * sigmoid(x)`). | `torch.nn.SiLU()` or `torch.nn.functional.silu(x)` |
+| `activations.Gelu(x)` | Applies Gaussian Error Linear Unit activation. | `torch.nn.GELU()` or `torch.nn.functional.gelu(x)` |
+| `activations.Softmax(x, axis)` | Applies Softmax activation along the specified axis. | `torch.nn.Softmax(dim=axis)` |
+| **Convolutional Layers** (`pkg/ml/layers`) | | |
+| `layers.Convolution(ctx, x)` | Builder for a convolutional layer (1D, 2D, or 3D inferred from input shape). Use chained methods (e.g., `Filters(n)`, `KernelSize(k)`) and call `Done()` to build. | `torch.nn.Conv1d`, `torch.nn.Conv2d`, `torch.nn.Conv3d` |
+| `layers.Conv2D(ctx, x, filters, kernelSize, strides, padding)` | Shorthand for a 2D convolution. | `torch.nn.Conv2d` |
+| **Pooling Layers** (`pkg/core/graph`) | | |
+| `graph.MaxPool(x)` | Builder for max pooling operation. Use chained methods like `Window(w)`, `Strides(s)`, and `Done()`. | `torch.nn.MaxPool1d`, `torch.nn.MaxPool2d`, `torch.nn.MaxPool3d` |
+| `graph.MeanPool(x)` | Builder for average pooling operation. Use chained methods and `Done()`. | `torch.nn.AvgPool1d`, `torch.nn.AvgPool2d`, `torch.nn.AvgPool3d` |
+| **Normalization Layers** (`pkg/ml/layers/batchnorm`, `pkg/ml/layers/layernorm`) | | |
+| `batchnorm.New(ctx, x, axis)` | Batch Normalization. Use chained methods and `Done()`. The `axis` specifies the feature dimension. | `torch.nn.BatchNorm1d`, `torch.nn.BatchNorm2d`, `torch.nn.BatchNorm3d` |
+| `layernorm.New(ctx, x, axes...)` | Layer Normalization applied over the given axes. Use chained methods and `Done()`. | `torch.nn.LayerNorm` |
+| `rmsnorm.New(ctx, x, axes...)` | Root Mean Square Normalization. | `torch.nn.RMSNorm` |
+| **Regularization / Dropout** (`pkg/ml/layers/regularizers`) | | |
+| `regularizers.Dropout(ctx, x, rate)` | Applies dropout to the input with the given rate (probability of dropping an element). Behavior depends on context phase (training vs eval). | `torch.nn.Dropout(p=rate)` |
+| `regularizers.L2(ctx, name, weight)` | Adds an L2 regularization penalty to a variable (weight decay). | `weight_decay` parameter in `torch.optim` |
+| **Other Advanced Layers** (`pkg/ml/layers/kan`, `pkg/ml/layers/attention`) | | |
+| `kan.New(ctx, x, hiddenSizes...)` | Kolmogorov-Arnold Network block. Uses spline-based learned activation functions instead of fixed ones. | (No direct equivalent, custom implementation required) |
+| `attention.MultiHeadAttention(ctx, query, key, value)` | Standard Multi-Head Attention layer. Builder pattern, finish with `Done()`. | `torch.nn.MultiheadAttention` |
+| **Losses** (`pkg/ml/train/losses`) | | |
+| `losses.MeanSquaredError(labels, predictions)` | Computes the mean squared error loss. | `torch.nn.MSELoss()` |
+| `losses.MeanAbsoluteError(labels, predictions)` | Computes the mean absolute error (L1) loss. | `torch.nn.L1Loss()` |
+| `losses.BinaryCrossentropyLogits(labels, logits)` | Computes binary cross-entropy loss from logits. | `torch.nn.BCEWithLogitsLoss()` |
+| `losses.SparseCategoricalCrossEntropyLogits(labels, logits)` | Computes categorical cross-entropy where labels are sparse integers. | `torch.nn.CrossEntropyLoss()` |
+| `losses.CategoricalCrossEntropyLogits(labels, logits)` | Computes categorical cross-entropy where labels are one-hot encoded. | `torch.nn.CrossEntropyLoss()` |
+| **Optimizers** (`pkg/ml/train/optimizers`) | | |
+| `optimizers.StochasticGradientDescent(ctx)` | Simple SGD optimizer. Configured via context hyperparameters. | `torch.optim.SGD` |
+| `optimizers.Adam(ctx)` | Adam optimizer. Configured via context hyperparameters. | `torch.optim.Adam` |
+| `optimizers.AdamW(ctx)` | Adam optimizer with weight decay. | `torch.optim.AdamW` |

--- a/.agents/skills/golang-gomlx/references/layers.md
+++ b/.agents/skills/golang-gomlx/references/layers.md
@@ -18,9 +18,6 @@ This table maps common machine learning layers and functions from `pkg/ml/layers
 | **Convolutional Layers** (`pkg/ml/layers`) | | |
 | `layers.Convolution(ctx, x)` | Builder for a convolutional layer (1D, 2D, or 3D inferred from input shape). Use chained methods (e.g., `Filters(n)`, `KernelSize(k)`) and call `Done()` to build. | `torch.nn.Conv1d`, `torch.nn.Conv2d`, `torch.nn.Conv3d` |
 | `layers.Conv2D(ctx, x, filters, kernelSize, strides, padding)` | Shorthand for a 2D convolution. | `torch.nn.Conv2d` |
-| **Pooling Layers** (`pkg/core/graph`) | | |
-| `graph.MaxPool(x)` | Builder for max pooling operation. Use chained methods like `Window(w)`, `Strides(s)`, and `Done()`. | `torch.nn.MaxPool1d`, `torch.nn.MaxPool2d`, `torch.nn.MaxPool3d` |
-| `graph.MeanPool(x)` | Builder for average pooling operation. Use chained methods and `Done()`. | `torch.nn.AvgPool1d`, `torch.nn.AvgPool2d`, `torch.nn.AvgPool3d` |
 | **Normalization Layers** (`pkg/ml/layers/batchnorm`, `pkg/ml/layers/layernorm`) | | |
 | `batchnorm.New(ctx, x, axis)` | Batch Normalization. Use chained methods and `Done()`. The `axis` specifies the feature dimension. | `torch.nn.BatchNorm1d`, `torch.nn.BatchNorm2d`, `torch.nn.BatchNorm3d` |
 | `layernorm.New(ctx, x, axes...)` | Layer Normalization applied over the given axes. Use chained methods and `Done()`. | `torch.nn.LayerNorm` |


### PR DESCRIPTION
This PR completes the instructions for AI agents working with GoMLX in the `.agents/skills/golang-gomlx/SKILL.md` file. It fills out the missing sections regarding core concepts like Shapes/DTypes, Computation Graphs, Executors, Tensors, and Contexts, and adds notes on ML layers and the training loop (including metrics from the `examples/adult` demo). It also creates two reference markdown files mapping GoMLX functionality to PyTorch equivalents for both the `graph` package and the `layers` package to provide easy mapping for AIs familiar with PyTorch.

---
*PR created automatically by Jules for task [13239508144541172539](https://jules.google.com/task/13239508144541172539) started by @janpfeifer*