### PR TITLE
Update MNIST example notebook: reset execution counts and fix RNG state reset

### DIFF
--- a/examples/mnist/mnist.ipynb
+++ b/examples/mnist/mnist.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -295,7 +295,7 @@
     "// createDefaultContext sets the context with default hyperparameters\n",
     "func CreateDefaultContext() *context.Context {\n",
     "\tctx := context.New()\n",
-    "\tctx.RngStateReset()\n",
+    "\t_ = ctx.ResetRNGState()\n",
     "\tctx.SetParams(map[string]any{\n",
     "\t\t// Model type to use\n",
     "\t\t\"model\":           \"linear\",\n",
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
This PR updates the MNIST example and notebook to accommodate recent GoMLX API changes.

**Changes included:**
- Updated the context RNG state reset from `ctx.RngStateReset()` to the newer `ctx.ResetRNGState()` API to ensure smooth execution without undefined method errors.
