### PR TITLE
Update gomlx_checkpoints variables table coloring to group by scope

### DIFF
--- a/cmd/gomlx_checkpoints/tables.go
+++ b/cmd/gomlx_checkpoints/tables.go
@@ -25,6 +25,35 @@ func newPlainTable(withHeader bool, alignments ...lipgloss.Position) *lgtable.Ta
 	return t.Table
 }
 
+func newPlainTableWithRowAlt(withHeader bool, rowAlt []bool, alignments ...lipgloss.Position) *lgtable.Table {
+	return lgtable.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
+		StyleFunc(func(row, col int) (s lipgloss.Style) {
+			if row < 0 {
+				s = headerRowStyle
+				return
+			}
+			isEven := false
+			if row < len(rowAlt) {
+				isEven = rowAlt[row]
+			}
+			if isEven {
+				s = evenRowStyle
+			} else {
+				s = oddRowStyle
+			}
+			alignment := lipgloss.Left
+			if col < len(alignments) {
+				alignment = alignments[col]
+			} else if len(alignments) > 0 {
+				alignment = alignments[len(alignments)-1]
+			}
+			s = s.Align(alignment)
+			return
+		})
+}
+
 type TableWithReds struct {
 	Table *lgtable.Table
 	Count int

--- a/cmd/gomlx_checkpoints/variables.go
+++ b/cmd/gomlx_checkpoints/variables.go
@@ -37,8 +37,6 @@ func ListVariables(scope *model.Scope) {
 		maxAV = ReduceAllMax(Abs(x))
 		return
 	}).SetMaxCache(-1)
-	table := newPlainTable(true)
-	table.Headers("Scope", "Name", "Shape", "Size", "Bytes", "Scalar/MAV", "RMS", "MaxAV")
 	var rows [][]string
 	for v := range scope.IterVariables() {
 		if !v.IsValid() {
@@ -69,6 +67,22 @@ func ListVariables(scope *model.Scope) {
 		}
 		return strings.Compare(a[1], b[1])
 	})
+	rowAlt := make([]bool, len(rows))
+	var lastScope string
+	var isEven bool
+	for i, row := range rows {
+		scope := row[0]
+		if i == 0 {
+			lastScope = scope
+			isEven = false
+		} else if scope != lastScope {
+			lastScope = scope
+			isEven = !isEven
+		}
+		rowAlt[i] = isEven
+	}
+	table := newPlainTableWithRowAlt(true, rowAlt)
+	table.Headers("Scope", "Name", "Shape", "Size", "Bytes", "Scalar/MAV", "RMS", "MaxAV")
 	for _, row := range rows {
 		table.Row(row...)
 	}

--- a/cmd/gomlx_checkpoints/variables_test.go
+++ b/cmd/gomlx_checkpoints/variables_test.go
@@ -7,11 +7,26 @@ import (
 	"os"
 	"testing"
 
+	_ "github.com/gomlx/gomlx/backends/default"
 	"github.com/gomlx/gomlx/core/tensors"
 	"github.com/gomlx/gomlx/ml/model"
 	"github.com/gomlx/gomlx/ml/model/checkpoint"
 	"github.com/stretchr/testify/require"
 )
+
+func TestListVariables(t *testing.T) {
+	store := model.NewStore()
+	s1 := store.Scope("scope1")
+	_ = s1.VariableWithValue("varA", tensors.FromScalar(1.0))
+	_ = s1.VariableWithValue("varB", tensors.FromScalar(2.0))
+	s2 := store.Scope("scope2")
+	_ = s2.VariableWithValue("varC", tensors.FromScalar(3.0))
+
+	// Ensure calling ListVariables doesn't panic and executes cleanly.
+	require.NotPanics(t, func() {
+		ListVariables(store.RootScope())
+	})
+}
 
 func TestPerturbVars(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test_perturb")


### PR DESCRIPTION
This PR updates the `gomlx_checkpoints` `variables` output table styling. Instead of strictly alternating colors for every row, rows are now grouped and colored by their scope prefix, only alternating colors when the scope changes.

### Key Changes
- **`cmd/gomlx_checkpoints/tables.go`**: Added `newPlainTableWithRowAlt` helper to initialize a table with custom alternating row flags (`rowAlt`).
- **`cmd/gomlx_checkpoints/variables.go`**: Modified `ListVariables` to compute row coloring mapping by comparing the scope of current and previous rows, toggling the alternate color state only when the scope changes.
- **`cmd/gomlx_checkpoints/variables_test.go`**: Added `TestListVariables` unit test to verify that calling `ListVariables` on a mock scope with multiple variables doesn't panic.
