### PR TITLE
New Exec wrappers with fixed number of outputs.

### DIFF
--- a/core/graph/exec_test.go
+++ b/core/graph/exec_test.go
@@ -332,3 +332,76 @@ func TestExecUnusedInput(t *testing.T) {
 	_, err = unusedInputFn.Call(0)
 	require.NoError(t, err)
 }
+
+func TestExecWrappers(t *testing.T) {
+	backend := testutil.BuildTestBackend()
+
+	t.Run("OneOutput", func(t *testing.T) {
+		graphFn := func(x *Node) *Node {
+			return AddScalar(x, 1)
+		}
+		exec1, err := NewExec1(backend, graphFn)
+		require.NoError(t, err)
+
+		res, err := exec1.Call(1.0)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, res.Value())
+
+		resMust := exec1.MustCall(2.0)
+		assert.Equal(t, 3.0, resMust.Value())
+
+		// Test MustNewExec1 as well.
+		exec1Must := MustNewExec1(backend, graphFn)
+		assert.Equal(t, 5.0, exec1Must.MustCall(4.0).Value())
+	})
+
+	t.Run("TwoOutputs", func(t *testing.T) {
+		graphFn := func(x *Node) (*Node, *Node) {
+			return AddScalar(x, 1), AddScalar(x, 2)
+		}
+		exec2, err := NewExec2(backend, graphFn)
+		require.NoError(t, err)
+
+		r1, r2, err := exec2.Call(1.0)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, r1.Value())
+		assert.Equal(t, 3.0, r2.Value())
+
+		r1Must, r2Must := exec2.MustCall(2.0)
+		assert.Equal(t, 3.0, r1Must.Value())
+		assert.Equal(t, 4.0, r2Must.Value())
+
+		// Test MustNewExec2 as well.
+		exec2Must := MustNewExec2(backend, graphFn)
+		mr1, mr2 := exec2Must.MustCall(4.0)
+		assert.Equal(t, 5.0, mr1.Value())
+		assert.Equal(t, 6.0, mr2.Value())
+	})
+
+	t.Run("ThreeOutputs", func(t *testing.T) {
+		graphFn := func(x *Node) (*Node, *Node, *Node) {
+			return AddScalar(x, 1), AddScalar(x, 2), AddScalar(x, 3)
+		}
+		exec3, err := NewExec3(backend, graphFn)
+		require.NoError(t, err)
+
+		r1, r2, r3, err := exec3.Call(1.0)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, r1.Value())
+		assert.Equal(t, 3.0, r2.Value())
+		assert.Equal(t, 4.0, r3.Value())
+
+		r1Must, r2Must, r3Must := exec3.MustCall(2.0)
+		assert.Equal(t, 3.0, r1Must.Value())
+		assert.Equal(t, 4.0, r2Must.Value())
+		assert.Equal(t, 5.0, r3Must.Value())
+
+		// Test MustNewExec3 as well.
+		exec3Must := MustNewExec3(backend, graphFn)
+		mr1, mr2, mr3 := exec3Must.MustCall(4.0)
+		assert.Equal(t, 5.0, mr1.Value())
+		assert.Equal(t, 6.0, mr2.Value())
+		assert.Equal(t, 7.0, mr3.Value())
+	})
+}
+

--- a/core/graph/execaliases.go
+++ b/core/graph/execaliases.go
@@ -489,3 +489,103 @@ func (e *Exec) MustExec3(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensor
 func (e *Exec) MustExec4(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensors.Tensor, *tensors.Tensor) {
 	return e.MustCall4(args...)
 }
+
+// ExecOneOutput is a wrapper around Exec for graphs that return exactly one output.
+type ExecOneOutput struct {
+	*Exec
+}
+
+// Call executes the computation with the given arguments and returns one output.
+//
+// It returns an error if the graph doesn't return exactly one output.
+func (e *ExecOneOutput) Call(args ...any) (*tensors.Tensor, error) {
+	return e.Call1(args...)
+}
+
+// MustCall executes the graph with the given arguments and returns one output.
+//
+// It panics on errors or if the graph doesn't return exactly one output.
+func (e *ExecOneOutput) MustCall(args ...any) *tensors.Tensor {
+	return e.MustCall1(args...)
+}
+
+// ExecTwoOutputs is a wrapper around Exec for graphs that return exactly two outputs.
+type ExecTwoOutputs struct {
+	*Exec
+}
+
+// Call executes the computation with the given arguments and returns two outputs.
+//
+// It returns an error if the graph doesn't return exactly two outputs.
+func (e *ExecTwoOutputs) Call(args ...any) (*tensors.Tensor, *tensors.Tensor, error) {
+	return e.Call2(args...)
+}
+
+// MustCall executes the graph with the given arguments and returns two outputs.
+//
+// It panics on errors or if the graph doesn't return exactly two outputs.
+func (e *ExecTwoOutputs) MustCall(args ...any) (*tensors.Tensor, *tensors.Tensor) {
+	return e.MustCall2(args...)
+}
+
+// ExecThreeOutputs is a wrapper around Exec for graphs that return exactly three outputs.
+type ExecThreeOutputs struct {
+	*Exec
+}
+
+// Call executes the computation with the given arguments and returns three outputs.
+//
+// It returns an error if the graph doesn't return exactly three outputs.
+func (e *ExecThreeOutputs) Call(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensors.Tensor, error) {
+	return e.Call3(args...)
+}
+
+// MustCall executes the graph with the given arguments and returns three outputs.
+//
+// It panics on errors or if the graph doesn't return exactly three outputs.
+func (e *ExecThreeOutputs) MustCall(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensors.Tensor) {
+	return e.MustCall3(args...)
+}
+
+// NewExec1 constructs an ExecOneOutput wrapper around a new Exec object, constraining the graphFn to return a single output.
+func NewExec1[F ExecGraphFnOneOutput](backend compute.Backend, graphFn F) (*ExecOneOutput, error) {
+	exec, err := NewExec(backend, graphFn)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecOneOutput{Exec: exec}, nil
+}
+
+// NewExec2 constructs an ExecTwoOutputs wrapper around a new Exec object, constraining the graphFn to return two outputs.
+func NewExec2[F ExecGraphFnTwoOutputs](backend compute.Backend, graphFn F) (*ExecTwoOutputs, error) {
+	exec, err := NewExec(backend, graphFn)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecTwoOutputs{Exec: exec}, nil
+}
+
+// NewExec3 constructs an ExecThreeOutputs wrapper around a new Exec object, constraining the graphFn to return three outputs.
+func NewExec3[F ExecGraphFnThreeOutputs](backend compute.Backend, graphFn F) (*ExecThreeOutputs, error) {
+	exec, err := NewExec(backend, graphFn)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecThreeOutputs{Exec: exec}, nil
+}
+
+// MustNewExec1 constructs an ExecOneOutput wrapper around a new Exec object and panics on error.
+func MustNewExec1[F ExecGraphFnOneOutput](backend compute.Backend, graphFn F) *ExecOneOutput {
+	return &ExecOneOutput{Exec: MustNewExec(backend, graphFn)}
+}
+
+// MustNewExec2 constructs an ExecTwoOutputs wrapper around a new Exec object and panics on error.
+func MustNewExec2[F ExecGraphFnTwoOutputs](backend compute.Backend, graphFn F) *ExecTwoOutputs {
+	return &ExecTwoOutputs{Exec: MustNewExec(backend, graphFn)}
+}
+
+// MustNewExec3 constructs an ExecThreeOutputs wrapper around a new Exec object and panics on error.
+func MustNewExec3[F ExecGraphFnThreeOutputs](backend compute.Backend, graphFn F) *ExecThreeOutputs {
+	return &ExecThreeOutputs{Exec: MustNewExec(backend, graphFn)}
+}
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@ And a few small renaming:
 - `Scope` -> `Store` and `Scope`
 - `NewScope` -> `NewStore` (the only "global" one)
 - `Exec.*Exec*` -> `Exec.*Call*`; the methods with `*Exec*` still exist but are deprecated.
+  - New `Exec` wrappers for fixed number of outputs: `NewExec1`, `NewExec2` and `NewExec3` for graphs with one, two or three outputs.
 - Using mostly `fullPath` instead of the split scope/key pairs.
 - Variables:
   - `Scope.VariableWithValueGraph` -> `Scope.VariableWithNodeValue`
@@ -80,6 +81,7 @@ And a few small renaming:
 
 ## Graph (github.com/gomlx/gomlx/core/graph):
 - `Exec.*Exec*` -> `Exec.*Call*`; the methods with `*Exec*` still exist but are deprecated.
+  - New `Exec` wrappers for fixed number of outputs: `NewExec1`, `NewExec2` and `NewExec3` for graphs with one, two or three outputs.
 
 ## Tensors (github.com/gomlx/gomlx/core/tensors):
 - Renamed `FromAnyValue` to `MustFromAnyValue` and added `FromAnyValue` returning `(tensor, error)`.

--- a/examples/gomlx.github.io/core-concepts/graph/main.go
+++ b/examples/gomlx.github.io/core-concepts/graph/main.go
@@ -28,16 +28,16 @@ func main() {
 		fmt.Println("* building addFn computation graph")
 		return Add(a, b)
 	}
-	addExec := MustNewExec(backend, addFn)
-	fmt.Printf("\t- 1+1=%s\n", addExec.MustCall1(1.0, 1.0))
-	fmt.Printf("\t- 2+2=%s\n", addExec.MustCall1(2.0, 2.0))
+	addExec := MustNewExec1(backend, addFn)
+	fmt.Printf("\t- 1+1=%s\n", addExec.MustCall(1.0, 1.0))
+	fmt.Printf("\t- 2+2=%s\n", addExec.MustCall(2.0, 2.0))
 	//md_end:cell2
 
 	// Output to cell2
 	fmt.Println("md:cell3")
 
 	//md_start:cell3
-	_, err := addExec.Call1(int32(1), float32(1.0))
+	_, err := addExec.Call(int32(1), float32(1.0))
 	if err != nil {
 		//md_end:cell3
 		//... //md:cell3

--- a/ml/model/exec_test.go
+++ b/ml/model/exec_test.go
@@ -357,3 +357,79 @@ func TestAutoSharding(t *testing.T) {
 		assert.Equal(t, must.M1(y0.Merge()).Value(), must.M1(y1.Merge()).Value())
 	})
 }
+
+func TestExecWrappers(t *testing.T) {
+	backend := testutil.BuildTestBackend()
+
+	t.Run("OneOutput", func(t *testing.T) {
+		store := model.NewStore()
+		graphFn := func(scope *model.Scope, x *Node) *Node {
+			return AddScalar(x, 1)
+		}
+		exec1, err := model.NewExec1(backend, store, graphFn)
+		require.NoError(t, err)
+
+		res, err := exec1.Call(1.0)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, res.Value())
+
+		resMust := exec1.MustCall(2.0)
+		assert.Equal(t, 3.0, resMust.Value())
+
+		// Test MustNewExec1 as well.
+		exec1Must := model.MustNewExec1(backend, store, graphFn)
+		assert.Equal(t, 5.0, exec1Must.MustCall(4.0).Value())
+	})
+
+	t.Run("TwoOutputs", func(t *testing.T) {
+		store := model.NewStore()
+		graphFn := func(scope *model.Scope, x *Node) (*Node, *Node) {
+			return AddScalar(x, 1), AddScalar(x, 2)
+		}
+		exec2, err := model.NewExec2(backend, store, graphFn)
+		require.NoError(t, err)
+
+		r1, r2, err := exec2.Call(1.0)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, r1.Value())
+		assert.Equal(t, 3.0, r2.Value())
+
+		r1Must, r2Must := exec2.MustCall(2.0)
+		assert.Equal(t, 3.0, r1Must.Value())
+		assert.Equal(t, 4.0, r2Must.Value())
+
+		// Test MustNewExec2 as well.
+		exec2Must := model.MustNewExec2(backend, store, graphFn)
+		mr1, mr2 := exec2Must.MustCall(4.0)
+		assert.Equal(t, 5.0, mr1.Value())
+		assert.Equal(t, 6.0, mr2.Value())
+	})
+
+	t.Run("ThreeOutputs", func(t *testing.T) {
+		store := model.NewStore()
+		graphFn := func(scope *model.Scope, x *Node) (*Node, *Node, *Node) {
+			return AddScalar(x, 1), AddScalar(x, 2), AddScalar(x, 3)
+		}
+		exec3, err := model.NewExec3(backend, store, graphFn)
+		require.NoError(t, err)
+
+		r1, r2, r3, err := exec3.Call(1.0)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, r1.Value())
+		assert.Equal(t, 3.0, r2.Value())
+		assert.Equal(t, 4.0, r3.Value())
+
+		r1Must, r2Must, r3Must := exec3.MustCall(2.0)
+		assert.Equal(t, 3.0, r1Must.Value())
+		assert.Equal(t, 4.0, r2Must.Value())
+		assert.Equal(t, 5.0, r3Must.Value())
+
+		// Test MustNewExec3 as well.
+		exec3Must := model.MustNewExec3(backend, store, graphFn)
+		mr1, mr2, mr3 := exec3Must.MustCall(4.0)
+		assert.Equal(t, 5.0, mr1.Value())
+		assert.Equal(t, 6.0, mr2.Value())
+		assert.Equal(t, 7.0, mr3.Value())
+	})
+}
+

--- a/ml/model/execaliases.go
+++ b/ml/model/execaliases.go
@@ -376,3 +376,103 @@ func (e *Exec) MustExec3(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensor
 func (e *Exec) MustExec4(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensors.Tensor, *tensors.Tensor) {
 	return e.MustCall4(args...)
 }
+
+// ExecOneOutput is a wrapper around Exec for graphs that return exactly one output.
+type ExecOneOutput struct {
+	*Exec
+}
+
+// Call executes the computation with the given arguments and returns one output.
+//
+// It returns an error if the graph doesn't return exactly one output.
+func (e *ExecOneOutput) Call(args ...any) (*tensors.Tensor, error) {
+	return e.Call1(args...)
+}
+
+// MustCall executes the graph with the given arguments and returns one output.
+//
+// It panics on errors or if the graph doesn't return exactly one output.
+func (e *ExecOneOutput) MustCall(args ...any) *tensors.Tensor {
+	return e.MustCall1(args...)
+}
+
+// ExecTwoOutputs is a wrapper around Exec for graphs that return exactly two outputs.
+type ExecTwoOutputs struct {
+	*Exec
+}
+
+// Call executes the computation with the given arguments and returns two outputs.
+//
+// It returns an error if the graph doesn't return exactly two outputs.
+func (e *ExecTwoOutputs) Call(args ...any) (*tensors.Tensor, *tensors.Tensor, error) {
+	return e.Call2(args...)
+}
+
+// MustCall executes the graph with the given arguments and returns two outputs.
+//
+// It panics on errors or if the graph doesn't return exactly two outputs.
+func (e *ExecTwoOutputs) MustCall(args ...any) (*tensors.Tensor, *tensors.Tensor) {
+	return e.MustCall2(args...)
+}
+
+// ExecThreeOutputs is a wrapper around Exec for graphs that return exactly three outputs.
+type ExecThreeOutputs struct {
+	*Exec
+}
+
+// Call executes the computation with the given arguments and returns three outputs.
+//
+// It returns an error if the graph doesn't return exactly three outputs.
+func (e *ExecThreeOutputs) Call(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensors.Tensor, error) {
+	return e.Call3(args...)
+}
+
+// MustCall executes the graph with the given arguments and returns three outputs.
+//
+// It panics on errors or if the graph doesn't return exactly three outputs.
+func (e *ExecThreeOutputs) MustCall(args ...any) (*tensors.Tensor, *tensors.Tensor, *tensors.Tensor) {
+	return e.MustCall3(args...)
+}
+
+// NewExec1 constructs an ExecOneOutput wrapper around a new Exec object, constraining the graphFn to return a single output.
+func NewExec1[F ExecGraphFnOneOutput](backend compute.Backend, store *Store, graphFn F) (*ExecOneOutput, error) {
+	exec, err := NewExec(backend, store, graphFn)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecOneOutput{Exec: exec}, nil
+}
+
+// NewExec2 constructs an ExecTwoOutputs wrapper around a new Exec object, constraining the graphFn to return two outputs.
+func NewExec2[F ExecGraphFnTwoOutputs](backend compute.Backend, store *Store, graphFn F) (*ExecTwoOutputs, error) {
+	exec, err := NewExec(backend, store, graphFn)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecTwoOutputs{Exec: exec}, nil
+}
+
+// NewExec3 constructs an ExecThreeOutputs wrapper around a new Exec object, constraining the graphFn to return three outputs.
+func NewExec3[F ExecGraphFnThreeOutputs](backend compute.Backend, store *Store, graphFn F) (*ExecThreeOutputs, error) {
+	exec, err := NewExec(backend, store, graphFn)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecThreeOutputs{Exec: exec}, nil
+}
+
+// MustNewExec1 constructs an ExecOneOutput wrapper around a new Exec object and panics on error.
+func MustNewExec1[F ExecGraphFnOneOutput](backend compute.Backend, store *Store, graphFn F) *ExecOneOutput {
+	return &ExecOneOutput{Exec: MustNewExec(backend, store, graphFn)}
+}
+
+// MustNewExec2 constructs an ExecTwoOutputs wrapper around a new Exec object and panics on error.
+func MustNewExec2[F ExecGraphFnTwoOutputs](backend compute.Backend, store *Store, graphFn F) *ExecTwoOutputs {
+	return &ExecTwoOutputs{Exec: MustNewExec(backend, store, graphFn)}
+}
+
+// MustNewExec3 constructs an ExecThreeOutputs wrapper around a new Exec object and panics on error.
+func MustNewExec3[F ExecGraphFnThreeOutputs](backend compute.Backend, store *Store, graphFn F) *ExecThreeOutputs {
+	return &ExecThreeOutputs{Exec: MustNewExec(backend, store, graphFn)}
+}
+


### PR DESCRIPTION
Added Exec wrappers (packages `graph` and `ml/model`) for fixed number of outputs.