### PR TITLE
Add VJP for OptimizationBarrier and SchedulingBarrier

### DIFF
--- a/core/graph/rev_autodiff.go
+++ b/core/graph/rev_autodiff.go
@@ -429,29 +429,31 @@ var VJPRegistration = map[NodeType]VJP{
 	NodeTypeConj:    vjpForSingleOutput(conjVJP),
 	NodeTypeComplex: vjpForSingleOutput(complexVJP),
 
-	NodeTypeMax:                vjpForSingleOutput(minMaxVJP),
-	NodeTypeMin:                vjpForSingleOutput(minMaxVJP),
-	NodeTypeReshape:            vjpForSingleOutput(reshapeVJP),
-	NodeTypeReduceSum:          vjpForSingleOutput(reduceSumVJP),
-	NodeTypeReduceMax:          vjpForSingleOutput(reduceMaxVJP),
-	NodeTypeReduceMin:          vjpForSingleOutput(reduceMinVJP),
-	NodeTypeLogistic:           vjpForSingleOutput(logisticVJP),
-	NodeTypeDotGeneral:         vjpForSingleOutput(dotGeneralVJP),
-	NodeTypeSlice:              vjpForSingleOutput(sliceVJP),
-	NodeTypeGather:             vjpForSingleOutput(gatherVJP),
-	NodeTypeScatterSum:         vjpForSingleOutput(scatterSumVJP),
-	NodeTypeScatterMax:         vjpForSingleOutput(scatterMaxOrMinVJP),
-	NodeTypeScatterMin:         vjpForSingleOutput(scatterMaxOrMinVJP),
-	NodeTypeConcatenate:        vjpForSingleOutput(concatenateVJP),
-	NodeTypeConvGeneral:        vjpForSingleOutput(convGeneralVJP),
-	NodeTypeReduceWindow:       vjpForSingleOutput(reduceWindowVJP),
-	NodeTypeTranspose:          vjpForSingleOutput(transposeVJP),
-	NodeTypeBroadcastInDim:     vjpForSingleOutput(broadcastInDimVJP),
-	NodeTypeFFT:                vjpForSingleOutput(fftVJP),
-	NodeTypeDynamicSlice:       vjpForSingleOutput(dynamicSliceVJP),
-	NodeTypeDynamicUpdateSlice: vjpForSingleOutput(dynamicUpdateSliceVJP),
+	NodeTypeMax:                  vjpForSingleOutput(minMaxVJP),
+	NodeTypeMin:                  vjpForSingleOutput(minMaxVJP),
+	NodeTypeReshape:              vjpForSingleOutput(reshapeVJP),
+	NodeTypeReduceSum:            vjpForSingleOutput(reduceSumVJP),
+	NodeTypeReduceMax:            vjpForSingleOutput(reduceMaxVJP),
+	NodeTypeReduceMin:            vjpForSingleOutput(reduceMinVJP),
+	NodeTypeLogistic:             vjpForSingleOutput(logisticVJP),
+	NodeTypeDotGeneral:           vjpForSingleOutput(dotGeneralVJP),
+	NodeTypeSlice:                vjpForSingleOutput(sliceVJP),
+	NodeTypeGather:               vjpForSingleOutput(gatherVJP),
+	NodeTypeScatterSum:           vjpForSingleOutput(scatterSumVJP),
+	NodeTypeScatterMax:           vjpForSingleOutput(scatterMaxOrMinVJP),
+	NodeTypeScatterMin:           vjpForSingleOutput(scatterMaxOrMinVJP),
+	NodeTypeConcatenate:          vjpForSingleOutput(concatenateVJP),
+	NodeTypeConvGeneral:          vjpForSingleOutput(convGeneralVJP),
+	NodeTypeReduceWindow:         vjpForSingleOutput(reduceWindowVJP),
+	NodeTypeTranspose:            vjpForSingleOutput(transposeVJP),
+	NodeTypeBroadcastInDim:       vjpForSingleOutput(broadcastInDimVJP),
+	NodeTypeFFT:                  vjpForSingleOutput(fftVJP),
+	NodeTypeDynamicSlice:         vjpForSingleOutput(dynamicSliceVJP),
+	NodeTypeDynamicUpdateSlice:   vjpForSingleOutput(dynamicUpdateSliceVJP),
 	NodeTypeDynamicDimensionSize: vjpForSingleOutput(zeroVJP),
 	NodeTypeDynamicShape:         vjpForSingleOutput(zeroVJP),
+	NodeTypeOptimizationBarrier:  vjpOptimizationBarrier,
+	NodeTypeSchedulingBarrier:    vjpForSingleOutput(vjpSchedulingBarrier),
 }
 
 // nilVJP returns no gradient, for functions without any inputNodes.
@@ -1013,5 +1015,21 @@ func dynamicUpdateSliceVJP(node, v *Node, _ shapes.Shape) []*Node {
 	// No gradients wrt. the startIndices, only wrt. the operand and the update.
 	vjps[0] = vjpOperand
 	vjps[1] = vjpUpdate
+	return vjps
+}
+
+// vjpOptimizationBarrier generates the "vector dot jacobian" w.r.t. the inputs of OptimizationBarrier.
+// Since OptimizationBarrier is mathematically an identity function for each of its inputs,
+// its gradient is just the identity function of the output gradients.
+func vjpOptimizationBarrier(node *Node, vjpOutputs []*Node, _ shapes.Shape) []*Node {
+	return vjpOutputs
+}
+
+// vjpSchedulingBarrier generates the "vector dot jacobian" w.r.t. the inputs of SchedulingBarrier.
+// Since SchedulingBarrier is mathematically an identity function of the first operand,
+// its gradient is just the incoming gradient for the operand, and nil (zero) for the dependencies.
+func vjpSchedulingBarrier(node, v *Node, _ shapes.Shape) []*Node {
+	vjps := make([]*Node, len(node.inputNodes))
+	vjps[0] = v
 	return vjps
 }

--- a/core/graph/rev_autodiff_test.go
+++ b/core/graph/rev_autodiff_test.go
@@ -724,3 +724,45 @@ func TestGradientQKVProjectionDecomposed(t *testing.T) {
 		},
 	)
 }
+
+func TestGradientBarriers(t *testing.T) {
+	// Test single optimization barrier
+	testGradients(t, "OptimizationBarrier",
+		func(g *Graph) (output *Node, nodesForGrad []*Node) {
+			x := Const(g, []float64{1, 2, 3})
+			y := OptimizationBarrier(x)
+			output = ReduceAllSum(y)
+			return output, []*Node{x}
+		}, []any{
+			[]float64{1, 1, 1},
+		},
+	)
+
+	// Test multiple optimization barriers
+	testGradients(t, "OptimizationBarriers",
+		func(g *Graph) (output *Node, nodesForGrad []*Node) {
+			x := Const(g, []float64{1, 2, 3})
+			y := Const(g, []float64{4, 5, 6})
+			barriers := OptimizationBarriers(x, y)
+			output = Add(ReduceAllSum(barriers[0]), ReduceAllSum(barriers[1]))
+			return output, []*Node{x, y}
+		}, []any{
+			[]float64{1, 1, 1},
+			[]float64{1, 1, 1},
+		},
+	)
+
+	// Test scheduling barrier
+	testGradients(t, "SchedulingBarrier",
+		func(g *Graph) (output *Node, nodesForGrad []*Node) {
+			x := Const(g, []float64{1, 2, 3})
+			dep := Const(g, []float64{10, 20, 30})
+			y := SchedulingBarrier(x, dep)
+			output = ReduceAllSum(y)
+			return output, []*Node{x, dep}
+		}, []any{
+			[]float64{1, 1, 1},
+			[]float64{0, 0, 0}, // dependency has gradient zero (nil)
+		},
+	)
+}


### PR DESCRIPTION
This PR implements VJP (Vector-Jacobian Product) / reverse-mode automatic differentiation for the newly added barrier operations: `OptimizationBarrier`, `OptimizationBarriers`, and `SchedulingBarrier`.

### Changes:
- **`core/graph/rev_autodiff.go`**:
  - Registered `NodeTypeOptimizationBarrier` and `NodeTypeSchedulingBarrier` in the `VJPRegistration` mapping.
  - Implemented `vjpOptimizationBarrier` to propagate gradients directly through `OptimizationBarrier` (which functions as an identity mapping).
  - Implemented `vjpSchedulingBarrier` to propagate the gradient only to the first input operand (the main value), setting the gradient to nil/zero for any additional dependency operands.
- **`core/graph/rev_autodiff_test.go`**:
  - Added unit test `TestGradientBarriers` validating single optimization barrier, multiple optimization barriers, and scheduling barriers to ensure correct gradient propagation.

### Testing:
- Verified that `TestGradientBarriers` passes successfully on the default backend.

See discussion in #422 