### PR TITLE
core/graph: build DotGeneral gradients as gemms, not multiply+reduce

### DIFF
--- a/core/graph/ops_dotgeneral.go
+++ b/core/graph/ops_dotgeneral.go
@@ -701,28 +701,49 @@ func dotGeneralVJP(node, v *Node, _ shapes.Shape) []*Node {
 		// Axes counts:
 		numBatchAxes := len(thisBatchAxes)             // == len(otherBatchAxes)
 		numContractionAxes := len(thisContractingAxes) // == len(otherContractingAxes)
-		//numCrossedAxes := len(thisCrossAxes) + len(otherCrossAxes)
 
-		// Project output (of the DotGeneral) shaped v to "this" (this node) shapes.
-
-		// * Add back contracted dimensions, with size 1.
-		//   thisVJP shapes will be [batch_dims..., lhs_cross_dims..., rhs_cross_dims..., 1 x (numContractionAxes)].
-		thisVJP := v
-		if thisVJP.DType() != computationDType {
-			thisVJP = ConvertDType(thisVJP, computationDType)
-		}
-		if numContractionAxes > 0 {
-			thisVJP = InsertAxes(thisVJP, xslices.SliceWithValue(numContractionAxes, -1)...)
-		}
-
-		// * Project other operand with contracted dimensions.
-		//   otherProjected shapes for this=lhs will be [batch_dims..., 1 x (this_cross_dims), rhs_cross_dims, contracted_dims]
-		otherProjected := otherInput
-		if otherProjected.DType() != computationDType {
-			otherProjected = ConvertDType(otherProjected, computationDType)
-		}
-		otherRank := otherProjected.Rank()
-		{
+		// Build the gradient w.r.t. "this" by contracting the "other" operand's cross (free) axes against
+		// the matching axes of v. When "other" has cross axes (the common matmul case), express it as a
+		// DotGeneral so XLA lowers it to a tensor-core gemm: the mathematically identical broadcast-Mul +
+		// ReduceSum (the else branch, the original implementation) is otherwise left by XLA as a CUDA-core
+		// reduction for weight-gradient shapes (small output, large reduced axis), ~18x slower. The else
+		// branch still handles the cases a DotGeneral cannot (no cross axes, e.g. a vector dot product).
+		// Both branches yield [batch_dims..., this_cross_dims..., contracted_dims...], so the transpose-
+		// back below is unchanged.
+		var thisVJP *Node
+		if len(otherCrossAxes) > 0 {
+			vv := v
+			if vv.DType() != computationDType {
+				vv = ConvertDType(vv, computationDType)
+			}
+			oo := otherInput
+			if oo.DType() != computationDType {
+				oo = ConvertDType(oo, computationDType)
+			}
+			// v's layout is [batch_dims..., lhs_cross_dims..., rhs_cross_dims...]; the axes matching
+			// "other"'s cross axes start after the batch axes (and after "this"'s cross axes when those
+			// come first in v, i.e. when "this" is the lhs).
+			vOtherCrossStart := numBatchAxes
+			if thisCrossesFirst {
+				vOtherCrossStart += len(thisCrossAxes)
+			}
+			thisVJP = DotGeneral(
+				vv, xslices.Iota(vOtherCrossStart, len(otherCrossAxes)), xslices.Iota(0, numBatchAxes),
+				oo, otherCrossAxes, otherBatchAxes)
+		} else {
+			// No "other" cross axes to contract: the gradient is a plain broadcast-multiply (no reduction).
+			thisVJP = v
+			if thisVJP.DType() != computationDType {
+				thisVJP = ConvertDType(thisVJP, computationDType)
+			}
+			if numContractionAxes > 0 {
+				thisVJP = InsertAxes(thisVJP, xslices.SliceWithValue(numContractionAxes, -1)...)
+			}
+			otherProjected := otherInput
+			if otherProjected.DType() != computationDType {
+				otherProjected = ConvertDType(otherProjected, computationDType)
+			}
+			otherRank := otherProjected.Rank()
 			permutations := make([]int, 0, otherRank)
 			permutations = append(permutations, otherBatchAxes...)
 			permutations = append(permutations, otherCrossAxes...)
@@ -736,27 +757,14 @@ func dotGeneralVJP(node, v *Node, _ shapes.Shape) []*Node {
 			if changed {
 				otherProjected = TransposeAllAxes(otherProjected, permutations...)
 			}
-			// Add placeholder axes (of dimension 1) for the crosses from "this".
 			if len(thisCrossAxes) > 0 {
-				pos := numBatchAxes // Where axes for thisCrossesAxes will be inserted.
+				pos := numBatchAxes
 				if !thisCrossesFirst {
 					pos += len(otherCrossAxes)
 				}
 				otherProjected = InsertAxes(otherProjected, xslices.SliceWithValue(len(thisCrossAxes), pos)...)
 			}
-		}
-
-		// * Multiply the contracted dimension by otherProjected: this will expand the contracted dimensions.
-		thisVJP = Mul(thisVJP, otherProjected)
-
-		// * Contract the otherCrossAxes, since those dimensions should exist in the final thisVJP — these
-		//   cross-axes came from the "other" input.
-		if len(otherCrossAxes) > 0 {
-			pos := numBatchAxes
-			if thisCrossesFirst {
-				pos += len(thisCrossAxes)
-			}
-			thisVJP = ReduceSum(thisVJP, xslices.Iota(pos, len(otherCrossAxes))...)
+			thisVJP = Mul(thisVJP, otherProjected)
 		}
 
 		// * Transpose thisVJP axes back to its inputNodes.

--- a/core/graph/ops_dotgeneral_test.go
+++ b/core/graph/ops_dotgeneral_test.go
@@ -605,3 +605,32 @@ func TestDotGeneralDTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestDotGeneralVJPLowersToGemm guards the gradient of a matrix multiply being built from DotGeneral
+// ops (which a GPU backend lowers to tensor-core gemms) rather than a broadcast-multiply + ReduceSum.
+// The latter is mathematically identical but XLA leaves it as a slow elementwise reduction for
+// weight-gradient shapes (small output, large reduced axis), so the gradient ran ~18x slower than the
+// forward. C = A·W has one forward DotGeneral; the gradients w.r.t. A and W must add two more.
+func TestDotGeneralVJPLowersToGemm(t *testing.T) {
+	backend := graphtest.BuildTestBackend()
+	g := NewGraph(backend, t.Name())
+	a := Add(Iota(g, MakeShape(F32, 8, 4), 0), Const(g, float32(1))) // [8,4]
+	w := Add(Iota(g, MakeShape(F32, 4, 6), 1), Const(g, float32(1))) // [4,6]
+	grads := Gradient(ReduceAllSum(MatMul(a, w)), a, w)              // [8,6] -> scalar -> grads wrt a, w
+	require.Len(t, grads, 2)
+
+	var dotGenerals, reduceSums int
+	for _, n := range g.Nodes() {
+		switch n.Type() {
+		case NodeTypeDotGeneral:
+			dotGenerals++
+		case NodeTypeReduceSum:
+			reduceSums++
+		}
+	}
+	// 1 forward DotGeneral + 1 for dA + 1 for dW. Before the fix the gradients were broadcast-multiply
+	// + ReduceSum, so only the single forward DotGeneral existed.
+	require.GreaterOrEqualf(t, dotGenerals, 3,
+		"matmul gradient must lower via DotGeneral (a gemm), not Mul+ReduceSum; got %d DotGeneral / %d ReduceSum",
+		dotGenerals, reduceSums)
+}


### PR DESCRIPTION
## Problem

`dotGeneralVJP` builds each operand's gradient by broadcasting the *other* operand, multiplying elementwise, and `ReduceSum`-ing over the contracted axes:

```go
thisVJP = Mul(thisVJP, otherProjected)
thisVJP = ReduceSum(thisVJP, ...otherCrossAxes)
```

That is mathematically a matmul, but it is handed to the backend as an elementwise multiply + reduction. XLA pattern-matches *some* of these back into gemms (the activation/input gradients), but for **weight gradients** — which reduce the large batch dimension `B*T` into a small `[in, out]` output — it leaves them as **CUDA-core reductions**, not tensor-core gemms.

So in a transformer the forward and the input gradients run on tensor cores, but **every weight gradient runs ~18x slower** on CUDA cores. Since a training step is dominated by weight gradients, the whole backward is pathologically slow while the forward is fast.

### Evidence (100M-param Llama, bf16, seq 2048, batch 2, RTX 3070 Ti / sm_86, XLA GPU)

Optimized HLO, weight-gradient-shaped outputs (`[768,2048]`, `[2048,768]`):

| | tensor-core `gemm_fusion` | CUDA-core `kInput` reduce |
|---|---|---|
| before | 0 | 60 |
| after | all | 0 |

The forward pass was already fast (~26 ms); the entire gap was the backward. Eager PyTorch is fast at the identical batch because cuBLAS computes `dW` as a gemm with a transpose flag.

| | step time | tok/s |
|---|---|---|
| before | 3.04 s | 1,346 |
| **after** | **0.16 s** | **25,217** |
| eager PyTorch, same GPU | 0.13 s | 32,093 |

**~18.7x faster**, ~80% of eager PyTorch.

## Fix

Emit a `DotGeneral` for the gradient when the "other" operand has cross (free) axes — the common matmul case — so the backend lowers it to a gemm. Keep the original broadcast-multiply path for the no-cross case (e.g. a vector dot product), which `DotGeneral` cannot express (removing it fails `TestGradientDot`). The result layout is unchanged, so the transpose-back is unchanged.

## Verification

- Full `core/graph` gradient / dot / einsum suite passes unchanged (numerics identical).
- Added `TestDotGeneralVJPLowersToGemm`: asserts a matmul gradient builds `DotGeneral` nodes (forward + dA + dW), guarding against a silent regression back to multiply+reduce.
- End-to-end: a 100M Llama overfit test converges to the identical loss; full training step is 18.7x faster.

---

*Disclosure: the diagnosis and implementation of this change were produced with heavy involvement of an AI coding assistant.*
