### PR TITLE
Fix comments and notes in tutorial notebook

### DIFF
--- a/examples/tutorial/tutorial.ipynb
+++ b/examples/tutorial/tutorial.ipynb
@@ -757,7 +757,7 @@
     "%%\n",
     "store := model.NewStore()\n",
     "exec := model.MustNewExec(backend, store, func(scope *model.Scope, g *Graph) *Node {\n",
-    "    counterVar := scope.VariableWithValue(\"count\", int32(10))  // Creates variable with 0, if it doesn't yet exist.\n",
+    "    counterVar := scope.VariableWithValue(\"count\", int32(10))  // Creates variable with 10, if it doesn't yet exist.\n",
     "    count := counterVar.NodeValue(g) // Get the current value of the variable as a graph.Node.\n",
     "    count = AddScalar(count, 1) // Increment it.\n",
     "    counterVar.SetNodeValue(count) // Store the value (as a graph.Node) into the variable.\n",
@@ -778,7 +778,7 @@
    "source": [
     "> **Note**:\n",
     "> - We are using `model.Exec`, while before we were using `graph.Exec`. The main difference is that\n",
-    ">   `model.Exec` compiles and executes graph functions that take a `model.Store` as its first parameter, and it \n",
+    ">   `model.Exec` compiles and executes graph functions that take a `model.Scope` as its first parameter, and it \n",
     ">   automatically handles the passing of variables as side inputs and outputs (for those variables updated)\n",
     ">   of the computation graph.\n",
     "> - During graph building, we access and set the variables's symbolic values (`graph.Node`) with `Variable.NodeValue` and `Variable.SetNodeValue`.\n",
@@ -1537,7 +1537,7 @@
    "metadata": {},
    "source": [
     "> **Note**:\n",
-    "> - The `gomlx/examples/notebook/gonb/plotly` package will automatically plot all the metrics registered in the trainer. When it attaches itself to \n",
+    "> - The `gomlx/gomlx/ui/gonb/plotly` package will automatically plot all the metrics registered in the trainer. When it attaches itself to \n",
     "> `loop` it collects the metric values (and run evaluation on any requested datasets), and at the end of it, plot it.\n",
     "> - Optionally, with `Plots.Dynamic()` it also plots intermediary results, displaying the progress of the training as it happens.\n",
     "> - Previously, we added a little L2 regularization as a hyperparameter. The `layers.DenseWithBias` layer picks up on that hyperparameter, and adds that bit of L2 regularization. GoMLX tracks the loss with/without regularization separately, and one can see the difference in the two lines.\n",


### PR DESCRIPTION
btw, after reading the whole tutorial, my overall impression is that it flows smoothly, but there is one main point of confusion. For example:
```
coefVar, biasVar := store.GetVariable("/dense/weights"), store.GetVariable("/dense/biases")
```
In this code, where does **/dense/biases** come from? How is it organized, and why does it start with **/**? This may need a bit more explanation to make it easier for beginners to understand.

maybe likes this: 
```
layers.DenseWithBias internally creates a sub-scope named "dense" and stores two variables in it: "weights" and "biases". Since the model store uses absolute scope paths starting at the root "/", these variables can later be retrieved as "/dense/weights" and "/dense/biases".
```