### PR TITLE
Stage 2: WithAttentionBias (additive attention bias, cumulative on #427)

### DIFF
--- a/ml/layers/attention/attention.go
+++ b/ml/layers/attention/attention.go
@@ -172,6 +172,13 @@ type CoreOptions struct {
 	// If one is set the other must also be set.
 	QuerySeqLen, KVSeqLen *Node
 
+	// AttentionBias is an optional additive attention-score bias [batch, numHeads, q_seq, kv_seq]
+	// (ALiBi / relative-position). It is DISTINCT from the Q/K/V projection bias (UseProjectionBias
+	// on the builder) and from AttentionMask. On the fused path it selects the cuDNN fmhaScaleBias
+	// variant; on the decomposed path it is added to the scores before softmax. It may combine with
+	// UseCausalMask; a bias+seqlens combination the fused kernel can't take falls back to decomposed.
+	AttentionBias *Node
+
 	// WantCoefficients, when true, forces the decomposed path to be used for the entire computation
 	// (no fused op) and returns coefficients. When false, the fused op is attempted for
 	// the output and coefficients is nil.
@@ -217,6 +224,9 @@ func (o CoreOptions) String() string {
 	}
 	if o.KVSeqLen != nil {
 		parts = append(parts, fmt.Sprintf("KVSeqLen: %s", o.KVSeqLen.Shape()))
+	}
+	if o.AttentionBias != nil {
+		parts = append(parts, fmt.Sprintf("AttentionBias: %s", o.AttentionBias.Shape()))
 	}
 	if o.WantCoefficients {
 		parts = append(parts, "WantCoefficients: true")
@@ -323,10 +333,19 @@ func Core(query, key, value *Node, layout AxesLayout, options CoreOptions) (outp
 		// only a free reshape of Q is needed.
 		isGQA := numQueryHeads != numKVHeads
 		decomposedQuery := query
+		// Bias convention is [B,H,Sq,Skv] (heads-major). BSHD scores are [B,Sq,H,Skv], so permute
+		// [0,2,1,3] before Add. BHSD scores are already [B,H,Sq,Skv]: no permute.
+		decomposedBias := options.AttentionBias
+		if decomposedBias != nil && layout == LayoutBSHD {
+			decomposedBias = TransposeAllAxes(decomposedBias, 0, 2, 1, 3)
+		}
 		if isGQA {
 			decomposedQuery = reshapeQueryForGQA(query, numQueryHeads, numKVHeads, layout)
 			if decomposedMask != nil {
 				decomposedMask = reshapeMaskForGQA(decomposedMask, numQueryHeads, numKVHeads, layout)
+			}
+			if decomposedBias != nil {
+				decomposedBias = reshapeMaskForGQA(decomposedBias, numQueryHeads, numKVHeads, layout)
 			}
 		}
 
@@ -336,6 +355,12 @@ func Core(query, key, value *Node, layout AxesLayout, options CoreOptions) (outp
 
 		if options.ScoreSoftCap > 0 {
 			scores = nn.SoftCap(scores, options.ScoreSoftCap)
+		}
+
+		// Additive attention bias (ALiBi / relative-position) before softmax; reshaped above to the
+		// score layout (and to 5D when GQA).
+		if decomposedBias != nil {
+			scores = Add(scores, decomposedBias)
 		}
 
 		if decomposedMask != nil && decomposedMask.DType() != dtypes.Bool {
@@ -379,13 +404,16 @@ func Core(query, key, value *Node, layout AxesLayout, options CoreOptions) (outp
 		output, isFused = InternalFusedOpCaller(
 			func() *Node {
 				var fusedConfig *compute.ScaledDotProductAttentionConfig
-				if options.QuerySeqLen != nil || options.KVSeqLen != nil {
+				if options.QuerySeqLen != nil || options.KVSeqLen != nil || options.AttentionBias != nil {
 					fusedConfig = &compute.ScaledDotProductAttentionConfig{}
 					if options.QuerySeqLen != nil {
 						fusedConfig.QuerySeqLen = InternalBackendOutputs(options.QuerySeqLen)[0]
 					}
 					if options.KVSeqLen != nil {
 						fusedConfig.KeyValueSeqLen = InternalBackendOutputs(options.KVSeqLen)[0]
+					}
+					if options.AttentionBias != nil {
+						fusedConfig.Bias = InternalBackendOutputs(options.AttentionBias)[0]
 					}
 				}
 				klog.V(2).Info("attention.Core(): attempting to use FusedScaledDotProductAttention op.")

--- a/ml/layers/attention/attention.go
+++ b/ml/layers/attention/attention.go
@@ -173,13 +173,13 @@ type CoreOptions struct {
 	QuerySeqLen, KVSeqLen *Node
 
 	// AttentionBias is an optional additive attention-score bias [batch, numHeads, q_seq, kv_seq]
-	// (ALiBi / relative-position). It is DISTINCT from the Q/K/V projection bias (UseProjectionBias
-	// on the builder) and from AttentionMask. On the fused path it selects the cuDNN fmhaScaleBias
-	// variant; on the decomposed path it is added to the scores before softmax. It may combine with
-	// UseCausalMask; a bias+seqlens combination the fused kernel can't take falls back to decomposed.
+	// (ALiBi / relative-position), added to the scores before softmax. It is DISTINCT from the
+	// Q/K/V projection bias (UseProjectionBias on the builder) and from AttentionMask. It may
+	// combine with UseCausalMask.
 	//
-	// For the fused path the bias dtype must match query/key/value (the backend does no automatic
-	// conversion): a mismatched dtype falls back to the decomposed path.
+	// To keep it on the fused (faster) path the bias dtype must match query/key/value, since the
+	// backend does no automatic conversion; a mismatched dtype, or a bias+seqlens combination the
+	// fused kernel can't take, falls back to the decomposed path.
 	AttentionBias *Node
 
 	// WantCoefficients, when true, forces the decomposed path to be used for the entire computation

--- a/ml/layers/attention/attention.go
+++ b/ml/layers/attention/attention.go
@@ -177,6 +177,9 @@ type CoreOptions struct {
 	// on the builder) and from AttentionMask. On the fused path it selects the cuDNN fmhaScaleBias
 	// variant; on the decomposed path it is added to the scores before softmax. It may combine with
 	// UseCausalMask; a bias+seqlens combination the fused kernel can't take falls back to decomposed.
+	//
+	// For the fused path the bias dtype must match query/key/value (the backend does no automatic
+	// conversion): a mismatched dtype falls back to the decomposed path.
 	AttentionBias *Node
 
 	// WantCoefficients, when true, forces the decomposed path to be used for the entire computation

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -246,6 +246,67 @@ func TestAttentionBiasFusedParity_cuda(t *testing.T) {
 		"fused and decomposed bias gradients diverge (dQ rel err)")
 }
 
+// TestAttentionBiasFusedParityMatrix_cuda [cuda] extends the bias fused-parity check across dtype
+// (Float16) and layout (BHSD), mirroring the plain-path BF16/Float16 coverage. Each case asserts the
+// fused bias op actually engaged (HasFusedSDPA) so a silent fallback cannot pass trivially. The base
+// bf16/BSHD case lives in TestAttentionBiasFusedParity_cuda.
+func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
+	backend := testutil.GetOfficialBackend("xla:cuda")
+	if backend == nil || !backendSupportsFusionForBFloat16(backend) {
+		t.Skip("xla:cuda fused attention backend not available")
+	}
+	require.True(t, backendSupportsBiasedFusion(backend),
+		"xla:cuda supports plain fused SDPA but not biased fusion")
+
+	const B, S, H, D = 2, 64, 2, 64
+	scale := 1.0 / math.Sqrt(float64(D))
+	cases := []struct {
+		name   string
+		dtype  dtypes.DType
+		layout AxesLayout
+	}{
+		{"f16_bshd", dtypes.Float16, LayoutBSHD},
+		{"bf16_bhsd", dtypes.BFloat16, LayoutBHSD},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// q/k/v shaped per layout; bias is [B,H,Sq,Skv] regardless. f32 seed data cast to the
+			// target dtype in-graph so the fused path engages (no auto-conversion at the backend).
+			qkvDims := []int{B, S, H, D}
+			if tc.layout == LayoutBHSD {
+				qkvDims = []int{B, H, S, D}
+			}
+			q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), qkvDims...)
+			k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), qkvDims...)
+			v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), qkvDims...)
+			bias := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
+
+			store := model.NewStore()
+			exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
+				cast := func(n *Node) *Node { return ConvertDType(n, tc.dtype) }
+				qc, kc, vc, bc := cast(qn), cast(kn), cast(vn), cast(bn)
+				fusedOut, _ := Core(qc, kc, vc, tc.layout, CoreOptions{Scale: scale, AttentionBias: bc})
+				refOut, _ := Core(qc, kc, vc, tc.layout, CoreOptions{Scale: scale, AttentionBias: bc, DisableFusion: true})
+				fF32 := ConvertDType(fusedOut, dtypes.Float32)
+				rF32 := ConvertDType(refOut, dtypes.Float32)
+				relFwd := Div(ReduceAllMax(Abs(Sub(fF32, rF32))), AddScalar(ReduceAllMax(Abs(rF32)), 1e-6))
+				dqF := ConvertDType(Gradient(ReduceAllSum(fF32), qc)[0], dtypes.Float32)
+				dqR := ConvertDType(Gradient(ReduceAllSum(rF32), qc)[0], dtypes.Float32)
+				relBwd := Div(ReduceAllMax(Abs(Sub(dqF, dqR))), AddScalar(ReduceAllMax(Abs(dqR)), 1e-6))
+				return []*Node{relFwd, relBwd}
+			})
+
+			out, g, err := exec.CallWithGraph(q, k, v, bias)
+			require.NoError(t, err)
+			hasFwd, hasBwd := HasFusedSDPA(g)
+			require.True(t, hasFwd, "fused bias must engage in forward for %s", tc.name)
+			require.True(t, hasBwd, "fused bias must engage in backward for %s", tc.name)
+			require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[0])), 0.06, "forward rel err (%s)", tc.name)
+			require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06, "backward rel err (%s)", tc.name)
+		})
+	}
+}
+
 func abs32(x float32) float32 {
 	if x < 0 {
 		return -x

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -1,0 +1,244 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package attention
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gomlx/compute"
+	"github.com/gomlx/compute/dtypes"
+	. "github.com/gomlx/gomlx/core/graph"
+	"github.com/gomlx/gomlx/core/tensors"
+	"github.com/gomlx/gomlx/ml/model"
+	"github.com/gomlx/gomlx/support/exceptions"
+	"github.com/gomlx/gomlx/support/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// backendSupportsBiasedFusion reports whether the backend implements fused SDPA with a [B,H,S,S]
+// bias, using the same probe-then-detect pattern as backendSupportsFusion. Dims match the real test
+// (S=64, H=2, D=64) so "probe succeeds" reliably implies the real test's fused arm will fuse.
+func backendSupportsBiasedFusion(backend compute.Backend) bool {
+	const B, S, H, D = 1, 64, 2, 64
+	scale := 1.0 / math.Sqrt(float64(D))
+	q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 20), B, S, H, D)
+	biasTensor := tensors.FromFlatDataAndDimensions(make([]float32, B*H*S*S), B, H, S, S)
+	supported := false
+	probeErr := exceptions.TryCatch[error](func() {
+		exec := MustNewExec(backend, func(qn, bn *Node) *Node {
+			round := func(n *Node) *Node { return ConvertDType(n, dtypes.BFloat16) }
+			cfg := &compute.ScaledDotProductAttentionConfig{Bias: InternalBackendOutputs(round(bn))[0]}
+			fused, _ := BackendFusedScaledDotProductAttention(
+				round(qn), round(qn), round(qn), nil, H, H,
+				compute.AxesLayoutBSHD, scale, false, cfg)
+			return ConvertDType(ReduceAllSum(fused), dtypes.Float32)
+		})
+		_ = exec.MustCall(q, biasTensor)
+		supported = true
+	})
+	if probeErr != nil {
+		if compute.IsNotImplemented(probeErr) {
+			return false
+		}
+		panic(probeErr)
+	}
+	return supported
+}
+
+// TestCoreAttentionBiasDecomposed checks that a non-nil AttentionBias yields output matching the
+// inline reference softmax(scale*QK^T + bias)*V on the CPU backend (decomposed). The bias strongly
+// favors key position 1, so the output diverges measurably from no-bias attention; the test fails
+// if bias is silently dropped.
+func TestCoreAttentionBiasDecomposed(t *testing.T) {
+	backend := testutil.BuildTestBackend()
+	// [B=1, S=2, H=1, D=4] — BSHD layout, scores are [B,Sq,H,Skv] = [1,2,1,2].
+	const B, S, H, D = 1, 2, 1, 4
+	scale := 1.0 / math.Sqrt(float64(D))
+
+	q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 1), B, S, H, D)
+	k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 2), B, S, H, D)
+	v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 3), B, S, H, D)
+	// Bias [B,H,Sq,Skv] = [1,1,2,2]: strongly favor key position 1 for both query positions.
+	biasData := []float32{-100, 0, -100, 0}
+	bias := tensors.FromFlatDataAndDimensions(biasData, B, H, S, S)
+
+	store := model.NewStore()
+	exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
+		// Decomposed forced via WantCoefficients.
+		biasedOut, _ := Core(qn, kn, vn, LayoutBSHD, CoreOptions{Scale: scale, WantCoefficients: true, AttentionBias: bn})
+
+		// Inline reference: softmax(scale*QK^T + bias)*V. bn is [B,H,Sq,Skv]; BSHD scores are
+		// [B,Sq,H,Skv] so permute before Add.
+		scores := MulScalar(Einsum("bqhd,bkhd->bqhk", qn, kn), scale)
+		scores = Add(scores, TransposeAllAxes(bn, 0, 2, 1, 3))
+		attn := Softmax(scores, -1)
+		refOut := Einsum("bqhk,bkhd->bqhd", attn, vn)
+
+		noBiasOut, _ := Core(qn, kn, vn, LayoutBSHD, CoreOptions{Scale: scale, WantCoefficients: true})
+		return []*Node{biasedOut, refOut, noBiasOut}
+	})
+
+	out := exec.MustCall(q, k, v, bias)
+	biasedData := out[0].Value().([][][][]float32)
+	refData := out[1].Value().([][][][]float32)
+	noBiasData := out[2].Value().([][][][]float32)
+
+	for b := range biasedData {
+		for s := range biasedData[b] {
+			for h := range biasedData[b][s] {
+				for d := range biasedData[b][s][h] {
+					require.InDeltaf(t, refData[b][s][h][d], biasedData[b][s][h][d], 1e-5,
+						"biased Core output != inline reference at [%d][%d][%d][%d]", b, s, h, d)
+				}
+			}
+		}
+	}
+
+	maxDiff := float32(0)
+	for b := range biasedData {
+		for s := range biasedData[b] {
+			for h := range biasedData[b][s] {
+				for d := range biasedData[b][s][h] {
+					if diff := abs32(biasedData[b][s][h][d] - noBiasData[b][s][h][d]); diff > maxDiff {
+						maxDiff = diff
+					}
+				}
+			}
+		}
+	}
+	require.Greater(t, maxDiff, float32(0.01),
+		"biased and unbiased outputs are too similar; bias appears to be ignored (maxDiff=%v)", maxDiff)
+}
+
+// TestCoreAttentionBiasGQA verifies AttentionBias is correctly applied under GQA (numQueryHeads >
+// numKVHeads). On the decomposed path the score tensor is 5D ([B,H,G,Sq,Skv] for BHSD), so the 4D
+// bias must be reshaped before Add; without the reshape the Add broadcasts along the wrong axis.
+func TestCoreAttentionBiasGQA(t *testing.T) {
+	backend := testutil.BuildTestBackend()
+	// 4 query heads, 2 kv heads (groupSize=2), BHSD layout.
+	const B, QH, KVH, Sq, Skv, D = 1, 4, 2, 3, 3, 4
+	scale := 1.0 / math.Sqrt(float64(D))
+
+	q := tensors.FromFlatDataAndDimensions(randFlat(B*QH*Sq*D, 7), B, QH, Sq, D)
+	k := tensors.FromFlatDataAndDimensions(randFlat(B*KVH*Skv*D, 8), B, KVH, Skv, D)
+	v := tensors.FromFlatDataAndDimensions(randFlat(B*KVH*Skv*D, 9), B, KVH, Skv, D)
+	// Bias [B,QH,Sq,Skv]: strongly favor key position 0 for every query position.
+	biasFlat := make([]float32, B*QH*Sq*Skv)
+	for i := range biasFlat {
+		if i%Skv != 0 {
+			biasFlat[i] = -100
+		}
+	}
+	biasTensor := tensors.FromFlatDataAndDimensions(biasFlat, B, QH, Sq, Skv)
+
+	store := model.NewStore()
+	exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
+		biasedOut, _ := Core(qn, kn, vn, LayoutBHSD, CoreOptions{Scale: scale, WantCoefficients: true, AttentionBias: bn})
+
+		// Inline reference: explicit GQA grouping, bias reshaped to 5D per group.
+		group := QH / KVH
+		qg := Reshape(qn, B, KVH, group, Sq, D)
+		scores := MulScalar(Einsum("bhgqd,bhkd->bhgqk", qg, kn), scale)
+		biasReshaped := Reshape(bn, B, KVH, group, Sq, Skv)
+		scores = Add(scores, biasReshaped)
+		attn := Softmax(scores, -1)
+		out5d := Einsum("bhgqk,bhkd->bhgqd", attn, vn)
+		refOut := Reshape(out5d, B, QH, Sq, D)
+
+		noBiasOut, _ := Core(qn, kn, vn, LayoutBHSD, CoreOptions{Scale: scale, WantCoefficients: true})
+		return []*Node{biasedOut, refOut, noBiasOut}
+	})
+
+	out := exec.MustCall(q, k, v, biasTensor)
+	biasedData := out[0].Value().([][][][]float32)
+	refData := out[1].Value().([][][][]float32)
+	noBiasData := out[2].Value().([][][][]float32)
+
+	for b := range biasedData {
+		for h := range biasedData[b] {
+			for s := range biasedData[b][h] {
+				for d := range biasedData[b][h][s] {
+					require.InDeltaf(t, refData[b][h][s][d], biasedData[b][h][s][d], 1e-5,
+						"GQA+bias Core output != inline reference at [%d][%d][%d][%d]", b, h, s, d)
+				}
+			}
+		}
+	}
+
+	maxDiff := float32(0)
+	for b := range biasedData {
+		for h := range biasedData[b] {
+			for s := range biasedData[b][h] {
+				for d := range biasedData[b][h][s] {
+					if diff := abs32(biasedData[b][h][s][d] - noBiasData[b][h][s][d]); diff > maxDiff {
+						maxDiff = diff
+					}
+				}
+			}
+		}
+	}
+	require.Greater(t, maxDiff, float32(0.01),
+		"GQA biased and unbiased outputs too similar; bias appears ignored (maxDiff=%v)", maxDiff)
+}
+
+// TestAttentionBiasFusedParity_cuda [cuda] verifies the fused bias path (cfg.Bias set) matches the
+// decomposed reference, forward and gradient (dQ), within bf16 tolerance. On xla:cuda the fused arm
+// uses cuDNN ScaleBias; the reference arm handles bias in software. Skipped unless xla:cuda supports
+// fused attention.
+func TestAttentionBiasFusedParity_cuda(t *testing.T) {
+	backend := testutil.GetOfficialBackend("xla:cuda")
+	if backend == nil || !backendSupportsFusionForBFloat16(backend) {
+		t.Skip("xla:cuda fused attention backend not available")
+	}
+	require.True(t, backendSupportsBiasedFusion(backend),
+		"xla:cuda supports plain fused SDPA but not biased fusion; bias layout rejected by validateBias")
+
+	const B, S, H, D = 2, 64, 2, 64
+	scale := 1.0 / math.Sqrt(float64(D))
+
+	q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), B, S, H*D)
+	k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), B, S, H*D)
+	v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), B, S, H*D)
+	biasTensor := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
+
+	store := model.NewStore()
+	exec := model.MustNewExec(backend, store, func(scope *model.Scope, qIn, kIn, vIn, biasIn *Node) []*Node {
+		qProj := Reshape(qIn, B, S, H, D)
+		kProj := Reshape(kIn, B, S, H, D)
+		vProj := Reshape(vIn, B, S, H, D)
+
+		// Fused vs decomposed arms through the builder, sharing projection weights.
+		fusedOut := MultiHeadAttention(scope.In("shared"), qIn, kIn, vIn, H, D).
+			WithAttentionBias(biasIn).WithPreProjected(true).Done()
+		refOut := MultiHeadAttention(scope.Shared("shared"), qIn, kIn, vIn, H, D).
+			WithAttentionBias(biasIn).WithFusion(false).WithPreProjected(true).Done()
+
+		fusedF32 := ConvertDType(fusedOut, dtypes.Float32)
+		refF32 := ConvertDType(refOut, dtypes.Float32)
+		relFwd := Div(ReduceAllMax(Abs(Sub(fusedF32, refF32))), AddScalar(ReduceAllMax(Abs(refF32)), 1e-6))
+
+		// Backward: dQ through the fused bias path vs the decomposed one.
+		fusedBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn})
+		refBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn, DisableFusion: true})
+		dqFused := Gradient(ReduceAllSum(ConvertDType(fusedBwdOut, dtypes.Float32)), qProj)[0]
+		dqRef := Gradient(ReduceAllSum(ConvertDType(refBwdOut, dtypes.Float32)), qProj)[0]
+		relBwd := Div(ReduceAllMax(Abs(Sub(dqFused, dqRef))), AddScalar(ReduceAllMax(Abs(dqRef)), 1e-6))
+
+		return []*Node{fusedF32, relFwd, relBwd}
+	})
+
+	out := exec.MustCall(q, k, v, biasTensor)
+	require.Equal(t, []int{B, S, H * D}, out[0].Shape().Dimensions, "fused bias output shape must be [B, S, H*D]")
+	require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06,
+		"fused and decomposed bias outputs diverge (forward rel err)")
+	require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[2])), 0.06,
+		"fused and decomposed bias gradients diverge (dQ rel err)")
+}
+
+func abs32(x float32) float32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -182,137 +182,142 @@ func TestCoreAttentionBiasGQA(t *testing.T) {
 		"GQA biased and unbiased outputs too similar; bias appears ignored (maxDiff=%v)", maxDiff)
 }
 
-// TestAttentionBiasFusedParity_cuda [cuda] verifies the fused bias path (cfg.Bias set) matches the
-// decomposed reference, forward and gradient (dQ), within bf16 tolerance. On xla:cuda the fused arm
-// uses cuDNN ScaleBias; the reference arm handles bias in software. Skipped unless xla:cuda supports
-// fused attention.
-func TestAttentionBiasFusedParity_cuda(t *testing.T) {
-	backend := testutil.GetOfficialBackend("xla:cuda")
-	if backend == nil || !backendSupportsFusionForBFloat16(backend) {
-		t.Skip("xla:cuda fused attention backend not available")
-	}
-	require.True(t, backendSupportsBiasedFusion(backend),
-		"xla:cuda supports plain fused SDPA but not biased fusion; bias layout rejected by validateBias")
+// TestAttentionBiasFusedParity verifies the fused bias path (cfg.Bias set) matches the decomposed
+// reference, forward and gradient (dQ), within bf16 tolerance. The fused arm uses the backend's
+// biased fusion (cuDNN ScaleBias on xla:cuda); the reference arm handles bias in software. Runs on
+// every official backend; those without biased fusion skip.
+func TestAttentionBiasFusedParity(t *testing.T) {
+	testutil.TestOfficialBackends(t, func(t *testing.T, backend compute.Backend) {
+		if !backendSupportsFusionForBFloat16(backend) {
+			t.Skipf("%s: fused attention backend not available", backend)
+		}
+		if !backendSupportsBiasedFusion(backend) {
+			t.Skipf("%s: supports plain fused SDPA but not biased fusion", backend)
+		}
 
-	const B, S, H, D = 2, 64, 2, 64
-	scale := 1.0 / math.Sqrt(float64(D))
+		const B, S, H, D = 2, 64, 2, 64
+		scale := 1.0 / math.Sqrt(float64(D))
 
-	// bf16 inputs and bias: the backend does no auto-conversion, so f32 would make the fused arm
-	// fall back to decomposed and the parity would pass trivially. HasFusedSDPA below guards that.
-	q := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 10), B, S, H*D)
-	k := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 11), B, S, H*D)
-	v := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 12), B, S, H*D)
-	biasTensor := tensors.FromFlatDataAndDimensions(randFlatBF16(B*H*S*S, 99), B, H, S, S)
+		// bf16 inputs and bias: the backend does no auto-conversion, so f32 would make the fused arm
+		// fall back to decomposed and the parity would pass trivially. HasFusedSDPA below guards that.
+		q := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 10), B, S, H*D)
+		k := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 11), B, S, H*D)
+		v := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 12), B, S, H*D)
+		biasTensor := tensors.FromFlatDataAndDimensions(randFlatBF16(B*H*S*S, 99), B, H, S, S)
 
-	store := model.NewStore()
-	exec := model.MustNewExec(backend, store, func(scope *model.Scope, qIn, kIn, vIn, biasIn *Node) []*Node {
-		qProj := Reshape(qIn, B, S, H, D)
-		kProj := Reshape(kIn, B, S, H, D)
-		vProj := Reshape(vIn, B, S, H, D)
+		store := model.NewStore()
+		exec := model.MustNewExec(backend, store, func(scope *model.Scope, qIn, kIn, vIn, biasIn *Node) []*Node {
+			qProj := Reshape(qIn, B, S, H, D)
+			kProj := Reshape(kIn, B, S, H, D)
+			vProj := Reshape(vIn, B, S, H, D)
 
-		// Backward arms first: dQ through the fused bias path vs the decomposed one. These take the
-		// gradient, so they put both the fused forward and the fused VJP into the graph.
-		fusedBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn})
-		refBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn, DisableFusion: true})
-		// Gradients are w.r.t. bf16 qProj, so cast to f32 before the metric (ToScalar wants f32).
-		dqFused := ConvertDType(Gradient(ReduceAllSum(ConvertDType(fusedBwdOut, dtypes.Float32)), qProj)[0], dtypes.Float32)
-		dqRef := ConvertDType(Gradient(ReduceAllSum(ConvertDType(refBwdOut, dtypes.Float32)), qProj)[0], dtypes.Float32)
-		relBwd := Div(ReduceAllMax(Abs(Sub(dqFused, dqRef))), AddScalar(ReduceAllMax(Abs(dqRef)), 1e-6))
+			// Backward arms first: dQ through the fused bias path vs the decomposed one. These take the
+			// gradient, so they put both the fused forward and the fused VJP into the graph.
+			fusedBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn})
+			refBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn, DisableFusion: true})
+			// Gradients are w.r.t. bf16 qProj, so cast to f32 before the metric (ToScalar wants f32).
+			dqFused := ConvertDType(Gradient(ReduceAllSum(ConvertDType(fusedBwdOut, dtypes.Float32)), qProj)[0], dtypes.Float32)
+			dqRef := ConvertDType(Gradient(ReduceAllSum(ConvertDType(refBwdOut, dtypes.Float32)), qProj)[0], dtypes.Float32)
+			relBwd := Div(ReduceAllMax(Abs(Sub(dqFused, dqRef))), AddScalar(ReduceAllMax(Abs(dqRef)), 1e-6))
 
-		// Forward parity through the builder, sharing projection weights.
-		fusedOut := MultiHeadAttention(scope.In("shared"), qIn, kIn, vIn, H, D).
-			WithAttentionBias(biasIn).WithPreProjected(true).Done()
-		refOut := MultiHeadAttention(scope.Shared("shared"), qIn, kIn, vIn, H, D).
-			WithAttentionBias(biasIn).WithFusion(false).WithPreProjected(true).Done()
-		fusedF32 := ConvertDType(fusedOut, dtypes.Float32)
-		refF32 := ConvertDType(refOut, dtypes.Float32)
-		relFwd := Div(ReduceAllMax(Abs(Sub(fusedF32, refF32))), AddScalar(ReduceAllMax(Abs(refF32)), 1e-6))
+			// Forward parity through the builder, sharing projection weights.
+			fusedOut := MultiHeadAttention(scope.In("shared"), qIn, kIn, vIn, H, D).
+				WithAttentionBias(biasIn).WithPreProjected(true).Done()
+			refOut := MultiHeadAttention(scope.Shared("shared"), qIn, kIn, vIn, H, D).
+				WithAttentionBias(biasIn).WithFusion(false).WithPreProjected(true).Done()
+			fusedF32 := ConvertDType(fusedOut, dtypes.Float32)
+			refF32 := ConvertDType(refOut, dtypes.Float32)
+			relFwd := Div(ReduceAllMax(Abs(Sub(fusedF32, refF32))), AddScalar(ReduceAllMax(Abs(refF32)), 1e-6))
 
-		return []*Node{fusedF32, relFwd, relBwd}
+			return []*Node{fusedF32, relFwd, relBwd}
+		})
+
+		out, g, err := exec.CallWithGraph(q, k, v, biasTensor)
+		require.NoError(t, err)
+
+		// Verify the fused bias op actually engaged, so the parity is meaningful and not a silent fallback.
+		hasFwd, hasBwd := HasFusedSDPA(g)
+		require.True(t, hasFwd, "fused bias arm must use FusedScaledDotProductAttention (not fall back to decomposed)")
+		require.True(t, hasBwd, "fused bias arm must use FusedScaledDotProductAttentionVJP in the backward")
+
+		require.Equal(t, []int{B, S, H * D}, out[0].Shape().Dimensions, "fused bias output shape must be [B, S, H*D]")
+		require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06,
+			"fused and decomposed bias outputs diverge (forward rel err)")
+		require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[2])), 0.06,
+			"fused and decomposed bias gradients diverge (dQ rel err)")
 	})
-
-	out, g, err := exec.CallWithGraph(q, k, v, biasTensor)
-	require.NoError(t, err)
-
-	// Verify the fused bias op actually engaged, so the parity is meaningful and not a silent fallback.
-	hasFwd, hasBwd := HasFusedSDPA(g)
-	require.True(t, hasFwd, "fused bias arm must use FusedScaledDotProductAttention (not fall back to decomposed)")
-	require.True(t, hasBwd, "fused bias arm must use FusedScaledDotProductAttentionVJP in the backward")
-
-	require.Equal(t, []int{B, S, H * D}, out[0].Shape().Dimensions, "fused bias output shape must be [B, S, H*D]")
-	require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06,
-		"fused and decomposed bias outputs diverge (forward rel err)")
-	require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[2])), 0.06,
-		"fused and decomposed bias gradients diverge (dQ rel err)")
 }
 
-// TestAttentionBiasFusedParityMatrix_cuda [cuda] extends the bias fused-parity check across dtype
+// TestAttentionBiasFusedParityMatrix extends the bias fused-parity check across dtype
 // (Float16) and layout (BHSD), mirroring the plain-path BF16/Float16 coverage. Each case asserts the
 // fused bias op actually engaged (HasFusedSDPA) so a silent fallback cannot pass trivially. The base
-// bf16/BSHD case lives in TestAttentionBiasFusedParity_cuda.
-func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
-	backend := testutil.GetOfficialBackend("xla:cuda")
-	if backend == nil || !backendSupportsFusionForBFloat16(backend) {
-		t.Skip("xla:cuda fused attention backend not available")
-	}
-	require.True(t, backendSupportsBiasedFusion(backend),
-		"xla:cuda supports plain fused SDPA but not biased fusion")
+// bf16/BSHD case lives in TestAttentionBiasFusedParity. Runs on every official backend; those
+// without biased fusion skip.
+func TestAttentionBiasFusedParityMatrix(t *testing.T) {
+	testutil.TestOfficialBackends(t, func(t *testing.T, backend compute.Backend) {
+		if !backendSupportsFusionForBFloat16(backend) {
+			t.Skipf("%s: fused attention backend not available", backend)
+		}
+		if !backendSupportsBiasedFusion(backend) {
+			t.Skipf("%s: supports plain fused SDPA but not biased fusion", backend)
+		}
 
-	const B, S, H, D = 2, 64, 2, 64
-	scale := 1.0 / math.Sqrt(float64(D))
-	cases := []struct {
-		name   string
-		dtype  dtypes.DType
-		layout AxesLayout
-		// fwdOnly skips the backward parity, kept as a knob for variants whose fused backward is
-		// unsupported. All current cases run full fwd+bwd.
-		fwdOnly bool
-	}{
-		{"f16_bshd", dtypes.Float16, LayoutBSHD, false},
-		{"bf16_bhsd", dtypes.BFloat16, LayoutBHSD, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// q/k/v shaped per layout; bias is [B,H,Sq,Skv] regardless. f32 seed data cast to the
-			// target dtype in-graph so the fused path engages (no auto-conversion at the backend).
-			qkvDims := []int{B, S, H, D}
-			if tc.layout == LayoutBHSD {
-				qkvDims = []int{B, H, S, D}
-			}
-			q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), qkvDims...)
-			k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), qkvDims...)
-			v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), qkvDims...)
-			bias := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
-
-			store := model.NewStore()
-			exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
-				cast := func(n *Node) *Node { return ConvertDType(n, tc.dtype) }
-				qc, kc, vc, bc := cast(qn), cast(kn), cast(vn), cast(bn)
-				fusedOut, _ := Core(qc, kc, vc, tc.layout, CoreOptions{Scale: scale, AttentionBias: bc})
-				refOut, _ := Core(qc, kc, vc, tc.layout, CoreOptions{Scale: scale, AttentionBias: bc, DisableFusion: true})
-				fF32 := ConvertDType(fusedOut, dtypes.Float32)
-				rF32 := ConvertDType(refOut, dtypes.Float32)
-				relFwd := Div(ReduceAllMax(Abs(Sub(fF32, rF32))), AddScalar(ReduceAllMax(Abs(rF32)), 1e-6))
-				if tc.fwdOnly {
-					return []*Node{relFwd}
+		const B, S, H, D = 2, 64, 2, 64
+		scale := 1.0 / math.Sqrt(float64(D))
+		cases := []struct {
+			name   string
+			dtype  dtypes.DType
+			layout AxesLayout
+			// fwdOnly skips the backward parity, kept as a knob for variants whose fused backward is
+			// unsupported. All current cases run full fwd+bwd.
+			fwdOnly bool
+		}{
+			{"f16_bshd", dtypes.Float16, LayoutBSHD, false},
+			{"bf16_bhsd", dtypes.BFloat16, LayoutBHSD, false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				// q/k/v shaped per layout; bias is [B,H,Sq,Skv] regardless. f32 seed data cast to the
+				// target dtype in-graph so the fused path engages (no auto-conversion at the backend).
+				qkvDims := []int{B, S, H, D}
+				if tc.layout == LayoutBHSD {
+					qkvDims = []int{B, H, S, D}
 				}
-				dqF := ConvertDType(Gradient(ReduceAllSum(fF32), qc)[0], dtypes.Float32)
-				dqR := ConvertDType(Gradient(ReduceAllSum(rF32), qc)[0], dtypes.Float32)
-				relBwd := Div(ReduceAllMax(Abs(Sub(dqF, dqR))), AddScalar(ReduceAllMax(Abs(dqR)), 1e-6))
-				return []*Node{relFwd, relBwd}
-			})
+				q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), qkvDims...)
+				k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), qkvDims...)
+				v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), qkvDims...)
+				bias := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
 
-			out, g, err := exec.CallWithGraph(q, k, v, bias)
-			require.NoError(t, err)
-			hasFwd, hasBwd := HasFusedSDPA(g)
-			require.True(t, hasFwd, "fused bias must engage in forward for %s", tc.name)
-			require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[0])), 0.06, "forward rel err (%s)", tc.name)
-			if !tc.fwdOnly {
-				require.True(t, hasBwd, "fused bias must engage in backward for %s", tc.name)
-				require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06, "backward rel err (%s)", tc.name)
-			}
-		})
-	}
+				store := model.NewStore()
+				exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
+					cast := func(n *Node) *Node { return ConvertDType(n, tc.dtype) }
+					qc, kc, vc, bc := cast(qn), cast(kn), cast(vn), cast(bn)
+					fusedOut, _ := Core(qc, kc, vc, tc.layout, CoreOptions{Scale: scale, AttentionBias: bc})
+					refOut, _ := Core(qc, kc, vc, tc.layout, CoreOptions{Scale: scale, AttentionBias: bc, DisableFusion: true})
+					fF32 := ConvertDType(fusedOut, dtypes.Float32)
+					rF32 := ConvertDType(refOut, dtypes.Float32)
+					relFwd := Div(ReduceAllMax(Abs(Sub(fF32, rF32))), AddScalar(ReduceAllMax(Abs(rF32)), 1e-6))
+					if tc.fwdOnly {
+						return []*Node{relFwd}
+					}
+					dqF := ConvertDType(Gradient(ReduceAllSum(fF32), qc)[0], dtypes.Float32)
+					dqR := ConvertDType(Gradient(ReduceAllSum(rF32), qc)[0], dtypes.Float32)
+					relBwd := Div(ReduceAllMax(Abs(Sub(dqF, dqR))), AddScalar(ReduceAllMax(Abs(dqR)), 1e-6))
+					return []*Node{relFwd, relBwd}
+				})
+
+				out, g, err := exec.CallWithGraph(q, k, v, bias)
+				require.NoError(t, err)
+				hasFwd, hasBwd := HasFusedSDPA(g)
+				require.True(t, hasFwd, "fused bias must engage in forward for %s", tc.name)
+				require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[0])), 0.06, "forward rel err (%s)", tc.name)
+				if !tc.fwdOnly {
+					require.True(t, hasBwd, "fused bias must engage in backward for %s", tc.name)
+					require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06, "backward rel err (%s)", tc.name)
+				}
+			})
+		}
+	})
 }
 
 func abs32(x float32) float32 {

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -264,12 +264,11 @@ func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
 		name   string
 		dtype  dtypes.DType
 		layout AxesLayout
-		// fwdOnly skips the backward parity. The cuDNN fmha BACKWARD does not compile in Float16 on
-		// this GPU (sm_8.6) even without bias, so f16 is exercised forward-only here; that is a base
-		// fmha limitation, not a bias one (the f16 bias forward fuses and matches).
+		// fwdOnly skips the backward parity, kept as a knob for variants whose fused backward is
+		// unsupported. All current cases run full fwd+bwd.
 		fwdOnly bool
 	}{
-		{"f16_bshd", dtypes.Float16, LayoutBSHD, true},
+		{"f16_bshd", dtypes.Float16, LayoutBSHD, false},
 		{"bf16_bhsd", dtypes.BFloat16, LayoutBHSD, false},
 	}
 	for _, tc := range cases {

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -197,10 +197,12 @@ func TestAttentionBiasFusedParity_cuda(t *testing.T) {
 	const B, S, H, D = 2, 64, 2, 64
 	scale := 1.0 / math.Sqrt(float64(D))
 
-	q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), B, S, H*D)
-	k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), B, S, H*D)
-	v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), B, S, H*D)
-	biasTensor := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
+	// bf16 inputs and bias: the backend does no auto-conversion, so f32 would make the fused arm
+	// fall back to decomposed and the parity would pass trivially. HasFusedSDPA below guards that.
+	q := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 10), B, S, H*D)
+	k := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 11), B, S, H*D)
+	v := tensors.FromFlatDataAndDimensions(randFlatBF16(B*S*H*D, 12), B, S, H*D)
+	biasTensor := tensors.FromFlatDataAndDimensions(randFlatBF16(B*H*S*S, 99), B, H, S, S)
 
 	store := model.NewStore()
 	exec := model.MustNewExec(backend, store, func(scope *model.Scope, qIn, kIn, vIn, biasIn *Node) []*Node {
@@ -208,27 +210,35 @@ func TestAttentionBiasFusedParity_cuda(t *testing.T) {
 		kProj := Reshape(kIn, B, S, H, D)
 		vProj := Reshape(vIn, B, S, H, D)
 
-		// Fused vs decomposed arms through the builder, sharing projection weights.
+		// Backward arms first: dQ through the fused bias path vs the decomposed one. These take the
+		// gradient, so they put both the fused forward and the fused VJP into the graph.
+		fusedBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn})
+		refBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn, DisableFusion: true})
+		// Gradients are w.r.t. bf16 qProj, so cast to f32 before the metric (ToScalar wants f32).
+		dqFused := ConvertDType(Gradient(ReduceAllSum(ConvertDType(fusedBwdOut, dtypes.Float32)), qProj)[0], dtypes.Float32)
+		dqRef := ConvertDType(Gradient(ReduceAllSum(ConvertDType(refBwdOut, dtypes.Float32)), qProj)[0], dtypes.Float32)
+		relBwd := Div(ReduceAllMax(Abs(Sub(dqFused, dqRef))), AddScalar(ReduceAllMax(Abs(dqRef)), 1e-6))
+
+		// Forward parity through the builder, sharing projection weights.
 		fusedOut := MultiHeadAttention(scope.In("shared"), qIn, kIn, vIn, H, D).
 			WithAttentionBias(biasIn).WithPreProjected(true).Done()
 		refOut := MultiHeadAttention(scope.Shared("shared"), qIn, kIn, vIn, H, D).
 			WithAttentionBias(biasIn).WithFusion(false).WithPreProjected(true).Done()
-
 		fusedF32 := ConvertDType(fusedOut, dtypes.Float32)
 		refF32 := ConvertDType(refOut, dtypes.Float32)
 		relFwd := Div(ReduceAllMax(Abs(Sub(fusedF32, refF32))), AddScalar(ReduceAllMax(Abs(refF32)), 1e-6))
 
-		// Backward: dQ through the fused bias path vs the decomposed one.
-		fusedBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn})
-		refBwdOut, _ := Core(qProj, kProj, vProj, LayoutBSHD, CoreOptions{Scale: scale, AttentionBias: biasIn, DisableFusion: true})
-		dqFused := Gradient(ReduceAllSum(ConvertDType(fusedBwdOut, dtypes.Float32)), qProj)[0]
-		dqRef := Gradient(ReduceAllSum(ConvertDType(refBwdOut, dtypes.Float32)), qProj)[0]
-		relBwd := Div(ReduceAllMax(Abs(Sub(dqFused, dqRef))), AddScalar(ReduceAllMax(Abs(dqRef)), 1e-6))
-
 		return []*Node{fusedF32, relFwd, relBwd}
 	})
 
-	out := exec.MustCall(q, k, v, biasTensor)
+	out, g, err := exec.CallWithGraph(q, k, v, biasTensor)
+	require.NoError(t, err)
+
+	// Verify the fused bias op actually engaged, so the parity is meaningful and not a silent fallback.
+	hasFwd, hasBwd := HasFusedSDPA(g)
+	require.True(t, hasFwd, "fused bias arm must use FusedScaledDotProductAttention (not fall back to decomposed)")
+	require.True(t, hasBwd, "fused bias arm must use FusedScaledDotProductAttentionVJP in the backward")
+
 	require.Equal(t, []int{B, S, H * D}, out[0].Shape().Dimensions, "fused bias output shape must be [B, S, H*D]")
 	require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06,
 		"fused and decomposed bias outputs diverge (forward rel err)")

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -307,6 +307,52 @@ func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
 	}
 }
 
+// TestF16BiasDiag_cuda is a TEMPORARY diagnostic to localize the f16+bias compile failure: it runs
+// plain vs biased, forward-only vs fwd+bwd, and reports which compiles + whether it fused.
+func TestF16BiasDiag_cuda(t *testing.T) {
+	backend := testutil.GetOfficialBackend("xla:cuda")
+	if backend == nil || !backendSupportsFusionForBFloat16(backend) {
+		t.Skip("xla:cuda fused attention backend not available")
+	}
+	const B, S, H, D = 2, 64, 2, 64
+	scale := 1.0 / math.Sqrt(float64(D))
+	q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), B, S, H, D)
+	k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), B, S, H, D)
+	v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), B, S, H, D)
+	bias := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
+
+	run := func(name string, withBias, withGrad bool) {
+		t.Run(name, func(t *testing.T) {
+			store := model.NewStore()
+			exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
+				c := func(n *Node) *Node { return ConvertDType(n, dtypes.Float16) }
+				qc, kc, vc := c(qn), c(kn), c(vn)
+				opts := CoreOptions{Scale: scale}
+				if withBias {
+					opts.AttentionBias = c(bn)
+				}
+				out, _ := Core(qc, kc, vc, LayoutBSHD, opts)
+				outF32 := ConvertDType(out, dtypes.Float32)
+				if withGrad {
+					dq := ConvertDType(Gradient(ReduceAllSum(outF32), qc)[0], dtypes.Float32)
+					return []*Node{ReduceAllSum(dq)}
+				}
+				return []*Node{ReduceAllSum(outF32)}
+			})
+			_, g, err := exec.CallWithGraph(q, k, v, bias)
+			if err != nil {
+				t.Fatalf("COMPILE FAILED: %v", err)
+			}
+			hasF, hasB := HasFusedSDPA(g)
+			t.Logf("OK: hasFwd=%v hasBwd=%v", hasF, hasB)
+		})
+	}
+	run("plain_f16_fwd", false, false)
+	run("plain_f16_fwdbwd", false, true)
+	run("bias_f16_fwd", true, false)
+	run("bias_f16_fwdbwd", true, true)
+}
+
 func abs32(x float32) float32 {
 	if x < 0 {
 		return -x

--- a/ml/layers/attention/fusion_bias_test.go
+++ b/ml/layers/attention/fusion_bias_test.go
@@ -264,9 +264,13 @@ func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
 		name   string
 		dtype  dtypes.DType
 		layout AxesLayout
+		// fwdOnly skips the backward parity. The cuDNN fmha BACKWARD does not compile in Float16 on
+		// this GPU (sm_8.6) even without bias, so f16 is exercised forward-only here; that is a base
+		// fmha limitation, not a bias one (the f16 bias forward fuses and matches).
+		fwdOnly bool
 	}{
-		{"f16_bshd", dtypes.Float16, LayoutBSHD},
-		{"bf16_bhsd", dtypes.BFloat16, LayoutBHSD},
+		{"f16_bshd", dtypes.Float16, LayoutBSHD, true},
+		{"bf16_bhsd", dtypes.BFloat16, LayoutBHSD, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -290,6 +294,9 @@ func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
 				fF32 := ConvertDType(fusedOut, dtypes.Float32)
 				rF32 := ConvertDType(refOut, dtypes.Float32)
 				relFwd := Div(ReduceAllMax(Abs(Sub(fF32, rF32))), AddScalar(ReduceAllMax(Abs(rF32)), 1e-6))
+				if tc.fwdOnly {
+					return []*Node{relFwd}
+				}
 				dqF := ConvertDType(Gradient(ReduceAllSum(fF32), qc)[0], dtypes.Float32)
 				dqR := ConvertDType(Gradient(ReduceAllSum(rF32), qc)[0], dtypes.Float32)
 				relBwd := Div(ReduceAllMax(Abs(Sub(dqF, dqR))), AddScalar(ReduceAllMax(Abs(dqR)), 1e-6))
@@ -300,57 +307,13 @@ func TestAttentionBiasFusedParityMatrix_cuda(t *testing.T) {
 			require.NoError(t, err)
 			hasFwd, hasBwd := HasFusedSDPA(g)
 			require.True(t, hasFwd, "fused bias must engage in forward for %s", tc.name)
-			require.True(t, hasBwd, "fused bias must engage in backward for %s", tc.name)
 			require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[0])), 0.06, "forward rel err (%s)", tc.name)
-			require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06, "backward rel err (%s)", tc.name)
-		})
-	}
-}
-
-// TestF16BiasDiag_cuda is a TEMPORARY diagnostic to localize the f16+bias compile failure: it runs
-// plain vs biased, forward-only vs fwd+bwd, and reports which compiles + whether it fused.
-func TestF16BiasDiag_cuda(t *testing.T) {
-	backend := testutil.GetOfficialBackend("xla:cuda")
-	if backend == nil || !backendSupportsFusionForBFloat16(backend) {
-		t.Skip("xla:cuda fused attention backend not available")
-	}
-	const B, S, H, D = 2, 64, 2, 64
-	scale := 1.0 / math.Sqrt(float64(D))
-	q := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 10), B, S, H, D)
-	k := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 11), B, S, H, D)
-	v := tensors.FromFlatDataAndDimensions(randFlat(B*S*H*D, 12), B, S, H, D)
-	bias := tensors.FromFlatDataAndDimensions(randFlat(B*H*S*S, 99), B, H, S, S)
-
-	run := func(name string, withBias, withGrad bool) {
-		t.Run(name, func(t *testing.T) {
-			store := model.NewStore()
-			exec := model.MustNewExec(backend, store, func(scope *model.Scope, qn, kn, vn, bn *Node) []*Node {
-				c := func(n *Node) *Node { return ConvertDType(n, dtypes.Float16) }
-				qc, kc, vc := c(qn), c(kn), c(vn)
-				opts := CoreOptions{Scale: scale}
-				if withBias {
-					opts.AttentionBias = c(bn)
-				}
-				out, _ := Core(qc, kc, vc, LayoutBSHD, opts)
-				outF32 := ConvertDType(out, dtypes.Float32)
-				if withGrad {
-					dq := ConvertDType(Gradient(ReduceAllSum(outF32), qc)[0], dtypes.Float32)
-					return []*Node{ReduceAllSum(dq)}
-				}
-				return []*Node{ReduceAllSum(outF32)}
-			})
-			_, g, err := exec.CallWithGraph(q, k, v, bias)
-			if err != nil {
-				t.Fatalf("COMPILE FAILED: %v", err)
+			if !tc.fwdOnly {
+				require.True(t, hasBwd, "fused bias must engage in backward for %s", tc.name)
+				require.LessOrEqual(t, float64(tensors.ToScalar[float32](out[1])), 0.06, "backward rel err (%s)", tc.name)
 			}
-			hasF, hasB := HasFusedSDPA(g)
-			t.Logf("OK: hasFwd=%v hasBwd=%v", hasF, hasB)
 		})
 	}
-	run("plain_f16_fwd", false, false)
-	run("plain_f16_fwdbwd", false, true)
-	run("bias_f16_fwd", true, false)
-	run("bias_f16_fwdbwd", true, true)
 }
 
 func abs32(x float32) float32 {

--- a/ml/layers/attention/multiheadattention.go
+++ b/ml/layers/attention/multiheadattention.go
@@ -81,6 +81,10 @@ type MultiHeadAttentionBuilder struct {
 	// threaded into the fused SDPA config for padding masking. Mutually exclusive with queryKeyMatrixMask.
 	querySeqLen    *Node
 	keyValueSeqLen *Node
+
+	// attentionBias is an optional additive attention-score bias [B,H,Sq,Skv] (ALiBi /
+	// relative-position). Distinct from UseProjectionBias. Threaded to CoreOptions.AttentionBias.
+	attentionBias *Node
 }
 
 // MultiHeadAttention defines a multi-head attention layers, as described in [1], plus some modern extensions.
@@ -366,6 +370,14 @@ func (b *MultiHeadAttentionBuilder) WithSeqLens(querySeqLen, keyValueSeqLen *Nod
 	return b
 }
 
+// WithAttentionBias supplies an additive attention-score bias [B,H,Sq,Skv] (ALiBi /
+// relative-position), threaded to CoreOptions.AttentionBias. It is DISTINCT from UseProjectionBias
+// (the Q/K/V dense bias). nil (the default) disables it.
+func (b *MultiHeadAttentionBuilder) WithAttentionBias(bias *Node) *MultiHeadAttentionBuilder {
+	b.attentionBias = bias
+	return b
+}
+
 // DoneWithCoefficients or Done should be called after all optional settings are configured.
 // It returns both the attention output and the attention coefficients (matrix) used.
 //
@@ -490,6 +502,7 @@ func (b *MultiHeadAttentionBuilder) doneInternal(wantCoefficients bool) (attenti
 		UseCausalMask: useCausalMask,
 		QuerySeqLen:   b.querySeqLen,
 		KVSeqLen:      b.keyValueSeqLen,
+		AttentionBias: b.attentionBias,
 
 		Scope:       b.scope,
 		DropoutRate: b.dropoutRate,


### PR DESCRIPTION
Stage 2 of the fused-attention work done with the AI help (Claude): additive attention bias through the layers. Cumulative on top of Stage 1 (#427), the prerequisite; the Stage 1 commits show here too until #427 merges to main, then this shrinks to the bias delta.

Adds `MultiHeadAttentionBuilder.WithAttentionBias(bias *Node)`, an additive attention-score bias in the heads-major [B,H,Sq,Skv] layout (ALiBi, relative-position), distinct from UseProjectionBias. Threaded into Core as a *Node: the fused closure builds it into the config so it fuses (cuDNN ScaleBias), the decomposed fallback transposes it to the score layout and adds it before softmax (reshaped for GQA), so fused and decomposed agree. The parity test has a probe guard so it fails rather than silently passing if the fused arm falls back.

Validated on an RTX 3070 Ti: the fused path actually runs the ScaleBias kernel and matches the decomposed reference for forward and dQ backward.