### PR TITLE
Description: Refactor Transformer API to use CallOptions and support dynamic seqLen

### DIFF
--- a/examples/gemma3/gemma3.go
+++ b/examples/gemma3/gemma3.go
@@ -17,12 +17,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"math"
-	"math/bits"
-	"math/rand/v2"
 	"os"
-	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -33,8 +28,10 @@ import (
 	"github.com/gomlx/go-huggingface/tokenizers"
 	"github.com/gomlx/go-huggingface/tokenizers/api"
 	. "github.com/gomlx/gomlx/core/graph"
-	"github.com/gomlx/gomlx/core/tensors"
+	"github.com/gomlx/gomlx/ml/layers/attention/kvcache"
 	"github.com/gomlx/gomlx/ml/model"
+	"github.com/gomlx/gomlx/ml/zoo/transformer/generate"
+	"github.com/gomlx/gomlx/ml/zoo/transformer/generate/sample"
 	"github.com/gomlx/onnx-gomlx/onnx"
 	onnxparser "github.com/gomlx/onnx-gomlx/onnx/parser"
 	"k8s.io/klog/v2"
@@ -57,6 +54,7 @@ var (
 	flagTopK        = flag.Int("top-k", 64, "Top-k sampling (0 = disabled).")
 	flagFP16        = flag.Bool("fp16", false, "Use fp16 (float16) model variant (570MB instead of 1.14GB).")
 	flagBackend     = flag.String("backend", "", "Backend to use (default: auto-detect).")
+	flagNaive       = flag.Bool("naive", false, "Use naive generation (re-runs the full prompt at each step) instead of KV cache.")
 )
 
 func main() {
@@ -105,13 +103,7 @@ func main() {
 	}
 	defer onnxModel.Close()
 
-	inputNames, inputShapes := onnxModel.Inputs()
-	outputNames, _ := onnxModel.Outputs()
-	fmt.Printf("Model inputs (%d):\n", len(inputNames))
-	for i, name := range inputNames {
-		fmt.Printf("  %s: %v\n", name, inputShapes[i])
-	}
-	fmt.Printf("Model outputs: %v\n\n", outputNames)
+	inputNames, _ := onnxModel.Inputs()
 
 	// Load model weights into model.
 	scope := model.NewStore().RootScope()
@@ -134,10 +126,6 @@ func main() {
 	hasPositionIDs := inputSet["position_ids"]
 	hasAttentionMask := inputSet["attention_mask"]
 
-	padID, err := tok.SpecialTokenID(api.TokPad)
-	if err != nil {
-		padID = 0
-	}
 	eosID, err := tok.SpecialTokenID(api.TokEndOfSentence)
 	if err != nil {
 		eosID = 1
@@ -149,87 +137,184 @@ func main() {
 	// Parse KV cache structure from model inputs/outputs.
 	kv := parseKVStructure(onnxModel)
 
-	if kv.hasOutputs() {
-		fmt.Printf("Using KV cache: %d layers, %d heads, dim=%d\n\n", kv.numLayers, kv.kvHeads, kv.headDim)
-		cacheSize := int(math.Log2(float64(maxSeqLen))) + 2
+	// Define NaiveModelFn using generate package's seqLen
+	var naiveModelFn generate.NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
+		g := tokens.Graph()
+		inputs := map[string]*Node{"input_ids": ConvertType(tokens, dtypes.Int64)}
 
-		prefillExec := model.MustNewExec(backend, scope.Store(),
-			func(scope *model.Scope, idNode, maskNode, posNode, seqLenNode *Node) []*Node {
-				return prefillKVCacheGraph(scope, onnxModel, kv, hasAttentionMask, hasPositionIDs,
-					idNode, maskNode, posNode, seqLenNode)
-			},
-		)
-		prefillExec.SetMaxCache(cacheSize)
-		defer prefillExec.Finalize()
-
-		decodeExec := model.MustNewExec(backend, scope.Store(),
-			func(scope *model.Scope, idNode, maskNode, posNode, concatKeysNode, concatValuesNode, kvInsertPosNode *Node) []*Node {
-				return decodeWithKVCacheGraph(scope, onnxModel, kv, hasAttentionMask, hasPositionIDs,
-					idNode, maskNode, posNode, concatKeysNode, concatValuesNode, kvInsertPosNode)
-			},
-		)
-		// Power-of-2 padding means O(log(maxSeqLen)) unique graph shapes.
-		decodeExec.SetMaxCache(cacheSize)
-		defer decodeExec.Finalize()
-
-		benchmarkMode := *flagPromptsFile != ""
-		warmupRounds := 0
-		if benchmarkMode {
-			warmupRounds = *flagWarmup
+		if hasAttentionMask {
+			// Create attention_mask from seqLen.
+			// seqLen has shape [batchSize]. We want mask shape [batchSize, totalSeqLen]
+			totalSeqLen := tokens.Shape().Dimensions[1]
+			iotaSeq := Iota(g, shapes.Make(dtypes.Int32, 1, totalSeqLen), 1)
+			seqLenCol := ExpandDims(seqLen, 1)
+			maskNode := Where(LessThan(iotaSeq, seqLenCol), Const(g, int32(1)), Const(g, int32(0)))
+			inputs["attention_mask"] = ConvertType(maskNode, dtypes.Int64)
 		}
-		totalRounds := warmupRounds + 1
-
-		for round := range totalRounds {
-			isWarmup := round < warmupRounds
-			if isWarmup {
-				fmt.Printf("=== Warmup round %d/%d ===\n", round+1, warmupRounds)
-			} else if benchmarkMode {
-				fmt.Println("=== Measurement round ===")
-			}
-
-			var totalTokens int
-			var totalDuration time.Duration
-
-			for _, prompt := range prompts {
-				promptTokens := tokenizePrompt(tok, formatChatPrompt(prompt))
-				if len(promptTokens) >= maxSeqLen {
-					fmt.Printf("Warning: prompt %q too long (%d tokens), skipping\n", prompt, len(promptTokens))
-					continue
-				}
-
-				verbose := !isWarmup
-				if verbose {
-					fmt.Printf("Prompt: %q\n", prompt)
-					fmt.Printf("Tokenized to %d tokens\n\n", len(promptTokens))
-					fmt.Println("Generating...")
-					fmt.Println("---")
-				}
-
-				n, dur := generateOne(backend, prefillExec, decodeExec, tok, promptTokens,
-					kv, padID, eosID, maxSeqLen, maxTokens, verbose)
-
-				if verbose {
-					fmt.Println("\n---")
-					if n > 0 {
-						tokensPerSec := float64(n) / dur.Seconds()
-						fmt.Printf("Generated %d tokens in %.2fs (%.1f tokens/s)\n\n", n, dur.Seconds(), tokensPerSec)
-					}
-				}
-
-				totalTokens += n
-				totalDuration += dur
-			}
-
-			if benchmarkMode && !isWarmup && totalTokens > 0 {
-				fmt.Printf("\nAverage: %.1f tokens/s (%d tokens in %.2fs)\n",
-					float64(totalTokens)/totalDuration.Seconds(), totalTokens, totalDuration.Seconds())
-			}
+		if hasPositionIDs {
+			// Position IDs is [batchSize, totalSeqLen]. We can just use Iota.
+			totalSeqLen := tokens.Shape().Dimensions[1]
+			batchSize := tokens.Shape().Dimensions[0]
+			iotaSeq := Iota(g, shapes.Make(dtypes.Int32, 1, totalSeqLen), 1)
+			seqLenCol := ExpandDims(seqLen, 1)
+			posNode := Where(LessThan(iotaSeq, seqLenCol), iotaSeq, ConstAs(iotaSeq, 0))
+			posNode = BroadcastToDims(posNode, batchSize, totalSeqLen)
+			inputs["position_ids"] = ConvertType(posNode, dtypes.Int64)
 		}
-	} else {
-		// Non-KV-cache fallback.
 		if kv.numLayers > 0 {
-			fmt.Printf("KV cache: %d past_key_values inputs will be provided as empty zeros\n", kv.numLayers*2)
+			batchSize := tokens.Shape().Dimensions[0]
+			for i := range kv.numLayers {
+				inputs[kv.inputKeyNames[i]] = Zeros(g, shapes.Make(kv.kvDType, batchSize, kv.kvHeads, 0, kv.headDim))
+				inputs[kv.inputValueNames[i]] = Zeros(g, shapes.Make(kv.kvDType, batchSize, kv.kvHeads, 0, kv.headDim))
+			}
 		}
+
+		outputs := onnxModel.CallGraph(scope, g, inputs)
+		logits := outputs[kv.logitsIndex]
+		return logits
+	}
+
+	// Define KVCacheModelFn
+	var cacheModelFn generate.KVCacheModelFn = func(scope *model.Scope, newTokens *Node, position *Node, cache kvcache.KVCacheNodes) (*Node, kvcache.KVCacheNodes) {
+		g := newTokens.Graph()
+		batchSize := newTokens.Shape().Dimensions[0]
+		inputs := map[string]*Node{"input_ids": ConvertType(newTokens, dtypes.Int64)}
+
+		// 1. Set past key/value cache inputs from the cache map.
+		for i := range kv.numLayers {
+			layerScopePath := fmt.Sprintf("/layer_%d", i)
+			inputs[kv.inputKeyNames[i]] = cache[layerScopePath+kvcache.KeySuffix]
+			inputs[kv.inputValueNames[i]] = cache[layerScopePath+kvcache.ValueSuffix]
+		}
+
+		// 2. Create the attention mask of shape [batchSize, cacheSeqLen + newSeqLen].
+		cacheSeqLen := inputs[kv.inputKeyNames[0]].Shape().Dimensions[2]
+		newSeqLen := newTokens.Shape().Dimensions[1]
+		totalSeqLen := cacheSeqLen + newSeqLen
+		iotaSeq := Iota(g, shapes.Make(dtypes.Int32, 1, totalSeqLen), 1)
+		posCol := Reshape(position, 1, 1)
+		posCol = BroadcastToDims(posCol, batchSize, 1)
+
+		isPast := LessThan(iotaSeq, Const(g, int32(cacheSeqLen)))
+		isValidPast := And(isPast, LessThan(iotaSeq, posCol))
+		isNew := LessOrEqual(Const(g, int32(cacheSeqLen)), iotaSeq)
+
+		maskNode := Or(isValidPast, isNew)
+		maskNode = Where(maskNode, Const(g, int32(1)), Const(g, int32(0)))
+		inputs["attention_mask"] = ConvertType(maskNode, dtypes.Int64)
+
+		if hasPositionIDs {
+			iotaNew := Iota(g, shapes.Make(dtypes.Int32, 1, newSeqLen), 1)
+			posNode := Add(posCol, iotaNew)
+			inputs["position_ids"] = ConvertType(posNode, dtypes.Int64)
+		}
+
+		// 3. Call the ONNX model
+		allOutputs := onnxModel.CallGraph(scope, g, inputs)
+		logits := allOutputs[kv.logitsIndex]
+
+		// 4. Update the KV Cache
+		updatedCache := make(kvcache.KVCacheNodes)
+		for k, v := range cache {
+			updatedCache[k] = v
+		}
+
+		batchIdx := Const(g, int32(0))
+		headsIdx := Const(g, int32(0))
+		dimIdx := Const(g, int32(0))
+
+		for i := range kv.numLayers {
+			presentKeys := allOutputs[kv.outputKeyIndices[i]]
+			presentValues := allOutputs[kv.outputValueIndices[i]]
+
+			sliceDims := []int{batchSize, kv.kvHeads, newSeqLen, kv.headDim}
+			newKey := DynamicSlice(presentKeys, []*Node{
+				Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(cacheSeqLen)), Const(g, int32(0)),
+			}, sliceDims)
+			newValue := DynamicSlice(presentValues, []*Node{
+				Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(cacheSeqLen)), Const(g, int32(0)),
+			}, sliceDims)
+
+			layerScopePath := fmt.Sprintf("/layer_%d", i)
+			kKey := layerScopePath + kvcache.KeySuffix
+			vKey := layerScopePath + kvcache.ValueSuffix
+			prevK := updatedCache[kKey]
+			prevV := updatedCache[vKey]
+
+			updatedK := prevK
+			updatedV := prevV
+			for stepIdx := 0; stepIdx < newSeqLen; stepIdx++ {
+				writePos := AddScalar(position, stepIdx)
+				tokenK := Slice(newKey, AxisRange(), AxisRange(), AxisRange(stepIdx, stepIdx+1), AxisRange())
+				tokenV := Slice(newValue, AxisRange(), AxisRange(), AxisRange(stepIdx, stepIdx+1), AxisRange())
+
+				updatedK = DynamicUpdateSlice(updatedK, tokenK, []*Node{batchIdx, headsIdx, writePos, dimIdx})
+				updatedV = DynamicUpdateSlice(updatedV, tokenV, []*Node{batchIdx, headsIdx, writePos, dimIdx})
+			}
+
+			updatedCache[kKey] = updatedK
+			updatedCache[vKey] = updatedV
+		}
+
+		return logits, updatedCache
+	}
+
+	// Setup KVCache if needed
+	var kvCache *kvcache.KVCache
+	if !*flagNaive && kv.hasOutputs() {
+		kvCache = kvcache.NewKVCache().
+			WithSinkPositions(0).
+			WithMaxSeqLenPerLayerType([]int{maxSeqLen, maxSeqLen}).
+			WithMinSeqLenPerLayerType([]int{32, 32})
+
+		scopes := make([]string, kv.numLayers)
+		for i := range kv.numLayers {
+			scopes[i] = fmt.Sprintf("/layer_%d", i)
+		}
+		kvCache.WithOrderedScopes(scopes)
+	}
+
+	var decoder *generate.Generator
+	if *flagNaive || kvCache == nil {
+		fmt.Printf("Using Naive generation (without KV cache)\n\n")
+		decoder = generate.New(naiveModelFn).FromScope(scope)
+	} else {
+		fmt.Printf("Using KV cache: %d layers, %d heads, dim=%d\n\n", kv.numLayers, kv.kvHeads, kv.headDim)
+		decoder = generate.New(cacheModelFn).FromScope(scope)
+		decoder.WithKVCache(kvCache, kv.kvHeads, kv.headDim, kv.kvDType)
+	}
+
+	if *flagTemp > 0 {
+		decoder.WithStrategy(sample.StrategyTemperature).WithTemperature(float32(*flagTemp))
+	} else {
+		decoder.WithStrategy(sample.StrategyGreedy)
+	}
+	if *flagTopK > 0 {
+		decoder.WithTopK(*flagTopK)
+	}
+	decoder.WithEOS(eosID)
+	encodedEOT := tok.Encode("<end_of_turn>")
+	if len(encodedEOT) > 0 {
+		decoder.WithStopTokens(encodedEOT[len(encodedEOT)-1])
+	}
+
+	benchmarkMode := *flagPromptsFile != ""
+	warmupRounds := 0
+	if benchmarkMode {
+		warmupRounds = *flagWarmup
+	}
+	totalRounds := warmupRounds + 1
+
+	for round := range totalRounds {
+		isWarmup := round < warmupRounds
+		if isWarmup {
+			fmt.Printf("=== Warmup round %d/%d ===\n", round+1, warmupRounds)
+		} else if benchmarkMode {
+			fmt.Println("=== Measurement round ===")
+		}
+
+		var totalTokens int
+		var totalDuration time.Duration
 
 		for _, prompt := range prompts {
 			promptTokens := tokenizePrompt(tok, formatChatPrompt(prompt))
@@ -238,19 +323,49 @@ func main() {
 				continue
 			}
 
-			fmt.Printf("Prompt: %q\n", prompt)
-			fmt.Printf("Tokenized to %d tokens\n\n", len(promptTokens))
-			fmt.Println("Generating...")
-			fmt.Println("---")
-			startTime := time.Now()
-			n := generateWithoutKVCache(backend, scope, onnxModel, tok, promptTokens,
-				padID, eosID, maxSeqLen, maxTokens, hasAttentionMask, hasPositionIDs, kv)
-			duration := time.Since(startTime)
-			fmt.Println("\n---")
-			if n > 0 {
-				tokensPerSec := float64(n) / duration.Seconds()
-				fmt.Printf("Generated %d tokens in %.2fs (%.1f tokens/s)\n\n", n, duration.Seconds(), tokensPerSec)
+			verbose := !isWarmup
+			if verbose {
+				fmt.Printf("Prompt: %q\n", prompt)
+				fmt.Printf("Tokenized to %d tokens\n\n", len(promptTokens))
+				fmt.Println("Generating...")
+				fmt.Println("---")
 			}
+
+			// Adjust max length dynamically for this prompt
+			promptLen := len(promptTokens)
+			decoder.WithMaxLength(min(promptLen+maxTokens, maxSeqLen))
+
+			var n int
+			startTime := time.Now()
+			err := decoder.GenerateStreaming(backend, scope, promptTokens, func(token int) bool {
+				if verbose {
+					tokenText := tok.Decode([]int{token})
+					fmt.Print(tokenText)
+					_ = os.Stdout.Sync()
+				}
+				n++
+				return true
+			})
+			if err != nil {
+				klog.Fatalf("Generation failed: %+v", err)
+			}
+			dur := time.Since(startTime)
+
+			if verbose {
+				fmt.Println("\n---")
+				if n > 0 {
+					tokensPerSec := float64(n) / dur.Seconds()
+					fmt.Printf("Generated %d tokens in %.2fs (%.1f tokens/s)\n\n", n, dur.Seconds(), tokensPerSec)
+				}
+			}
+
+			totalTokens += n
+			totalDuration += dur
+		}
+
+		if benchmarkMode && !isWarmup && totalTokens > 0 {
+			fmt.Printf("\nAverage: %.1f tokens/s (%d tokens in %.2fs)\n",
+				float64(totalTokens)/totalDuration.Seconds(), totalTokens, totalDuration.Seconds())
 		}
 	}
 }
@@ -304,42 +419,12 @@ func tokenizePrompt(tok api.Tokenizer, prompt string) []int32 {
 	return tokens
 }
 
-// nextPow2 returns the next power of 2 >= n.
-func nextPow2(n int) int {
-	if n <= 0 {
-		return 1
-	}
-	return 1 << (bits.UintSize - bits.LeadingZeros(uint(n-1)))
-}
-
-// padSequence pads token IDs to targetLen and returns input_ids, attention_mask, and position_ids
-// as flat []int64 slices suitable for execution.
-func padSequence(tokens []int32, padID int32, targetLen int) (inputIDs []int64, attentionMask []int64, positionIDs []int64) {
-	ids := make([]int64, targetLen)
-	mask := make([]int64, targetLen)
-	pos := make([]int64, targetLen)
-
-	for i := range targetLen {
-		if i < len(tokens) {
-			ids[i] = int64(tokens[i])
-			mask[i] = 1
-			pos[i] = int64(i)
-		} else {
-			ids[i] = int64(padID)
-			mask[i] = 0
-			pos[i] = 0
-		}
-	}
-	return ids, mask, pos
-}
-
 // kvStructure holds the KV cache layout parsed from the ONNX model.
 type kvStructure struct {
 	numLayers       int
 	inputKeyNames   []string // past_key_values.{i}.key, ordered by layer
 	inputValueNames []string // past_key_values.{i}.value, ordered by layer
 	// outputKeyIndices are indices into the model's output list for the present key tensors.
-	// The model returns present KV (past KV concatenated with the newly computed token's KV).
 	outputKeyIndices []int
 	// outputValueIndices are indices into the model's output list for the present value tensors.
 	outputValueIndices []int
@@ -354,28 +439,6 @@ func (kv *kvStructure) hasOutputs() bool {
 	return kv.numLayers > 0 && len(kv.outputKeyIndices) == kv.numLayers
 }
 
-// extractOutputs collects per-layer KV outputs from the model and concatenates them
-// across layers into [numLayers, 1, kvHeads, seqLen, headDim] tensors.
-// Each layer's output contains the past concatenated KV (the full KV history for that layer),
-// and we stack them along a new leading axis so all layers can be carried as a single tensor.
-func (kv *kvStructure) extractOutputs(allOutputs []*Node) (concatKeys, concatValues *Node) {
-	keys := make([]*Node, kv.numLayers)
-	values := make([]*Node, kv.numLayers)
-	for i := range kv.numLayers {
-		keys[i] = InsertAxes(allOutputs[kv.outputKeyIndices[i]], 0)
-		values[i] = InsertAxes(allOutputs[kv.outputValueIndices[i]], 0)
-	}
-	return Concatenate(keys, 0), Concatenate(values, 0)
-}
-
-// setInputs splits concatenated KV and feeds per-layer inputs into the model input map.
-func (kv *kvStructure) setInputs(inputs map[string]*Node, concatKeys, concatValues *Node) {
-	for i := range kv.numLayers {
-		inputs[kv.inputKeyNames[i]] = Squeeze(Slice(concatKeys, AxisElem(i)), 0)
-		inputs[kv.inputValueNames[i]] = Squeeze(Slice(concatValues, AxisElem(i)), 0)
-	}
-}
-
 // parseKVStructure inspects the ONNX model's inputs and outputs to identify
 // the KV cache layout: layer count, input/output names, and shapes.
 func parseKVStructure(onnxModel onnx.Model) *kvStructure {
@@ -384,9 +447,6 @@ func parseKVStructure(onnxModel onnx.Model) *kvStructure {
 
 	kv := &kvStructure{logitsIndex: 0} // default logits at index 0
 
-	// Find KV input names and shapes.
-	// Note: fmt.Sscanf returns n=1 once the integer is parsed, even if the trailing
-	// literal doesn't match. We reconstruct and compare to ensure an exact match.
 	layerKeys := make(map[int]string)
 	layerValues := make(map[int]string)
 	for i, name := range inputNames {
@@ -408,7 +468,6 @@ func parseKVStructure(onnxModel onnx.Model) *kvStructure {
 		return kv
 	}
 
-	// Build ordered lists of KV input names.
 	kv.inputKeyNames = make([]string, kv.numLayers)
 	kv.inputValueNames = make([]string, kv.numLayers)
 	for i := range kv.numLayers {
@@ -416,7 +475,6 @@ func parseKVStructure(onnxModel onnx.Model) *kvStructure {
 		kv.inputValueNames[i] = layerValues[i]
 	}
 
-	// Find KV output indices and logits index.
 	kv.outputKeyIndices = make([]int, kv.numLayers)
 	kv.outputValueIndices = make([]int, kv.numLayers)
 	foundKeys := 0
@@ -426,7 +484,6 @@ func parseKVStructure(onnxModel onnx.Model) *kvStructure {
 			kv.logitsIndex = i
 		}
 		var layerIdx int
-		// Try "present.{i}.key" pattern (HuggingFace Optimum).
 		if n, _ := fmt.Sscanf(name, "present.%d.key", &layerIdx); n == 1 && name == fmt.Sprintf("present.%d.key", layerIdx) && layerIdx < kv.numLayers {
 			kv.outputKeyIndices[layerIdx] = i
 			foundKeys++
@@ -435,7 +492,6 @@ func parseKVStructure(onnxModel onnx.Model) *kvStructure {
 			kv.outputValueIndices[layerIdx] = i
 			foundValues++
 		}
-		// Try "present_key_values.{i}.key" pattern.
 		if n, _ := fmt.Sscanf(name, "present_key_values.%d.key", &layerIdx); n == 1 && name == fmt.Sprintf("present_key_values.%d.key", layerIdx) && layerIdx < kv.numLayers {
 			kv.outputKeyIndices[layerIdx] = i
 			foundKeys++
@@ -447,370 +503,9 @@ func parseKVStructure(onnxModel onnx.Model) *kvStructure {
 	}
 
 	if foundKeys != kv.numLayers || foundValues != kv.numLayers {
-		// Model has KV inputs but not matching outputs; can't use KV cache.
 		kv.outputKeyIndices = nil
 		kv.outputValueIndices = nil
 	}
 
 	return kv
-}
-
-// prefillKVCacheGraph builds the computation graph for the prefill step.
-// It takes the full prompt tokens (padded to power-of-2), runs them through the model
-// with empty KV caches, and returns:
-//   - lastLogits [vocabSize]: logits for the last real token position, used to sample the first generated token.
-//   - concatKeys [numLayers, 1, kvHeads, seqLen, headDim]: per-layer key caches concatenated across layers.
-//   - concatValues [numLayers, 1, kvHeads, seqLen, headDim]: per-layer value caches concatenated across layers.
-//
-// The returned KV caches initialize the decode loop. The attention mask must mark
-// which positions are real tokens vs padding so the model attends only to valid positions.
-func prefillKVCacheGraph(
-	scope *model.Scope, onnxModel onnx.Model, kv *kvStructure,
-	hasAttentionMask, hasPositionIDs bool,
-	idNode, maskNode, posNode, seqLenNode *Node,
-) []*Node {
-	g := idNode.Graph()
-	inputs := map[string]*Node{"input_ids": idNode}
-	if hasAttentionMask {
-		inputs["attention_mask"] = maskNode
-	}
-	if hasPositionIDs {
-		inputs["position_ids"] = posNode
-	}
-	for i := range kv.numLayers {
-		inputs[kv.inputKeyNames[i]] = Zeros(g, shapes.Make(kv.kvDType, 1, kv.kvHeads, 0, kv.headDim))
-		inputs[kv.inputValueNames[i]] = Zeros(g, shapes.Make(kv.kvDType, 1, kv.kvHeads, 0, kv.headDim))
-	}
-
-	allOutputs := onnxModel.CallGraph(scope, g, inputs)
-
-	// Extract last-token logits: [1, seqLen, vocabSize] -> [vocabSize]
-	logits := allOutputs[kv.logitsIndex]
-	lastPos := SubScalar(seqLenNode, int32(1))
-	vocabSize := logits.Shape().Dimensions[2]
-	lastLogits := DynamicSlice(logits, []*Node{
-		Const(g, int32(0)), lastPos, Const(g, int32(0)),
-	}, []int{1, 1, vocabSize})
-	lastLogits = Reshape(lastLogits, vocabSize)
-
-	concatKeys, concatValues := kv.extractOutputs(allOutputs)
-	return []*Node{lastLogits, concatKeys, concatValues}
-}
-
-// decodeWithKVCacheGraph builds the computation graph for a single decode step.
-// It takes one new token and the accumulated KV cache, runs the model, extracts the
-// newly computed KV entry, and inserts it into the padded cache buffer at kvInsertPos.
-//
-// The attention mask is obligatory: it tells the model which columns of the KV cache
-// contain valid past tokens (masking out unused padding slots).
-//
-// Returns:
-//   - lastLogits [vocabSize]: logits for the new token.
-//   - updatedKeys [numLayers, 1, kvHeads, paddedSize, headDim]: cache with the new key inserted.
-//   - updatedValues [numLayers, 1, kvHeads, paddedSize, headDim]: cache with the new value inserted.
-func decodeWithKVCacheGraph(
-	scope *model.Scope, onnxModel onnx.Model, kv *kvStructure,
-	hasAttentionMask, hasPositionIDs bool,
-	idNode, maskNode, posNode, concatKeysNode, concatValuesNode, kvInsertPosNode *Node,
-) []*Node {
-	g := idNode.Graph()
-	inputs := map[string]*Node{"input_ids": idNode}
-	inputs["attention_mask"] = maskNode
-	if hasPositionIDs {
-		inputs["position_ids"] = posNode
-	}
-	kv.setInputs(inputs, concatKeysNode, concatValuesNode)
-
-	allOutputs := onnxModel.CallGraph(scope, g, inputs)
-
-	// Logits for the single new token: [1, 1, vocabSize] -> [vocabSize]
-	logits := allOutputs[kv.logitsIndex]
-	vocabSize := logits.Shape().Dimensions[2]
-	lastLogits := Reshape(logits, vocabSize)
-
-	presentKeys, presentValues := kv.extractOutputs(allOutputs)
-	// presentKeys shape: [numLayers, 1, kvHeads, P+1, headDim] where P = paddedSize.
-	// The model appends the new token's KV at position P (after the padded past cache).
-	paddedSize := concatKeysNode.Shape().Dimensions[3]
-	sliceDims := []int{kv.numLayers, 1, kv.kvHeads, 1, kv.headDim}
-	newKeys := DynamicSlice(presentKeys, []*Node{
-		Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(0)),
-		Const(g, int32(paddedSize)), Const(g, int32(0)),
-	}, sliceDims)
-	newValues := DynamicSlice(presentValues, []*Node{
-		Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(0)),
-		Const(g, int32(paddedSize)), Const(g, int32(0)),
-	}, sliceDims)
-
-	// Insert new KV at kvInsertPos in the padded buffer.
-	updatedKeys := DynamicUpdateSlice(concatKeysNode, newKeys, []*Node{
-		Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(0)),
-		kvInsertPosNode, Const(g, int32(0)),
-	})
-	updatedValues := DynamicUpdateSlice(concatValuesNode, newValues, []*Node{
-		Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(0)),
-		kvInsertPosNode, Const(g, int32(0)),
-	})
-
-	return []*Node{lastLogits, updatedKeys, updatedValues}
-}
-
-// generateOne runs a single prompt through prefill and decode with KV cache,
-// returning the number of tokens generated and the wall-clock duration.
-func generateOne(
-	backend compute.Backend,
-	prefillExec *model.Exec,
-	decodeExec *model.Exec,
-	tok api.Tokenizer,
-	promptTokens []int32,
-	kv *kvStructure,
-	padID, eosID, maxSeqLen, maxTokens int,
-	verbose bool,
-) (int, time.Duration) {
-	startTime := time.Now()
-	seqLen := len(promptTokens)
-	paddedLen := nextPow2(seqLen)
-
-	// Pad prompt and run prefill.
-	ids, mask, pos := padSequence(promptTokens, int32(padID), paddedLen)
-	prefillResults := prefillExec.MustCall(
-		[][]int64{ids}, [][]int64{mask}, [][]int64{pos}, int32(seqLen),
-	)
-
-	logitsTensor := prefillResults[0]
-	kvKeys := prefillResults[1]   // [numLayers, 1, kvHeads, paddedLen, headDim]
-	kvValues := prefillResults[2] // [numLayers, 1, kvHeads, paddedLen, headDim]
-
-	// Sample first token from prefill logits.
-	logits := tensors.MustCopyFlatData[float32](logitsTensor)
-	nextToken := sampleToken(logits, *flagTemp, *flagTopK)
-	tokenText := tok.Decode([]int{int(nextToken)})
-	if int(nextToken) == eosID || tokenText == "<end_of_turn>" {
-		return 0, time.Since(startTime)
-	}
-	if verbose {
-		fmt.Print(tokenText)
-	}
-	tokensGenerated := 1
-
-	// Decode loop with power-of-2 KV cache padding.
-	// The padded buffer stays at a fixed power-of-2 size, so the decode graph
-	// only needs to be recompiled when crossing a power-of-2 boundary.
-	realKVLen := seqLen
-	paddedSize := paddedLen
-
-	for range maxTokens - 1 {
-		if realKVLen+1 >= maxSeqLen {
-			if verbose {
-				fmt.Printf("\n(reached max sequence length %d)", maxSeqLen)
-			}
-			break
-		}
-
-		// Grow buffer if the next insertion would exceed current padded size.
-		if realKVLen >= paddedSize {
-			paddedSize = nextPow2(realKVLen + 1)
-			kvKeys = growKVBuffer(backend, kvKeys, paddedSize)
-			kvValues = growKVBuffer(backend, kvValues, paddedSize)
-		}
-
-		// Build attention mask: paddedSize+1 positions (padded past + new token).
-		decodeMask := make([]int64, paddedSize+1)
-		for i := 0; i < realKVLen; i++ {
-			decodeMask[i] = 1
-		}
-		decodeMask[paddedSize] = 1 // new token position
-
-		results := decodeExec.MustCall(
-			[][]int64{{int64(nextToken)}},
-			[][]int64{decodeMask},
-			[][]int64{{int64(realKVLen)}},
-			kvKeys,
-			kvValues,
-			int32(realKVLen), // kvInsertPos
-		)
-
-		logitsTensor = results[0]
-		kvKeys = results[1]
-		kvValues = results[2]
-		realKVLen++
-
-		logits = tensors.MustCopyFlatData[float32](logitsTensor)
-		nextToken = sampleToken(logits, *flagTemp, *flagTopK)
-		tokenText = tok.Decode([]int{int(nextToken)})
-		if int(nextToken) == eosID || tokenText == "<end_of_turn>" {
-			break
-		}
-		if verbose {
-			fmt.Print(tokenText)
-		}
-		tokensGenerated++
-	}
-
-	return tokensGenerated, time.Since(startTime)
-}
-
-// growKVBuffer creates a new padded KV buffer by zero-padding along the sequence dimension.
-func growKVBuffer(backend compute.Backend, kv *tensors.Tensor, targetSeqLen int) *tensors.Tensor {
-	oldShape := kv.Shape()
-	if oldShape.Dimensions[3] >= targetSeqLen {
-		return kv
-	}
-	newShape := shapes.Make(oldShape.DType,
-		oldShape.Dimensions[0], oldShape.Dimensions[1],
-		oldShape.Dimensions[2], targetSeqLen, oldShape.Dimensions[4])
-	zeroTarget := tensors.FromShape(newShape)
-	return model.MustCallOnce(backend, nil,
-		func(_ *model.Scope, target, old *Node) *Node {
-			g := old.Graph()
-			return DynamicUpdateSlice(target, old, []*Node{
-				Const(g, int32(0)), Const(g, int32(0)), Const(g, int32(0)),
-				Const(g, int32(0)), Const(g, int32(0)),
-			})
-		},
-		zeroTarget, kv,
-	)
-}
-
-// generateWithoutKVCache runs generation without KV cache: each step processes
-// the full sequence with power-of-2 padding. A persistent Exec is created
-// outside the loop to enable compilation caching across steps.
-func generateWithoutKVCache(
-	backend compute.Backend, scope *model.Scope, onnxModel onnx.Model, tok api.Tokenizer,
-	promptTokens []int32,
-	padID, eosID, maxSeqLen, maxTokens int, hasAttentionMask, hasPositionIDs bool,
-	kv *kvStructure,
-) int {
-	// Create the Exec outside the loop. The seqLen parameter is passed dynamically
-	// so the same compiled graph works for different sequence lengths within the
-	// same power-of-2 padded shape.
-	genExec := model.MustNewExec(backend, scope.Store(),
-		func(scope *model.Scope, idNode, maskNode, posNode, seqLenNode *Node) *Node {
-			g := idNode.Graph()
-			inputs := map[string]*Node{"input_ids": idNode}
-			if hasAttentionMask {
-				inputs["attention_mask"] = maskNode
-			}
-			if hasPositionIDs {
-				inputs["position_ids"] = posNode
-			}
-			if kv.numLayers > 0 {
-				for i := range kv.numLayers {
-					inputs[kv.inputKeyNames[i]] = Zeros(g, shapes.Make(kv.kvDType, 1, kv.kvHeads, 0, kv.headDim))
-					inputs[kv.inputValueNames[i]] = Zeros(g, shapes.Make(kv.kvDType, 1, kv.kvHeads, 0, kv.headDim))
-				}
-			}
-
-			outputs := onnxModel.CallGraph(scope, g, inputs)
-			logits := outputs[0]
-
-			// Extract logits at the last real token position.
-			lastPos := SubScalar(seqLenNode, int32(1))
-			vocabSize := logits.Shape().Dimensions[2]
-			lastLogits := DynamicSlice(logits, []*Node{
-				Const(g, int32(0)), lastPos, Const(g, int32(0)),
-			}, []int{1, 1, vocabSize})
-			lastLogits = Reshape(lastLogits, vocabSize)
-			return lastLogits
-		},
-	)
-	defer genExec.Finalize()
-
-	tokens := slices.Clone(promptTokens)
-	tokensGenerated := 0
-
-	for range maxTokens {
-		seqLen := len(tokens)
-		if seqLen >= maxSeqLen {
-			fmt.Printf("\n(reached max sequence length %d)", maxSeqLen)
-			break
-		}
-
-		targetLen := min(nextPow2(seqLen), maxSeqLen)
-		ids, mask, pos := padSequence(tokens, int32(padID), targetLen)
-
-		output := genExec.MustCall1([][]int64{ids}, [][]int64{mask}, [][]int64{pos}, int32(seqLen))
-
-		logits := tensors.MustCopyFlatData[float32](output)
-		nextToken := sampleToken(logits, *flagTemp, *flagTopK)
-		tokenText := tok.Decode([]int{int(nextToken)})
-		if int(nextToken) == eosID || tokenText == "<end_of_turn>" {
-			break
-		}
-		fmt.Print(tokenText)
-		tokens = append(tokens, nextToken)
-		tokensGenerated++
-	}
-
-	return tokensGenerated
-}
-
-// sampleToken performs CPU-side sampling from logits with temperature scaling and optional top-k filtering.
-func sampleToken(logits []float32, temperature float64, topK int) int32 {
-	if temperature <= 0 {
-		// Greedy: return argmax.
-		maxIdx := 0
-		maxVal := logits[0]
-		for i, v := range logits[1:] {
-			if v > maxVal {
-				maxVal = v
-				maxIdx = i + 1
-			}
-		}
-		return int32(maxIdx)
-	}
-
-	// Apply temperature.
-	scaled := make([]float64, len(logits))
-	for i, v := range logits {
-		scaled[i] = float64(v) / temperature
-	}
-
-	// Top-k filtering.
-	if topK > 0 && topK < len(scaled) {
-		type indexedLogit struct {
-			index int
-			value float64
-		}
-		indexed := make([]indexedLogit, len(scaled))
-		for i, v := range scaled {
-			indexed[i] = indexedLogit{i, v}
-		}
-		sort.Slice(indexed, func(i, j int) bool {
-			return indexed[i].value > indexed[j].value
-		})
-		threshold := indexed[topK-1].value
-		for i := range scaled {
-			if scaled[i] < threshold {
-				scaled[i] = math.Inf(-1)
-			}
-		}
-	}
-
-	// Softmax.
-	maxVal := scaled[0]
-	for _, v := range scaled[1:] {
-		if v > maxVal {
-			maxVal = v
-		}
-	}
-	var sum float64
-	for i := range scaled {
-		scaled[i] = math.Exp(scaled[i] - maxVal)
-		sum += scaled[i]
-	}
-	for i := range scaled {
-		scaled[i] /= sum
-	}
-
-	// Categorical sample.
-	r := rand.Float64()
-	var cumulative float64
-	for i, p := range scaled {
-		cumulative += p
-		if r < cumulative {
-			return int32(i)
-		}
-	}
-	return int32(len(scaled) - 1)
 }

--- a/examples/gpt2/model.go
+++ b/examples/gpt2/model.go
@@ -167,13 +167,12 @@ func LoadGPT2(backend compute.Backend, repo *hub.Repo) (*GPT2Model, api.Tokenize
 	posEmbedder := pos.NewLearned(scope, config.MaxPosEmbed, config.HiddenSize)
 
 	// Build the transformer model and wrap it in our GPT2Model.
-	transformerModel := transformer.New(
-		config.VocabSize,
-		config.HiddenSize,
-		config.NumLayers,
-		config.NumHeads,
-		config.HiddenSize/config.NumHeads, // head_dim
-	).
+	transformerModel := transformer.New(scope).
+		WithVocabSize(config.VocabSize).
+		WithEmbedDim(config.HiddenSize).
+		WithNumLayers(config.NumLayers).
+		WithNumHeads(config.NumHeads).
+		WithHeadDim(config.HiddenSize/config.NumHeads).
 		WithFFNDim(config.HiddenSize * 4). // GPT-2 uses 4x expansion
 		WithMaxPosEmbed(config.MaxPosEmbed).
 		WithDType(config.DType).

--- a/examples/textgen/main.go
+++ b/examples/textgen/main.go
@@ -151,10 +151,10 @@ func trainModel(backend compute.Backend, scope *model.Scope) {
 	// Simple model function wrapper
 	modelFn := func(scope *model.Scope, _ any, inputs []*graph.Node) []*graph.Node {
 		tokens := inputs[0]
-		transformerModel := transformer.NewFromScope(scope)
+		transformerModel := transformer.New(scope)
 		posEmbeder := pos.NewLearned(scope, transformerModel.MaxPosEmbed, transformerModel.EmbedDim)
 		transformerModel.WithPositionalEncoder(posEmbeder)
-		return []*graph.Node{transformerModel.Logits(scope, tokens, nil)}
+		return []*graph.Node{transformerModel.Logits(tokens, transformer.CallOptions{})}
 	}
 
 	trainer := train.NewTrainer(backend, scope.Store(), modelFn,
@@ -194,9 +194,9 @@ func generateText(backend compute.Backend, scope *model.Scope, prompt string) {
 		promptTokens = []int{32}
 	}
 
-	transformerModel := transformer.NewFromScope(scope)
+	transformerModel := transformer.New(scope)
 	modelFn := transformer.MakeKVCacheModelFn(transformerModel)
-	transformerModel.PopulateKVCacheConfigs(scope)
+	transformerModel.PopulateKVCacheConfigs()
 
 	decoder := generate.New(modelFn).FromScope(scope)
 	numKVHeads := transformerModel.NumKVHeads

--- a/ml/layers/attention/attention.go
+++ b/ml/layers/attention/attention.go
@@ -3,8 +3,10 @@
 package attention
 
 import (
+	"fmt"
 	"math"
 	"slices"
+	"strings"
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
@@ -198,6 +200,42 @@ type CoreOptions struct {
 	DisableFusion bool
 }
 
+// String returns a representation of non-zero fields of CoreOptions.
+func (o CoreOptions) String() string {
+	var parts []string
+	if o.Scale != 0 {
+		parts = append(parts, fmt.Sprintf("Scale: %g", o.Scale))
+	}
+	if o.AttentionMask != nil {
+		parts = append(parts, fmt.Sprintf("AttentionMask: %s", o.AttentionMask.Shape()))
+	}
+	if o.UseCausalMask {
+		parts = append(parts, "UseCausalMask: true")
+	}
+	if o.QuerySeqLen != nil {
+		parts = append(parts, fmt.Sprintf("QuerySeqLen: %s", o.QuerySeqLen.Shape()))
+	}
+	if o.KVSeqLen != nil {
+		parts = append(parts, fmt.Sprintf("KVSeqLen: %s", o.KVSeqLen.Shape()))
+	}
+	if o.WantCoefficients {
+		parts = append(parts, "WantCoefficients: true")
+	}
+	if o.ScoreSoftCap != 0 {
+		parts = append(parts, fmt.Sprintf("ScoreSoftCap: %g", o.ScoreSoftCap))
+	}
+	if o.Scope != nil {
+		parts = append(parts, fmt.Sprintf("Scope: %s", o.Scope.Scope()))
+	}
+	if o.DropoutRate != nil {
+		parts = append(parts, fmt.Sprintf("DropoutRate: %s", o.DropoutRate.Shape()))
+	}
+	if o.DisableFusion {
+		parts = append(parts, "DisableFusion: true")
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
 // Core computes the core scaled dot-product attention operation.
 // This is the shared implementation used by MultiHeadAttention and ONNX op converters.
 //
@@ -246,10 +284,8 @@ func Core(query, key, value *Node, layout AxesLayout, options CoreOptions) (outp
 		if options.Scope != nil {
 			scopePath = options.Scope.Scope()
 		}
-		klog.Infof("attention.Core(scope=%s, query=%s, key=%s, value=%s, scale=%f, attentionMask=%v, dropoutRate=%v, "+
-			"layout=%+v, useCausalMask=%v, wantCoefficients=%v, scoreSoftCap=%f)",
-			scopePath, query.Shape(), key.Shape(), value.Shape(), scale, options.AttentionMask != nil, options.DropoutRate != nil,
-			layout, options.UseCausalMask, options.WantCoefficients, options.ScoreSoftCap)
+		klog.Infof("attention.Core(scope=%s, query=%s, key=%s, value=%s, layout=%s, options=%s)",
+			scopePath, query.Shape(), key.Shape(), value.Shape(), layout, options)
 	}
 
 	// Function to compute the attention "decomposed" (as in not-fused).
@@ -334,6 +370,7 @@ func Core(query, key, value *Node, layout AxesLayout, options CoreOptions) (outp
 	hasFused := capabilities.Operations[compute.OpTypeFusedScaledDotProductAttention]
 	hasFusedVJP := capabilities.Operations[compute.OpTypeFusedScaledDotProductAttentionVJP]
 	if options.WantCoefficients || dropoutActive || options.ScoreSoftCap > 0 || options.DisableFusion || !hasFused {
+		klog.V(2).Info("attention.Core(): forced decomposed version.")
 		output, coefficients = decomposedFn()
 	} else {
 		// Attempt fused version:

--- a/ml/model/scope.go
+++ b/ml/model/scope.go
@@ -161,6 +161,14 @@ func (s *Scope) At(nameFormat string, args ...any) *Scope {
 	return s2
 }
 
+// ResetVisited returns a copy of the Scope at the same path, but with its visited-paths set cleared.
+// This is useful when reusing the same scope across different compilation passes.
+func (s *Scope) ResetVisited() *Scope {
+	s2 := s.copy()
+	s2.visitedPaths = sets.Make[string]()
+	return s2
+}
+
 // WithInitializer returns a new reference to the Scope, with the initializer set.
 func (s *Scope) WithInitializer(initializer VariableInitializer) *Scope {
 	if initializer == nil {

--- a/ml/nn/quantized_dense_test.go
+++ b/ml/nn/quantized_dense_test.go
@@ -86,6 +86,10 @@ func TestQuantizedDense_Int8(t *testing.T) {
 func TestQuantizedDense_NF4(t *testing.T) {
 	// Sub-byte dtypes (Uint4) are only supported by the simplego backend; exclude XLA.
 	testutil.TestOfficialBackends(t, func(t *testing.T, backend compute.Backend) {
+		if backend.Name() == "xla" {
+			t.Skip("Skipping: XLA seems to have some bugs when supporting some sub-byte dtypes operations.")
+		}
+
 		// M=1, K=2, N=4, blockSize=4 → numBlocks=1.
 		//
 		// Nibble indices (low nibble = even col, high nibble = odd col):
@@ -450,6 +454,10 @@ func TestQuantizedDense_GGML_IQ4NL(t *testing.T) {
 func TestQuantizedDense_Int4(t *testing.T) {
 	// Sub-byte dtypes (Int4) are only supported by the simplego backend; exclude XLA.
 	testutil.TestOfficialBackends(t, func(t *testing.T, backend compute.Backend) {
+		if backend.Name() == "xla" {
+			t.Skip("Skipping: XLA seems to have some bugs when supporting sub-byte dtypes operations.")
+		}
+
 		// Same packed layout as the NF4 test, but QuantLinear dequant with Int4 weights.
 		//
 		// Packed bytes (low nibble first):

--- a/ml/zoo/transformer/generate/generate.go
+++ b/ml/zoo/transformer/generate/generate.go
@@ -49,11 +49,12 @@ const (
 // Parameters:
 //   - scope: Model scope passed along by the Generator.
 //   - tokens: Input token sequence, shaped [batch, paddedSeqLen].
-//   - length: Number of tokens that are non-padding.
+//   - seqLen: A [batchSize] tensor containing the unpadded sequence length for each element of the batch.
+//             If nil, the full paddedSeqLen is assumed (no padding / masking).
 //
 // Returns:
 //   - logits: Output logits per candidate token (vocabSize), shaped [batch, seqLen, vocabSize]
-type NaiveModelFn func(scope *model.Scope, tokens *Node, length int) *Node
+type NaiveModelFn func(scope *model.Scope, tokens *Node, seqLen *Node) *Node
 
 // KVCacheModelFn represents an incremental model function, which is expected to have
 // an associated KVCache.
@@ -474,7 +475,7 @@ func (gen *Generator) validate() error {
 // Parameters:
 //   - backend: Backend for computation
 //   - scope: Scope containing model parameters
-//   - prompt: Input token sequence (1D or 2D tensor)
+//   - prompt: Input token sequence (1D or 2D tensor). If not a [tensors.Tensor] it will be converted to one using [tensors.FromAnyValue].
 //
 // Returns:
 //   - Generated token sequence including the prompt
@@ -761,25 +762,21 @@ func (gen *Generator) generateSamplingNaive(
 	if gen.naiveExec == nil {
 		gen.naiveExec, err = model.NewExec(backend, scope.Store(), func(scope *model.Scope, inputs []*Node) *Node {
 			currentSeqNode := inputs[0]
-			if useDynamic {
-				seqLenNode := inputs[1]
-				logits := gen.naiveModelFn(scope, currentSeqNode, -1)
-				lastIndex := Sub(seqLenNode, ConstAs(seqLenNode, 1))
-				transposed := Transpose(logits, 0, 1)
-				lastLogits := Gather(transposed, lastIndex)
-				nextToken := sample.SampleWithStrategy(scope, lastLogits, gen.Strategy, float64(gen.Temperature), gen.TopK, float64(gen.TopP))
-				return nextToken
+			seqLenNode := inputs[1]
+			logits := gen.naiveModelFn(scope, currentSeqNode, seqLenNode)
+
+			var lastIndex *Node
+			if seqLenNode.Rank() > 0 {
+				lastIndex = Squeeze(Slice(seqLenNode, AxisElem(0)))
 			} else {
-				lengthDummy := inputs[1]
-				currentSeqLen := lengthDummy.Shape().Dimensions[0]
-				logits := gen.naiveModelFn(scope, currentSeqNode, currentSeqLen)
-				g := logits.Graph()
-				lastIndex := Const(g, int32(currentSeqLen-1))
-				transposed := Transpose(logits, 0, 1)
-				lastLogits := Gather(transposed, lastIndex)
-				nextToken := sample.SampleWithStrategy(scope, lastLogits, gen.Strategy, float64(gen.Temperature), gen.TopK, float64(gen.TopP))
-				return nextToken
+				lastIndex = seqLenNode
 			}
+			lastIndex = Sub(lastIndex, ConstAs(lastIndex, 1))
+
+			transposed := Transpose(logits, 0, 1)
+			lastLogits := Gather(transposed, lastIndex)
+			nextToken := sample.SampleWithStrategy(scope, lastLogits, gen.Strategy, float64(gen.Temperature), gen.TopK, float64(gen.TopP))
+			return nextToken
 		})
 		if err != nil {
 			return nil, errors.WithMessagef(err, "failed to create naiveExec")
@@ -792,14 +789,15 @@ func (gen *Generator) generateSamplingNaive(
 	for step := range numTokensToGenerate {
 		currentSeqLen := promptLen + step
 
-		var outputs []*tensors.Tensor
-		if useDynamic {
-			outputs, err = gen.naiveExec.Call(currentSeq, tensors.FromValue(int32(currentSeqLen)))
-		} else {
-			lengthDummy := tensors.FromShape(shapes.Make(dtypes.Int32, currentSeqLen))
-			outputs, err = gen.naiveExec.Call(currentSeq, lengthDummy)
-			lengthDummy.FinalizeAll()
+		seqLenVals := make([]int32, batchSize)
+		for i := range batchSize {
+			seqLenVals[i] = int32(currentSeqLen)
 		}
+		seqLenTensor := tensors.FromValue(seqLenVals)
+
+		var outputs []*tensors.Tensor
+		outputs, err = gen.naiveExec.Call(currentSeq, seqLenTensor)
+		seqLenTensor.FinalizeAll()
 
 		if err != nil {
 			return nil, errors.WithMessagef(err, "generation step %d failed", step)
@@ -1241,7 +1239,8 @@ func (gen *Generator) generateBeamSearchNaive(
 				} else {
 					paddedSequences = sequences
 				}
-				logits := gen.naiveModelFn(scope, paddedSequences, currentLength)
+				seqLenNode := BroadcastToDims(Scalar(g, dtypes.Int32, int32(currentLength)), batchBeamSize)
+				logits := gen.naiveModelFn(scope, paddedSequences, seqLenNode)
 
 				// Last token logits: [batch_beam_size, vocab_size]
 				lastIndex := Const(g, int32(currentLength-1))

--- a/ml/zoo/transformer/generate/generate.go
+++ b/ml/zoo/transformer/generate/generate.go
@@ -50,7 +50,7 @@ const (
 //   - scope: Model scope passed along by the Generator.
 //   - tokens: Input token sequence, shaped [batch, paddedSeqLen].
 //   - seqLen: A [batchSize] tensor containing the unpadded sequence length for each element of the batch.
-//             If nil, the full paddedSeqLen is assumed (no padding / masking).
+//     If nil, the full paddedSeqLen is assumed (no padding / masking).
 //
 // Returns:
 //   - logits: Output logits per candidate token (vocabSize), shaped [batch, seqLen, vocabSize]

--- a/ml/zoo/transformer/generate/generate_test.go
+++ b/ml/zoo/transformer/generate/generate_test.go
@@ -19,7 +19,7 @@ import (
 // TestGenerator groups config default and builder tests.
 func TestGenerator(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node { return tokens }
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node { return tokens }
 		cfg := New(modelFn)
 		assert.Equal(t, 100, cfg.MaxLength)
 		assert.Equal(t, sample.StrategyGreedy, cfg.Strategy)
@@ -32,7 +32,7 @@ func TestGenerator(t *testing.T) {
 	})
 
 	t.Run("Builders", func(t *testing.T) {
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node { return tokens }
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node { return tokens }
 		cfg := New(modelFn).
 			WithMaxLength(50).
 			WithTemperature(0.7).
@@ -57,7 +57,7 @@ func TestGeneratorSampling(t *testing.T) {
 	t.Run("Greedy", func(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 			vocabSize := 10
 			g := tokens.Graph()
 			vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)
@@ -87,7 +87,7 @@ func TestGeneratorSampling(t *testing.T) {
 	t.Run("Temperature", func(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 			vocabSize := 10
 			g := tokens.Graph()
 			vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)
@@ -114,7 +114,7 @@ func TestGeneratorSampling(t *testing.T) {
 	t.Run("OneDPrompt", func(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 			vocabSize := 10
 			g := tokens.Graph()
 			vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)
@@ -137,7 +137,7 @@ func TestGeneratorSampling(t *testing.T) {
 	t.Run("PromptTooLong", func(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node { return tokens }
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node { return tokens }
 		cfg := New(modelFn).WithMaxLength(5)
 		prompt := [][]int32{{1, 2, 3, 4, 5, 6, 7, 8}}
 		_, err := cfg.Decode(backend, store.RootScope(), prompt)
@@ -150,7 +150,7 @@ func TestGeneratorSampling(t *testing.T) {
 func TestBeamSearch(t *testing.T) {
 	backend := testutil.BuildTestBackend()
 	store := model.NewStore()
-	var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+	var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 		vocabSize := 10
 		g := tokens.Graph()
 		vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)
@@ -175,7 +175,7 @@ func TestBeamSearch(t *testing.T) {
 func TestStreaming(t *testing.T) {
 	backend := testutil.BuildTestBackend()
 	store := model.NewStore()
-	var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+	var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 		vocabSize := 10
 		g := tokens.Graph()
 		vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)
@@ -212,7 +212,7 @@ func TestDynamicShapesAndBucketing(t *testing.T) {
 		}
 
 		store := model.NewStore()
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 			vocabSize := 10
 			g := tokens.Graph()
 			vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)
@@ -238,7 +238,7 @@ func TestDynamicShapesAndBucketing(t *testing.T) {
 
 	t.Run("BucketingPow2Strategy", func(t *testing.T) {
 		store := model.NewStore()
-		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, length int) *Node {
+		var modelFn NaiveModelFn = func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
 			vocabSize := 10
 			g := tokens.Graph()
 			vocabIota := Iota(g, shapes.Make(dtypes.Float32, vocabSize), 0)

--- a/ml/zoo/transformer/transformer.go
+++ b/ml/zoo/transformer/transformer.go
@@ -85,8 +85,28 @@ func NewKVCache() *kvcache.KVCache {
 	return kvcache.NewKVCache()
 }
 
+// CallOptions holds transient execution/graph building options for a forward pass or layer generation.
+type CallOptions struct {
+	// SeqLen is an optional 1D tensor of shape [batchSize] containing the non-padded sequence lengths.
+	// Cannot be set if AttentionMask is set.
+	SeqLen *Node
+
+	// AttentionMask is an optional 2D tensor of shape [batchSize, paddedSeqLen] containing 1s for valid tokens and 0s for padding.
+	// Cannot be set if SeqLen is set.
+	AttentionMask *Node
+
+	// PositionIds is shaped [batchSize, seqLen]. If nil, defaults to sequential positions (0, 1, 2...).
+	PositionIds *Node
+
+	// Cache is the optional KVCacheNodes map containing cached key/value nodes from past steps.
+	// If it is nil, no KV cache is used and the model computes attention across the entire sequence.
+	// If it is non-nil, the model uses/updates the cache, which is typical for fast autoregressive generation.
+	Cache KVCacheNodes
+}
+
 // Model configures a cached transformer model.
 type Model struct {
+	Scope                *model.Scope    // Scope for variables and hyperparameters configuration
 	VocabSize            int             // Vocabulary size
 	EmbedDim             int             // Embedding dimension
 	NumLayers            int             // Transformer layers
@@ -136,14 +156,15 @@ type Model struct {
 }
 
 // New creates a default transformer configuration.
-func New(vocabSize, embedDim, numLayers, numHeads, headDim int) *Model {
-	return &Model{
-		VocabSize:                    vocabSize,
-		EmbedDim:                     embedDim,
-		NumLayers:                    numLayers,
-		NumHeads:                     numHeads,
-		HeadDim:                      headDim,
-		FFNDim:                       embedDim * 4, // 4x expansion
+func New(scope *model.Scope) *Model {
+	m := &Model{
+		Scope:                        scope,
+		VocabSize:                    0,
+		EmbedDim:                     0,
+		NumLayers:                    0,
+		NumHeads:                     0,
+		HeadDim:                      0,
+		FFNDim:                       0,
 		MaxPosEmbed:                  512,
 		DType:                        dtypes.Float32,
 		Dropout:                      0.0,
@@ -163,9 +184,67 @@ func New(vocabSize, embedDim, numLayers, numHeads, headDim int) *Model {
 		PerLayerModelProjectionScale: 1,
 		RMSNormOffset:                1,
 	}
+
+	if scope != nil {
+		m.VocabSize = model.GetParamOr(scope, ParamVocabSize, m.VocabSize)
+		m.EmbedDim = model.GetParamOr(scope, ParamEmbedDim, m.EmbedDim)
+		m.NumLayers = model.GetParamOr(scope, ParamNumLayers, m.NumLayers)
+		m.NumHeads = model.GetParamOr(scope, ParamNumHeads, m.NumHeads)
+		m.HeadDim = model.GetParamOr(scope, ParamHeadDim, m.HeadDim)
+
+		m.FFNDim = model.GetParamOr(scope, ParamFFNDim, m.FFNDim)
+		if m.FFNDim == 0 && m.EmbedDim > 0 {
+			m.FFNDim = m.EmbedDim * 4
+		}
+		m.MaxPosEmbed = model.GetParamOr(scope, ParamMaxPosEmbed, m.MaxPosEmbed)
+		m.Dropout = model.GetParamOr(scope, ParamDropout, m.Dropout)
+
+		// Deprecated way to specify LayerNorm:
+		useLayerNorm := model.GetParamOr(scope, ParamUseLayerNorm, true)
+		if useLayerNorm {
+			m.WithNormalization(layers.NormalizationLayerNorm)
+		} else {
+			m.WithNormalization(layers.NormalizationNone)
+		}
+		m.Normalization = model.GetParamOr(scope, ParamNormalization, m.Normalization)
+		m.UseBias = model.GetParamOr(scope, ParamUseBias, m.UseBias)
+		m.UseCausalMask = model.GetParamOr(scope, ParamUseCausalMask, m.UseCausalMask)
+		archStr := model.GetParamOr(scope, ParamArchitecture, m.Architecture.String())
+		if arch, err := ArchitectureString(archStr); err == nil {
+			m.Architecture = arch
+		} else {
+			exceptions.Panicf("invalid architecture name %q: options are %v", archStr, ArchitectureValues())
+		}
+		m.NormEpsilon = model.GetParamOr(scope, ParamNormEpsilon, m.NormEpsilon)
+		m.Activation = activation.FromName(model.GetParamOr(scope, ParamActivation, m.Activation.String()))
+		m.NumKVHeads = model.GetParamOr(scope, ParamNumKVHeads, m.NumKVHeads)
+		m.GlobalHeadDim = model.GetParamOr(scope, ParamGlobalHeadDim, m.GlobalHeadDim)
+		m.NumKVSharedLayers = model.GetParamOr(scope, ParamNumKVSharedLayers, m.NumKVSharedLayers)
+		m.AttentionScoreSoftCap = model.GetParamOr(scope, ParamAttentionScoreSoftCap, m.AttentionScoreSoftCap)
+		m.FinalLogitSoftCap = model.GetParamOr(scope, ParamFinalLogitSoftCap, m.FinalLogitSoftCap)
+
+		// Legacy RoPE configuration from scope
+		useRoPE := model.GetParamOr(scope, ParamUseRoPE, false)
+		if useRoPE {
+			baseFreq := model.GetParamOr(scope, ParamRoPEBaseFreq, 10000.0)
+			m.posEncoder = pos.NewRoPE(baseFreq)
+		}
+
+		// Handle dtype separately since it's a string
+		dtypeStr := model.GetParamOr(scope, ParamDType, "")
+		if dtypeStr != "" {
+			dtype, err := dtypes.DTypeString(dtypeStr)
+			if err != nil || !dtype.IsFloat() {
+				panic(fmt.Sprintf("Invalid hyperparameter value %s=%q", ParamDType, dtypeStr))
+			}
+			m.DType = dtype
+		}
+	}
+
+	return m
 }
 
-func (m *Model) populateOrderedScopes(scope *model.Scope) {
+func (m *Model) populateOrderedScopes() {
 	if len(m.KVCache.OrderedScopes) > 0 {
 		return
 	}
@@ -173,25 +252,25 @@ func (m *Model) populateOrderedScopes(scope *model.Scope) {
 	for i := range m.NumLayers {
 		var path string
 		if m.Architecture == ArchitectureGemma || m.Architecture == ArchitectureGemma3 || m.Architecture == ArchitectureGemma4 {
-			path = scope.At("layer_%d", i).At("self_attn").Scope()
+			path = m.Scope.At("layer_%d", i).At("self_attn").Scope()
 		} else {
-			path = scope.At("layer_%d", i).At("attn").Scope()
+			path = m.Scope.At("layer_%d", i).At("attn").Scope()
 		}
 		scopes[i] = path
 	}
 	m.KVCache.OrderedScopes = scopes
 }
 
-func (m *Model) populateLayerTypes(scope *model.Scope) {
+func (m *Model) populateLayerTypes() {
 	if len(m.KVCache.LayerTypes) > 0 {
 		return
 	}
 	for i := range m.NumLayers {
 		var path string
 		if m.Architecture == ArchitectureGemma || m.Architecture == ArchitectureGemma3 || m.Architecture == ArchitectureGemma4 {
-			path = scope.At("layer_%d", i).At("self_attn").Scope()
+			path = m.Scope.At("layer_%d", i).At("self_attn").Scope()
 		} else {
-			path = scope.At("layer_%d", i).At("attn").Scope()
+			path = m.Scope.At("layer_%d", i).At("attn").Scope()
 		}
 
 		lt := GlobalLayer
@@ -203,123 +282,66 @@ func (m *Model) populateLayerTypes(scope *model.Scope) {
 }
 
 // PopulateKVCacheConfigs initializes the internal KVCache configuration's OrderedScopes
-// and LayerTypes based on the model's architecture and the execution scope.
-func (m *Model) PopulateKVCacheConfigs(scope *model.Scope) {
-	m.populateOrderedScopes(scope)
-	m.populateLayerTypes(scope)
+// and LayerTypes based on the model's architecture.
+func (m *Model) PopulateKVCacheConfigs() {
+	m.populateOrderedScopes()
+	m.populateLayerTypes()
 }
 
-// NewFromScope creates a transformer model configured from the hyperparameters in Scope:
-// It reads parameters with the following keys (with defaults):
-//   - transformer_vocab_size (required, no default)
-//   - transformer_embed_dim (required, no default)
-//   - transformer_num_layers (required, no default)
-//   - transformer_num_heads (required, no default)
-//   - transformer_head_dim (required, no default)
-//   - transformer_ffn_dim (default: embed_dim * 4)
-//   - transformer_max_pos_embed (default: 512)
-//   - transformer_dtype (default: "float32")
-//   - transformer_dropout (default: 0.0)
-//   - transformer_use_rope (default: false)
-//   - transformer_rope_base_freq (default: 10000.0)
-//   - transformer_use_layer_norm (default: true)
-//   - transformer_use_bias (default: true)
-//
-// Example usage:
-//
-//	scope.SetParams(map[string]any{
-//	    "transformer_vocab_size": 50257,
-//	    "transformer_embed_dim": 768,
-//	    "transformer_num_layers": 12,
-//	    "transformer_num_heads": 12,
-//	    "transformer_head_dim": 64,
-//	})
-//	model := transformer.NewFromScope(scope)
-func NewFromScope(scope *model.Scope) *Model {
-	// Required parameters
-	vocabSize, found := scope.GetParam(ParamVocabSize)
-	if !found {
-		panic(fmt.Sprintf("Required hyperparameter %q not found in scope", ParamVocabSize))
+func (m *Model) validate(options CallOptions) {
+	if m.VocabSize <= 0 {
+		exceptions.Panicf("VocabSize must be configured (> 0)")
 	}
-	embedDim, found := scope.GetParam(ParamEmbedDim)
-	if !found {
-		panic(fmt.Sprintf("Required hyperparameter %q not found in scope", ParamEmbedDim))
+	if m.EmbedDim <= 0 {
+		exceptions.Panicf("EmbedDim must be configured (> 0)")
 	}
-	numLayers, found := scope.GetParam(ParamNumLayers)
-	if !found {
-		panic(fmt.Sprintf("Required hyperparameter %q not found in scope", ParamNumLayers))
+	if m.NumLayers <= 0 {
+		exceptions.Panicf("NumLayers must be configured (> 0)")
 	}
-	numHeads, found := scope.GetParam(ParamNumHeads)
-	if !found {
-		panic(fmt.Sprintf("Required hyperparameter %q not found in scope", ParamNumHeads))
+	if m.NumHeads <= 0 {
+		exceptions.Panicf("NumHeads must be configured (> 0)")
 	}
-	headDim, found := scope.GetParam(ParamHeadDim)
-	if !found {
-		panic(fmt.Sprintf("Required hyperparameter %q not found in scope", ParamHeadDim))
+	if m.HeadDim <= 0 {
+		exceptions.Panicf("HeadDim must be configured (> 0)")
 	}
+	if m.FFNDim <= 0 {
+		m.FFNDim = m.EmbedDim * 4
+	}
+	if options.AttentionMask != nil && options.SeqLen != nil {
+		exceptions.Panicf("AttentionMask and SeqLen cannot both be configured")
+	}
+}
 
-	// Create model with required parameters
-	m := New(
-		vocabSize.(int),
-		embedDim.(int),
-		numLayers.(int),
-		numHeads.(int),
-		headDim.(int),
-	)
-
-	// Apply optional parameters from scope
-	m.FromScope(scope)
+// WithVocabSize sets vocabulary size.
+func (m *Model) WithVocabSize(size int) *Model {
+	m.VocabSize = size
 	return m
 }
 
-// FromScope configures the model with optional hyperparameters from the model.
-// This allows fine-tuning an existing model configuration.
-func (m *Model) FromScope(scope *model.Scope) *Model {
-	// Optional parameters with defaults
-	m.FFNDim = model.GetParamOr(scope, ParamFFNDim, m.FFNDim)
-	m.MaxPosEmbed = model.GetParamOr(scope, ParamMaxPosEmbed, m.MaxPosEmbed)
-	m.Dropout = model.GetParamOr(scope, ParamDropout, m.Dropout)
-
-	// Deprecated way to specify LayerNorm:
-	useLayerNorm := model.GetParamOr(scope, ParamUseLayerNorm, true)
-	if useLayerNorm {
-		m.WithLayerNorm(true)
+// WithEmbedDim sets embedding dimension.
+func (m *Model) WithEmbedDim(dim int) *Model {
+	m.EmbedDim = dim
+	if m.FFNDim == 0 {
+		m.FFNDim = dim * 4
 	}
-	m.Normalization = model.GetParamOr(scope, ParamNormalization, m.Normalization)
-	m.WithNormalization(m.Normalization)
-	m.UseBias = model.GetParamOr(scope, ParamUseBias, m.UseBias)
-	m.UseCausalMask = model.GetParamOr(scope, ParamUseCausalMask, m.UseCausalMask)
-	archStr := model.GetParamOr(scope, ParamArchitecture, m.Architecture.String())
-	if arch, err := ArchitectureString(archStr); err == nil {
-		m.Architecture = arch
-	} else {
-		exceptions.Panicf("invalid architecture name %q: options are %v", archStr, ArchitectureValues())
-	}
-	m.NormEpsilon = model.GetParamOr(scope, ParamNormEpsilon, m.NormEpsilon)
-	m.Activation = activation.FromName(model.GetParamOr(scope, ParamActivation, m.Activation.String()))
-	m.NumKVHeads = model.GetParamOr(scope, ParamNumKVHeads, m.NumKVHeads)
-	m.GlobalHeadDim = model.GetParamOr(scope, ParamGlobalHeadDim, m.GlobalHeadDim)
-	m.NumKVSharedLayers = model.GetParamOr(scope, ParamNumKVSharedLayers, m.NumKVSharedLayers)
-	m.AttentionScoreSoftCap = model.GetParamOr(scope, ParamAttentionScoreSoftCap, m.AttentionScoreSoftCap)
-	m.FinalLogitSoftCap = model.GetParamOr(scope, ParamFinalLogitSoftCap, m.FinalLogitSoftCap)
+	return m
+}
 
-	// Legacy RoPE configuration from scope
-	useRoPE := model.GetParamOr(scope, ParamUseRoPE, false)
-	if useRoPE {
-		baseFreq := model.GetParamOr(scope, ParamRoPEBaseFreq, 10000.0)
-		m.posEncoder = pos.NewRoPE(baseFreq)
-	}
+// WithNumLayers sets the number of transformer layers.
+func (m *Model) WithNumLayers(num int) *Model {
+	m.NumLayers = num
+	return m
+}
 
-	// Handle dtype separately since it's a string
-	dtypeStr := model.GetParamOr(scope, ParamDType, "")
-	if dtypeStr != "" {
-		dtype, err := dtypes.DTypeString(dtypeStr)
-		if err != nil || !dtype.IsFloat() {
-			panic(fmt.Sprintf("Invalid hyperparameter value %s=%q", ParamDType, dtypeStr))
-		}
-		m.DType = dtype
-	}
+// WithNumHeads sets the number of attention heads per layer.
+func (m *Model) WithNumHeads(num int) *Model {
+	m.NumHeads = num
+	return m
+}
 
+// WithHeadDim sets the head dimension.
+func (m *Model) WithHeadDim(dim int) *Model {
+	m.HeadDim = dim
 	return m
 }
 
@@ -574,87 +596,67 @@ func (m *Model) sourceLayerForShared(layerNum int) int {
 //
 // This form can be used to embed full sentences or for training.
 //
-//   - tokens: shaped [batchSize, seqLen], or simply [seqLen]
-//   - mask: optional, if provided the shape must match tokens.Shape(), and it indicates
-//     which tokens are valid (1) and which are padding (0). The attention mask (causal or not)
-//     is computed taking into consideration the mask.
-//
 // It returns the logits of the last layer, typically shaped [batchSize, seqLen, vocabSize]
-// Logits builds the model including the last logits projection to predict the next token,
-// for each element of the sequence.
-//
-// This form can be used to embed full sentences or for training.
-//
-//   - tokens: shaped [batchSize, seqLen], or simply [seqLen]
-//   - mask: optional, shaped [batchSize, seqLen] of some integer dtype or [dtypes.Bool].
-//     If provided the shape must match tokens.Shape(), and it indicates
-//     which tokens are valid (1/true) and which are padding (0/false). The attention mask (causal or not)
-//     is computed taking into consideration the mask.
-//
-// It returns the logits of the last layer, typically shaped [batchSize, seqLen, vocabSize]
-func (m *Model) Logits(scope *model.Scope, tokens, mask *Node) *Node {
-	embeddings, _, _ := m.AllLayers(scope, tokens, nil, mask, nil)
-	return m.LogitsFromEmbeddings(scope, embeddings)
+func (m *Model) Logits(tokens *Node, options CallOptions) *Node {
+	embeddings, _, _ := m.AllLayers(tokens, options)
+	return m.LogitsFromEmbeddings(embeddings)
 }
 
 // MakeNaiveModelFn returns a "naive" model function for iterative (increasing sequence length, no KVCache)
 // generation, using the decode package.
 //
-// It returns a generate.NaiveModel interface.
+// It returns a generate.NaiveModelFn interface.
 func MakeNaiveModelFn(m *Model) generate.NaiveModelFn {
-	return func(scope *model.Scope, tokens *Node, length int) *Node {
-		paddedSeqLen := tokens.Shape().Dimensions[1]
-		if length > paddedSeqLen {
-			exceptions.Panicf("indicated length %d of sequence is larger than the tokens ([batch, seqLen]=%s) length provided", length, tokens.Shape())
+	return func(scope *model.Scope, tokens *Node, seqLen *Node) *Node {
+		if scope.Store() != m.Scope.Store() {
+			exceptions.Panicf("NaiveModelFn called with a scope from a different Store")
 		}
-		var attentionMask *Node
-		if paddedSeqLen != length {
-			g := tokens.Graph()
-			attentionMask = Iota(g, tokens.Shape(), 1)
-			attentionMask = LessThan(attentionMask, ConstAs(attentionMask, length))
-		}
-		return m.Logits(scope, tokens, attentionMask)
+		m.Scope = m.Scope.ResetVisited()
+		return m.Logits(tokens, CallOptions{SeqLen: seqLen})
 	}
 }
 
 // Forward returns the forward path for the model.
 //
-// - tokens: shaped [batchSize, seqLen]
-// - positionIds: shaped [batchSize, seqLen], or nil (which defaults to sequential positions)
-// - attentionMask: shaped [batchSize, seqLen], or nil
-// - cache: KVCacheNodes, or nil if no KV cache is used.
-//
 // It returns the logits of the last layer, typically shaped [batchSize, seqLen, vocabSize],
 // and the updated KV cache.
-func (m *Model) Forward(scope *model.Scope,
-	tokens, positionIds *Node,
-	attentionMask *Node,
-	cache KVCacheNodes,
+func (m *Model) Forward(
+	tokens *Node,
+	options CallOptions,
 ) (logits *Node, updatedCache KVCacheNodes) {
-	embeddings, _, updatedCache := m.AllLayers(scope, tokens, positionIds, attentionMask, cache)
-	return m.LogitsFromEmbeddings(scope, embeddings), updatedCache
+	embeddings, _, updatedCache := m.AllLayers(tokens, options)
+	return m.LogitsFromEmbeddings(embeddings), updatedCache
 }
 
 // LogitsWithKVCache returns the forward path for the newTokens sequence, using the KV cache.
-func (m *Model) LogitsWithKVCache(scope *model.Scope, newTokens *Node, positionIds *Node, cache KVCacheNodes) (*Node, KVCacheNodes) {
-	return m.Forward(scope, newTokens, positionIds, nil, cache)
+func (m *Model) LogitsWithKVCache(newTokens *Node, positionIds *Node, cache KVCacheNodes) (*Node, KVCacheNodes) {
+	return m.Forward(newTokens, CallOptions{
+		PositionIds: positionIds,
+		Cache:       cache,
+	})
 }
 
 // MakeKVCacheModelFn returns a model function used by the decoder for incremental generation with KVCache,
 // using the decode package.
+//
+// Note that the returned function marks the Model.Scope to be reused (see [Scope.ResetVisited])
 func MakeKVCacheModelFn(m *Model) generate.KVCacheModelFn {
 	return func(scope *model.Scope, newTokens *Node, position *Node, cache KVCacheNodes) (*Node, KVCacheNodes) {
-		return m.Forward(scope, newTokens, position, nil, cache)
+		if scope.Store() != m.Scope.Store() {
+			exceptions.Panicf("KVCacheModelFn called with a scope from a different Store")
+		}
+		m.Scope = m.Scope.ResetVisited()
+		return m.Forward(newTokens, CallOptions{
+			PositionIds: position,
+			Cache:       cache,
+		})
 	}
 }
 
 // AllLayers takes the input tokens and creates the forward graph for the transformer model,
 // returning the last layer and all the intermediate layers.
 //
-//   - tokens: shaped [batchSize, seqLen], or simply [seqLen]
 //   - positionIds: shaped [batchSize, seqLen], or nil
-//   - attentionMask: optional, if provided the shape must match tokens.Shape(), and it indicates
-//     which tokens are valid (1) and which are padding (0).
 //   - cache: the KVCacheNodes map containing cached key/value nodes.
 //
 // It returns:
@@ -662,21 +664,28 @@ func MakeKVCacheModelFn(m *Model) generate.KVCacheModelFn {
 //   - lastLayer: the final hidden state of the last layer, shaped [batchSize, seqLen,hiddenSize].
 //   - allLayers: the input to the first layer and the output of each layer.
 //   - updatedCache: the updated KVCacheNodes map.
-func (m *Model) AllLayers(scope *model.Scope, tokens, positionIds *Node, attentionMask *Node, cache KVCacheNodes) (lastLayer *Node, allLayers []*Node, updatedCache KVCacheNodes) {
+func (m *Model) AllLayers(tokens *Node, options CallOptions) (lastLayer *Node, allLayers []*Node, updatedCache KVCacheNodes) {
+	m.validate(options)
+
+	if tokens == nil {
+		exceptions.Panicf("tokens must be set")
+	}
 	if tokens.Rank() == 1 {
 		tokens = ExpandAxes(tokens, 0)
 	}
 	g := tokens.Graph()
 	seqLen := tokens.Shape().Dimensions[1]
 
+	positionIds := options.PositionIds
 	if positionIds == nil {
 		posIdx := Iota(g, shapes.Make(dtypes.Int32, seqLen), 0)
 		positionIds = ExpandDims(posIdx, 0)
 		positionIds = BroadcastToDims(positionIds, tokens.Shape().Dimensions...)
 	}
 
-	m.populateOrderedScopes(scope)
-	m.populateLayerTypes(scope)
+	m.populateOrderedScopes()
+	m.populateLayerTypes()
+	cache := options.Cache
 	if cache != nil {
 		updatedCache = make(KVCacheNodes)
 		for k, v := range cache {
@@ -685,7 +694,7 @@ func (m *Model) AllLayers(scope *model.Scope, tokens, positionIds *Node, attenti
 	}
 
 	allLayers = make([]*Node, 0, m.NumLayers+1)
-	x := m.EmbedTokens(scope, tokens)
+	x := m.EmbedTokens(tokens)
 
 	if m.posEncoder != nil {
 		if preEnc, ok := m.posEncoder.(pos.PreEncoder); ok {
@@ -694,7 +703,7 @@ func (m *Model) AllLayers(scope *model.Scope, tokens, positionIds *Node, attenti
 	}
 
 	if m.EmbedNormalization != layers.NormalizationNone {
-		x = m.normalize(scope.In("embed_norm"), x, m.EmbedNormalization)
+		x = m.normalize(m.Scope.In("embed_norm"), x, m.EmbedNormalization)
 	}
 	allLayers = append(allLayers, x)
 
@@ -716,17 +725,17 @@ func (m *Model) AllLayers(scope *model.Scope, tokens, positionIds *Node, attenti
 	var perLayerInputs *Node
 	if m.HiddenSizePerLayerInput > 0 {
 		// Per-layer Embedding (PLE): see explanation in [Model.WithHiddenSizePerLayerInput].
-		embeddedPLE := layers.Embedding(scope.In("token_embed_per_layer"), tokens, m.DType, m.VocabSizePerLayerInput, m.NumLayers*m.HiddenSizePerLayerInput)
+		embeddedPLE := layers.Embedding(m.Scope.In("token_embed_per_layer"), tokens, m.DType, m.VocabSizePerLayerInput, m.NumLayers*m.HiddenSizePerLayerInput)
 		pleScale := Scalar(embeddedPLE.Graph(), m.DType, math.Sqrt(float64(m.HiddenSizePerLayerInput)))
 		embeddedPLE = Mul(embeddedPLE, pleScale)
 		batchSize := tokens.Shape().Dimensions[0]
 		embeddedPLE = Reshape(embeddedPLE, batchSize, seqLen, m.NumLayers, m.HiddenSizePerLayerInput)
 
-		perLayerProjection := m.dense(scope.In("per_layer_model_projection"), x, false, m.NumLayers*m.HiddenSizePerLayerInput)
+		perLayerProjection := m.dense(m.Scope.In("per_layer_model_projection"), x, false, m.NumLayers*m.HiddenSizePerLayerInput)
 		perLayerProjectionScale := Scalar(perLayerProjection.Graph(), m.DType, m.PerLayerModelProjectionScale)
 		perLayerProjection = Mul(perLayerProjection, perLayerProjectionScale)
 		perLayerProjection = Reshape(perLayerProjection, batchSize, seqLen, m.NumLayers, m.HiddenSizePerLayerInput)
-		perLayerProjection = m.normalize(scope.In("per_layer_projection_norm"), perLayerProjection, layers.NormalizationRMSNorm)
+		perLayerProjection = m.normalize(m.Scope.In("per_layer_projection_norm"), perLayerProjection, layers.NormalizationRMSNorm)
 
 		perLayerInputs = Add(perLayerProjection, embeddedPLE)
 		if m.PerLayerInputScale != 1 {
@@ -741,16 +750,16 @@ func (m *Model) AllLayers(scope *model.Scope, tokens, positionIds *Node, attenti
 
 	// Apply all layers.
 	for layerNum := range m.NumLayers {
-		layerScope := scope.In("layer_%d", layerNum)
+		layerScope := m.Scope.In("layer_%d", layerNum)
 		var perLayerInput *Node
 		if perLayerInputs != nil {
 			perLayerInput = Squeeze(Slice(perLayerInputs, AxisRange(), AxisRange(), AxisElem(layerNum), AxisRange()), 2)
 		}
-		x = m.ForwardLayer(layerScope, layerNum, x, attentionMask, positionNode, updatedCache, perLayerInput, sharedKVs)
+		x = m.ForwardLayer(layerScope, layerNum, x, positionNode, updatedCache, perLayerInput, sharedKVs, options)
 		allLayers = append(allLayers, x)
 	}
 	if m.FinalNormalization != layers.NormalizationNone {
-		x = m.normalize(scope.In("final_norm"), x, m.FinalNormalization)
+		x = m.normalize(m.Scope.In("final_norm"), x, m.FinalNormalization)
 		if len(allLayers) > 0 {
 			allLayers[len(allLayers)-1] = x
 		}
@@ -774,8 +783,8 @@ func (m *Model) AllLayers(scope *model.Scope, tokens, positionIds *Node, attenti
 //
 // It defaults to TokenType 0 for all tokens if TokenTypeEmbedSize > 0.
 // Use EmbedTokensWithType to select a different index.
-func (m *Model) EmbedTokens(scope *model.Scope, tokens *Node) *Node {
-	return m.EmbedTokensWithType(scope, tokens, nil)
+func (m *Model) EmbedTokens(tokens *Node) *Node {
+	return m.EmbedTokensWithType(tokens, nil)
 }
 
 // EmbedTokensWithType returns the token embeddings for the given tokens and tokenTypes using lookup tables.
@@ -787,10 +796,10 @@ func (m *Model) EmbedTokens(scope *model.Scope, tokens *Node) *Node {
 //
 // tokenTypes must be a scalar int (limited to the vocabSize set in WithTokenTypeEmbedding).
 // Or it can be nil, in which case it defaults to TokenType 0 for all tokens if TokenTypeEmbedSize > 0.
-func (m *Model) EmbedTokensWithType(scope *model.Scope, tokens, tokenTypes *Node) *Node {
+func (m *Model) EmbedTokensWithType(tokens, tokenTypes *Node) *Node {
 	g := tokens.Graph()
 	// Tokens embedding table lookup.
-	embedded := layers.Embedding(scope.In("token_embed"), tokens, m.DType, m.VocabSize, m.EmbedDim)
+	embedded := layers.Embedding(m.Scope.In("token_embed"), tokens, m.DType, m.VocabSize, m.EmbedDim)
 	if embedded.Rank() == 2 {
 		embedded = ExpandDims(embedded, 1)
 	}
@@ -802,7 +811,7 @@ func (m *Model) EmbedTokensWithType(scope *model.Scope, tokens, tokenTypes *Node
 		if tokenTypes == nil {
 			tokenTypes = ScalarZero(g, dtypes.Int32)
 		}
-		tokenTypeEmbed := layers.Embedding(scope.In("token_type_embed"), tokenTypes, m.DType, m.TokenTypeEmbedSize, m.EmbedDim)
+		tokenTypeEmbed := layers.Embedding(m.Scope.In("token_type_embed"), tokenTypes, m.DType, m.TokenTypeEmbedSize, m.EmbedDim)
 		embedded = Add(embedded, broadcastPrefixToMatch(tokenTypeEmbed, embedded))
 	}
 	return embedded
@@ -817,7 +826,7 @@ func (m *Model) EmbedTokensWithType(scope *model.Scope, tokens, tokenTypes *Node
 //
 // This step is done automatically by AllLayers or Logits, but if needed, it can
 // be used separately by calling this method.
-func (m *Model) PrePositionalEncoder(scope *model.Scope, x *Node, position int, useKVCache bool) *Node {
+func (m *Model) PrePositionalEncoder(x *Node, position int, useKVCache bool) *Node {
 	if m.posEncoder == nil {
 		return x
 	}
@@ -839,32 +848,31 @@ func (m *Model) PrePositionalEncoder(scope *model.Scope, x *Node, position int, 
 //
 // This step is done automatically by Logits (which builds the full forward path from the tokens), but if needed, it can
 // be used separately by calling this method.
-func (m *Model) LogitsFromEmbeddings(scope *model.Scope, embeddings *Node) *Node {
-	logits := layers.Dense(scope.In("output"), embeddings, false, m.VocabSize)
+func (m *Model) LogitsFromEmbeddings(embeddings *Node) *Node {
+	logits := layers.Dense(m.Scope.In("output"), embeddings, false, m.VocabSize)
 	if m.FinalLogitSoftCap > 0 {
 		logits = nn.SoftCap(logits, m.FinalLogitSoftCap)
 	}
 	return logits
 }
 
-// // ForwardLayer executes a single transformer layer block depending on the configured architecture.
+// ForwardLayer executes a single transformer layer block depending on the configured architecture.
 //
-// - scope: scope must be already scoped for the layer, e.g. scope.In("layer_0")
+// - layerScope: scope must be already scoped for the layer, e.g. scope.In("layer_0")
 // - x: features coming from the previous layer (or token embedding table), shape [batchSize, seqLen, embedDim]
-// - attentionMask: (optional, can be nil) shaped [batchSize, seqLen]
 // - position: position node (scalar int32) indicating the current absolute position
 // - cache: updated KVCacheNodes map
 // - sharedKVs: optional, map of shared key/values for layers that don't project their own KVs
 //
 // It returns the output of the layer, shape [batchSize, seqLen, embedDim].
-func (m *Model) ForwardLayer(scope *model.Scope, layerNum int, x, attentionMask *Node, position *Node, cache KVCacheNodes, perLayerInput *Node, sharedKVs KVCacheNodes) *Node {
+func (m *Model) ForwardLayer(layerScope *model.Scope, layerNum int, x *Node, position *Node, cache KVCacheNodes, perLayerInput *Node, sharedKVs KVCacheNodes, options CallOptions) *Node {
 	if m.Architecture == ArchitectureGemma || m.Architecture == ArchitectureGemma3 || m.Architecture == ArchitectureGemma4 {
-		return m.forwardLayerGemma(scope, layerNum, x, attentionMask, position, cache, perLayerInput, sharedKVs)
+		return m.forwardLayerGemma(layerScope, layerNum, x, position, cache, perLayerInput, sharedKVs, options)
 	}
-	return m.forwardLayerStandard(scope, layerNum, x, attentionMask, position, cache, perLayerInput, sharedKVs)
+	return m.forwardLayerStandard(layerScope, layerNum, x, position, cache, perLayerInput, sharedKVs, options)
 }
 
-func (m *Model) forwardLayerStandard(layerScope *model.Scope, layerNum int, x, attentionMask *Node, position *Node, cache KVCacheNodes, perLayerInput *Node, sharedKVs KVCacheNodes) *Node {
+func (m *Model) forwardLayerStandard(layerScope *model.Scope, layerNum int, x *Node, position *Node, cache KVCacheNodes, perLayerInput *Node, sharedKVs KVCacheNodes, options CallOptions) *Node {
 	residual := x
 	var attn *Node
 
@@ -961,8 +969,8 @@ func (m *Model) forwardLayerStandard(layerScope *model.Scope, layerNum int, x, a
 		}
 		customMask := m.KVCache.BuildAttentionMask(attnScope, cache, x, position, m.UseCausalMask, slidingWindow)
 
-		if attentionMask != nil {
-			expandedMask := ExpandDims(attentionMask, 1)
+		if options.AttentionMask != nil {
+			expandedMask := ExpandDims(options.AttentionMask, 1)
 			expandedMask = BroadcastToDims(expandedMask, customMask.Shape().Dimensions...)
 			customMask = LogicalAnd(customMask, expandedMask)
 		}
@@ -998,8 +1006,11 @@ func (m *Model) forwardLayerStandard(layerScope *model.Scope, layerNum int, x, a
 			WithOutputDim(m.EmbedDim).
 			WithScoreSoftCap(m.AttentionScoreSoftCap).
 			WithQueryKeyScale(m.QueryKeyScale)
-		if attentionMask != nil {
-			attnBuilder.WithMask(attentionMask)
+		if options.AttentionMask != nil {
+			attnBuilder.WithMask(options.AttentionMask)
+		}
+		if options.SeqLen != nil {
+			attnBuilder.WithSeqLens(options.SeqLen, options.SeqLen)
 		}
 		if m.UseCausalMask {
 			attnBuilder.WithCausalMask(true)
@@ -1087,7 +1098,7 @@ func (m *Model) normalize(scope *model.Scope, operand *Node, normType string) *N
 	}
 }
 
-func (m *Model) forwardLayerGemma(layerScope *model.Scope, layerNum int, x, attentionMask *Node, position *Node, cache KVCacheNodes, perLayerInput *Node, sharedKVs KVCacheNodes) *Node {
+func (m *Model) forwardLayerGemma(layerScope *model.Scope, layerNum int, x *Node, position *Node, cache KVCacheNodes, perLayerInput *Node, sharedKVs KVCacheNodes, options CallOptions) *Node {
 	residual := x
 
 	// Pre-attention normalization.
@@ -1208,8 +1219,8 @@ func (m *Model) forwardLayerGemma(layerScope *model.Scope, layerNum int, x, atte
 		}
 		customMask := m.KVCache.BuildAttentionMask(selfAttnScope, cache, x, position, m.UseCausalMask, slidingWindow)
 
-		if attentionMask != nil {
-			expandedMask := ExpandDims(attentionMask, 1)
+		if options.AttentionMask != nil {
+			expandedMask := ExpandDims(options.AttentionMask, 1)
 			expandedMask = BroadcastToDims(expandedMask, customMask.Shape().Dimensions...)
 			customMask = LogicalAnd(expandedMask, customMask)
 		}
@@ -1245,8 +1256,11 @@ func (m *Model) forwardLayerGemma(layerScope *model.Scope, layerNum int, x, atte
 			WithOutputDim(m.EmbedDim).
 			WithScoreSoftCap(m.AttentionScoreSoftCap).
 			WithQueryKeyScale(m.QueryKeyScale)
-		if attentionMask != nil {
-			attnBuilder.WithMask(attentionMask)
+		if options.AttentionMask != nil {
+			attnBuilder.WithMask(options.AttentionMask)
+		}
+		if options.SeqLen != nil {
+			attnBuilder.WithSeqLens(options.SeqLen, options.SeqLen)
 		}
 		if m.UseCausalMask {
 			attnBuilder.WithCausalMask(true)

--- a/ml/zoo/transformer/transformer_test.go
+++ b/ml/zoo/transformer/transformer_test.go
@@ -23,7 +23,12 @@ import (
 // TestModel groups transformer model tests.
 func TestModel(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
-		cfg := New(1000, 128, 4, 8, 16)
+		cfg := New(nil).
+			WithVocabSize(1000).
+			WithEmbedDim(128).
+			WithNumLayers(4).
+			WithNumHeads(8).
+			WithHeadDim(16)
 		assert.Equal(t, 1000, cfg.VocabSize)
 		assert.Equal(t, 128, cfg.EmbedDim)
 		assert.Equal(t, 4, cfg.NumLayers)
@@ -39,7 +44,12 @@ func TestModel(t *testing.T) {
 	})
 
 	t.Run("Builders", func(t *testing.T) {
-		cfg := New(1000, 128, 4, 8, 16).
+		cfg := New(nil).
+			WithVocabSize(1000).
+			WithEmbedDim(128).
+			WithNumLayers(4).
+			WithNumHeads(8).
+			WithHeadDim(16).
 			WithFFNDim(256).
 			WithMaxPosEmbed(1024).
 			WithDType(dtypes.Float16).
@@ -49,8 +59,6 @@ func TestModel(t *testing.T) {
 			WithBias(false)
 		assert.Equal(t, 256, cfg.FFNDim)
 		assert.Equal(t, 1024, cfg.MaxPosEmbed)
-		assert.Equal(t, dtypes.Float16, cfg.DType)
-		assert.Equal(t, 0.1, cfg.Dropout)
 		assert.Equal(t, dtypes.Float16, cfg.DType)
 		assert.Equal(t, 0.1, cfg.Dropout)
 		require.NotNil(t, cfg.posEncoder)
@@ -80,7 +88,7 @@ func TestModel(t *testing.T) {
 			ParamNormalization: "none", // layers.NormalizationNone or "".
 		})
 
-		cfg := NewFromScope(scope)
+		cfg := New(scope)
 		assert.Equal(t, 1000, cfg.VocabSize)
 		assert.Equal(t, 128, cfg.EmbedDim)
 		assert.Equal(t, 4, cfg.NumLayers)
@@ -88,8 +96,6 @@ func TestModel(t *testing.T) {
 		assert.Equal(t, 16, cfg.HeadDim)
 		assert.Equal(t, 256, cfg.FFNDim)
 		assert.Equal(t, 1024, cfg.MaxPosEmbed)
-		assert.Equal(t, dtypes.Float16, cfg.DType)
-		assert.Equal(t, 0.1, cfg.Dropout)
 		assert.Equal(t, dtypes.Float16, cfg.DType)
 		assert.Equal(t, 0.1, cfg.Dropout)
 		require.NotNil(t, cfg.posEncoder)
@@ -100,33 +106,21 @@ func TestModel(t *testing.T) {
 		assert.False(t, cfg.UseBias)
 	})
 
-	t.Run("FromScope", func(t *testing.T) {
-		store := model.NewStore()
-		scope := store.RootScope()
-		scope.SetParams(map[string]any{
-			ParamFFNDim:        256,
-			ParamMaxPosEmbed:   1024,
-			ParamDType:         "float16",
-			ParamDropout:       0.1,
-			ParamUseRoPE:       true,
-			ParamRoPEBaseFreq:  5000.0,
-			ParamUseBias:       false,
-			ParamNormalization: "", // or layers.NormalizationNone.
+	t.Run("ValidationRejectsMissingConfig", func(t *testing.T) {
+		assert.Panics(t, func() {
+			New(nil).validate(CallOptions{})
 		})
+	})
 
-		cfg := New(1000, 128, 4, 8, 16).FromScope(scope)
-		assert.Equal(t, 256, cfg.FFNDim)
-		assert.Equal(t, 1024, cfg.MaxPosEmbed)
-		assert.Equal(t, dtypes.Float16, cfg.DType)
-		assert.Equal(t, 0.1, cfg.Dropout)
-		assert.Equal(t, dtypes.Float16, cfg.DType)
-		assert.Equal(t, 0.1, cfg.Dropout)
-		require.NotNil(t, cfg.posEncoder)
-		rope, ok := cfg.posEncoder.(*pos.RoPE)
-		require.True(t, ok)
-		assert.Equal(t, 5000.0, rope.BaseFreq)
-		assert.Equal(t, layers.NormalizationNone, cfg.Normalization)
-		assert.False(t, cfg.UseBias)
+	t.Run("ValidationRejectsBothMaskAndSeqLen", func(t *testing.T) {
+		assert.Panics(t, func() {
+			backend := testutil.BuildTestBackend()
+			g := NewGraph(backend, "test")
+			mask := ScalarZero(g, dtypes.Int32)
+			seqLen := ScalarZero(g, dtypes.Int32)
+			m := New(nil).WithVocabSize(10).WithEmbedDim(16).WithNumLayers(1).WithNumHeads(1).WithHeadDim(16)
+			m.validate(CallOptions{AttentionMask: mask, SeqLen: seqLen})
+		})
 	})
 }
 
@@ -136,11 +130,18 @@ func TestTransformerBuilder(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		cfg := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128)
 		g := NewGraph(backend, "BuildGraph")
 		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 2, 8))
+		cfg := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128)
 		tokens = Mod(tokens, Const(g, int32(cfg.VocabSize)))
-		logits := cfg.Logits(scope, tokens, nil)
+		logits := cfg.Logits(tokens, CallOptions{})
 		require.NotNil(t, logits)
 		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
 		assert.Equal(t, dtypes.Float32, logits.DType())
@@ -150,11 +151,18 @@ func TestTransformerBuilder(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		model := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128)
 		g := NewGraph(backend, "BuildGraphWithKVCache")
 		prompt := IotaFull(g, shapes.Make(dtypes.Int32, 2, 5))
-		prompt = Mod(prompt, Const(g, int32(model.VocabSize)))
-		logits, _ := model.LogitsWithKVCache(scope, prompt, nil, nil)
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128)
+		prompt = Mod(prompt, Const(g, int32(m.VocabSize)))
+		logits, _ := m.LogitsWithKVCache(prompt, nil, nil)
 		require.NotNil(t, logits)
 		assert.Equal(t, []int{2, 5, 100}, logits.Shape().Dimensions)
 	})
@@ -166,32 +174,68 @@ func TestTransformerVariants(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		model := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128).WithRoPE(10000.0)
 		g := NewGraph(backend, "WithRoPE")
 		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 1, 4))
-		tokens = Mod(tokens, Const(g, int32(model.VocabSize)))
-		logits, _ := model.LogitsWithKVCache(scope, tokens, nil, nil)
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128).
+			WithRoPE(10000.0)
+		tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
+		logits, _ := m.LogitsWithKVCache(tokens, nil, nil)
 		require.NotNil(t, logits)
 		assert.Equal(t, []int{1, 4, 100}, logits.Shape().Dimensions)
+	})
+
+	t.Run("WithSeqLen", func(t *testing.T) {
+		backend := testutil.BuildTestBackend()
+		store := model.NewStore()
+		scope := store.RootScope()
+		g := NewGraph(backend, "WithSeqLen")
+		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 2, 8))
+		seqLen := Const(g, []int32{5, 3}) // non-padded sequence lengths
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128)
+		tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
+		logits := m.Logits(tokens, CallOptions{SeqLen: seqLen})
+		require.NotNil(t, logits)
+		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
 	})
 
 	t.Run("ExplicitKVCacheExecution", func(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		m := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128)
-		
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128)
+
 		// 1. Initialize Cache
-		m.populateOrderedScopes(scope)
-		m.populateLayerTypes(scope)
+		m.populateOrderedScopes()
+		m.populateLayerTypes()
 		cacheTensors := m.KVCache.InitializeTensors(2, 4, 16, dtypes.Float32, 5) // batch=2, numKVHeads=4, headDim=16, seqLen=5
-		
+
 		// 2. Build graph for prompt execution
 		exec, err := model.NewExec(backend, store, func(scope *model.Scope, inputs []*Node) []*Node {
 			tokens := inputs[0]
 			cacheNodes := inputs[1:]
 			cache := m.KVCache.DeserializeNodes(cacheNodes)
-			logits, updatedCache := m.Forward(scope, tokens, nil, nil, cache)
+			logits, updatedCache := m.Forward(tokens, CallOptions{Cache: cache})
 			serializedCache, err := m.KVCache.SerializeNodes(updatedCache)
 			if err != nil {
 				panic(err)
@@ -203,32 +247,32 @@ func TestTransformerVariants(t *testing.T) {
 		})
 		require.NoError(t, err)
 		defer exec.Finalize()
-		
+
 		// 3. Prepare inputs
 		promptTensor := tensors.FromValue([][]int32{
 			{1, 2, 3, 4, 5},
 			{5, 4, 3, 2, 1},
 		})
-		
+
 		serializedCacheTensors, err := m.KVCache.SerializeTensors(cacheTensors)
 		require.NoError(t, err)
-		
+
 		args := make([]any, 0, 1+len(serializedCacheTensors))
 		args = append(args, promptTensor)
 		for _, tensor := range serializedCacheTensors {
 			args = append(args, tensor)
 		}
-		
+
 		// 4. Run Execution
 		results, err := exec.Call(args...)
 		require.NoError(t, err)
-		
+
 		logits := results[0]
 		assert.Equal(t, []int{2, 5, 100}, logits.Shape().Dimensions)
-		
+
 		updatedCacheTensors := m.KVCache.DeserializeTensors(results[1:])
 		assert.Equal(t, 2*len(m.KVCache.OrderedScopes), len(results)-1)
-		
+
 		// Verify shapes of updated cache
 		for _, scopePath := range m.KVCache.OrderedScopes {
 			kTensor := updatedCacheTensors[scopePath+kvcache.KeySuffix]
@@ -240,11 +284,19 @@ func TestTransformerVariants(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		model := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128).WithNormalization("none")
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128).
+			WithNormalization("none")
 		g := NewGraph(backend, "WithoutLayerNorm")
 		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 2, 8))
-		tokens = Mod(tokens, Const(g, int32(model.VocabSize)))
-		logits := model.Logits(scope, tokens, nil)
+		tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
+		logits := m.Logits(tokens, CallOptions{})
 		require.NotNil(t, logits)
 		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
 	})
@@ -253,11 +305,19 @@ func TestTransformerVariants(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		model := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128).WithBias(false)
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128).
+			WithBias(false)
 		g := NewGraph(backend, "WithoutBias")
 		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 2, 8))
-		tokens = Mod(tokens, Const(g, int32(model.VocabSize)))
-		logits := model.Logits(scope, tokens, nil)
+		tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
+		logits := m.Logits(tokens, CallOptions{})
 		require.NotNil(t, logits)
 		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
 	})
@@ -266,11 +326,19 @@ func TestTransformerVariants(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()
 		scope := store.RootScope()
-		model := New(100, 64, 2, 4, 16).WithFFNDim(128).WithMaxPosEmbed(128).WithDropout(0.1)
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128).
+			WithDropout(0.1)
 		g := NewGraph(backend, "WithDropout")
 		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 2, 8))
-		tokens = Mod(tokens, Const(g, int32(model.VocabSize)))
-		logits := model.Logits(scope, tokens, nil)
+		tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
+		logits := m.Logits(tokens, CallOptions{})
 		require.NotNil(t, logits)
 		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
 	})
@@ -286,7 +354,12 @@ func TestTransformerBatchSizes(t *testing.T) {
 			store := model.NewStore()
 			scope := store.RootScope()
 
-			model := New(100, 64, 2, 4, 16).
+			m := New(scope).
+				WithVocabSize(100).
+				WithEmbedDim(64).
+				WithNumLayers(2).
+				WithNumHeads(4).
+				WithHeadDim(16).
 				WithFFNDim(128).
 				WithMaxPosEmbed(128)
 
@@ -296,9 +369,9 @@ func TestTransformerBatchSizes(t *testing.T) {
 			g := NewGraph(manager, "TestTransformerBatchSize")
 
 			tokens := IotaFull(g, shapes.Make(dtypes.Int32, batchSize, seqLen))
-			tokens = Mod(tokens, Const(g, int32(model.VocabSize)))
+			tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
 
-			logits := model.Logits(scope, tokens, nil)
+			logits := m.Logits(tokens, CallOptions{})
 			require.NotNil(t, logits)
 			assert.Equal(t, []int{batchSize, seqLen, 100}, logits.Shape().Dimensions)
 		})


### PR DESCRIPTION
## Background & Motivation
This PR refactors the GoMLX transformer APIs to support dynamic sequence lengths (`seqLen`) during naive generation, simplify layer invocation with a consolidated `CallOptions` structure, and resolve scope-reuse issues across multi-pass compilation (prefill & decode) via scope resetting. Additionally, it transitions the `gemma3` example to use the standardized `generate` package APIs for both KV Cache and Naive execution.

## Key Changes

### 1. Core Transformer API Refactoring (`ml/zoo/transformer`)
- **`CallOptions` Introduction**: Grouped optional execution parameters (`PositionIds`, `Cache`, `SeqLen`, and `AttentionMask`) into a single `CallOptions` struct to simplify layer function signatures and keep the API clean.
- **Dynamic `seqLen` Support**: Updated `NaiveModelFn` and `MakeNaiveModelFn` to take `seqLen *Node` (a `[batchSize]` tensor of unpadded sequence lengths) rather than `length int`, enabling compilation caching and dynamic masking of padded sequences in naive mode.
- **Attention Layer Updates**: Adjusted standard and Gemma layer forward paths to read from `CallOptions` and correctly set up the sequence lengths on the underlying attention builders.

### 2. Scope Management (`ml/model`)
- **`Scope.ResetVisited()`**: Added a helper method to copy a scope at the same path while resetting its visited-paths set. This allows the same variable scope to be safely reused across different graph compilation passes (e.g., prefill and decode) without failing on duplicate variable access checks.

### 3. Generator Improvements (`ml/zoo/transformer/generate`)
- **`generate.go` cleanups**: Minor documentation clarifications and validation of model functions.

### 4. Gemma 3 Example Modernization (`examples/gemma3`)
- **Use `generate` Package**: Replaced the custom prefill/decode looping logic in `gemma3.go` with the standard `generate.Generator`.
- **KV Cache & Naive Generation**: Unified both generation paradigms. Added a `-naive` flag to toggle between Naive generation (~7.5 tokens/s) and KV Cache generation (~10.4 tokens/s).
- **Reduced Verbosity**: Removed verbose startup prints that listed all 38 ONNX model inputs and outputs, keeping command line execution output clean and focused.

---

## Verification
1. **Tests**: All transformer tests in `ml/zoo/transformer` pass successfully (including the new `WithSeqLen` test case).
2. **Examples**: `examples/gemma3` executes correctly and streams generated output cleanly:
```bash
GOMLX_BACKEND="xla:cuda,preallocate=false" go run ./examples/gemma3/gemma3.go
```
Output:
```
Using KV cache: 18 layers, 1 heads, dim=256
Prompt: "Write a short poem about the sea."
Tokenized to 18 tokens
Generating...
---
The sea... (generated output)
---
Generated 100 tokens in 9.59s (10.4 tokens/s)
```
