### PR TITLE
Add Dynamic Tanh (DyT) normalization layer

### DIFF
--- a/ml/layers/norm/dynamictanh.go
+++ b/ml/layers/norm/dynamictanh.go
@@ -1,0 +1,90 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package norm
+
+import (
+	"github.com/gomlx/compute/shapes"
+	. "github.com/gomlx/gomlx/core/graph"
+	"github.com/gomlx/gomlx/ml/model"
+	"github.com/gomlx/gomlx/ml/model/initializer"
+)
+
+// DynamicTanhBuilder holds the configuration for Dynamic Tanh (DyT).
+// Once finished configuring, call DynamicTanhBuilder.Done().
+type DynamicTanhBuilder struct {
+	scope   *model.Scope
+	operand *Node
+	alpha   float64
+}
+
+var (
+	// ParamDynamicTanhAlpha is the scope hyperparameter that defines the initial value for the
+	// learnable alpha parameter. The default is 0.5.
+	//
+	// Alpha is a scalar shared across the input and scales values before the tanh nonlinearity.
+	ParamDynamicTanhAlpha = "dynamic_tanh_alpha"
+)
+
+// DynamicTanh starts the configuration of a Dynamic Tanh (DyT) operation,
+// as described in "Transformers without Normalization" (https://arxiv.org/abs/2503.10622).
+//
+// DyT is a drop-in replacement for layer normalization in transformer blocks. Unlike
+// LayerNorm or RMSNorm, it does not compute mean or variance. Instead it applies:
+//
+//	DyT(x) = tanh(alpha * x) * gamma + beta
+//
+// Where:
+//   - alpha is a learnable scalar (initialized to 0.5 by default)
+//   - gamma is a learnable per-feature scale (initialized to 1)
+//   - beta is a learnable per-feature offset (initialized to 0)
+//
+// Parameters are stored under the "dynamic_tanh" sub-scope as "alpha", "gamma", and "beta".
+// Gamma and beta are shaped to the last dimension of the input (the feature dimension) and
+// broadcast to the full input rank.
+//
+// For a transformer activation of shape [batch, seq, features], gamma and beta have shape
+// [features] and are broadcast across batch and sequence positions.
+func DynamicTanh(scope *model.Scope, operand *Node) *DynamicTanhBuilder {
+	return &DynamicTanhBuilder{
+		scope:   scope,
+		operand: operand,
+		alpha:   model.GetParamOr(scope, ParamDynamicTanhAlpha, 0.5),
+	}
+}
+
+// WithAlpha sets the initial value for the learnable alpha parameter and returns the updated builder.
+// The default is read from ParamDynamicTanhAlpha (0.5 if not set).
+func (dyt *DynamicTanhBuilder) WithAlpha(alpha float64) *DynamicTanhBuilder {
+	dyt.alpha = alpha
+	return dyt
+}
+
+// Done uses the current configuration to apply Dynamic Tanh.
+// It returns a node with the same shape as the input operand.
+func (dyt *DynamicTanhBuilder) Done() *Node {
+	scope := dyt.scope.In("dynamic_tanh")
+	x := dyt.operand
+
+	g := x.Graph()
+	dtype := x.DType()
+
+	features := x.Shape().Dim(-1)
+
+	alphaVar := scope.VariableWithValue("alpha", shapes.CastAsDType(dyt.alpha, dtype))
+	alpha := alphaVar.NodeValue(g)
+
+	paramShape := shapes.Make(dtype, features)
+	broadcastShape := x.Shape().Clone()
+
+	for i := range len(broadcastShape.Dimensions) - 1 {
+		broadcastShape.Dimensions[i] = 1
+	}
+
+	gammaVar := scope.WithInitializer(initializer.One).VariableWithShape("gamma", paramShape).SetTrainable(true)
+	gamma := Reshape(gammaVar.NodeValue(g), broadcastShape.Dimensions...)
+
+	betaVar := scope.WithInitializer(initializer.Zero).VariableWithShape("beta", paramShape).SetTrainable(true)
+	beta := Reshape(betaVar.NodeValue(g), broadcastShape.Dimensions...)
+
+	return Add(Mul(Tanh(Mul(x, alpha)), gamma), beta)
+}

--- a/ml/layers/norm/dynamictanh_test.go
+++ b/ml/layers/norm/dynamictanh_test.go
@@ -1,0 +1,46 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package norm
+
+import (
+	"testing"
+
+	. "github.com/gomlx/gomlx/core/graph"
+	"github.com/gomlx/gomlx/ml/model"
+	"github.com/gomlx/gomlx/support/testutil"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/gomlx/gomlx/backends/default"
+)
+
+func TestDynamicTanh(t *testing.T) {
+	backend := testutil.BuildTestBackend()
+	store := model.NewStore()
+
+	exec := model.MustNewExec(backend, store, func(scope *model.Scope, x *Node) *Node {
+		return DynamicTanh(scope, x).WithAlpha(1.0).Done()
+	})
+
+	x := [][][]float32{{{1, 2}, {3, 4}}}
+	got := exec.MustCall(x)[0]
+	require.NoError(t, got.Shape().CheckDims(1, 2, 2), "shape should not have changed")
+
+	want := [][][]float32{{
+		{0.7615942, 0.9640276}, {0.9950547, 0.9993292},
+	}}
+	if ok, diff := testutil.IsInDelta(want, got.Value(), 1e-3); !ok {
+		t.Errorf("DynamicTanh mismatch (-want +got):\n%s", diff)
+	}
+
+	alphaVar := store.GetVariable("/dynamic_tanh/alpha")
+	require.NotNil(t, alphaVar)
+	require.NoError(t, alphaVar.Shape().CheckDims())
+
+	gammaVar := store.GetVariable("/dynamic_tanh/gamma")
+	require.NotNil(t, gammaVar)
+	require.NoError(t, gammaVar.Shape().CheckDims(2))
+
+	betaVar := store.GetVariable("/dynamic_tanh/beta")
+	require.NotNil(t, betaVar)
+	require.NoError(t, betaVar.Shape().CheckDims(2))
+}

--- a/ml/layers/normalizers.go
+++ b/ml/layers/normalizers.go
@@ -19,6 +19,9 @@ const (
 	NormalizationRMSNorm = "rms"
 	// NormalizationBatchNorm is the value for norm.BatchNorm.
 	NormalizationBatchNorm = "batch"
+	// NormalizationDyT is the value for norm.DynamicTanh.
+	// DyT is a drop-in replacement for layer normalization; see norm.DynamicTanh for details.
+	NormalizationDyT = "dyt"
 	// NormalizationNone is the value for no normalization.
 	NormalizationNone = "none"
 )
@@ -44,6 +47,9 @@ var (
 		NormalizationRMSNorm: func(scope *model.Scope, input *Node) *Node {
 			return norm.RMSNorm(scope, input).Done()
 		},
+		NormalizationDyT: func(scope *model.Scope, input *Node) *Node {
+			return norm.DynamicTanh(scope, input).Done()
+		},
 		NormalizationNone: func(scope *model.Scope, input *Node) *Node {
 			return input
 		},
@@ -56,8 +62,8 @@ var (
 	// between layers.
 	// This is usually applied after a residual sum (but model choices varies).
 	//
-	// Valid values are "layer" for LayerNormalization, "batch" for batchnorm.New,
-	// "rms" for RMSNorm or "none".
+	// Valid values are "layer" for LayerNormalization, "batch" for BatchNorm,
+	// "rms" for RMSNorm, "dyt" for DynamicTanh, or "none".
 	//
 	// Notice that this won't work for special shapes setups.
 	// New will normalize on the batch axis (assumed to be axis-0), and
@@ -131,8 +137,10 @@ func MaskedNormalizeFromScope(scope *model.Scope, input, mask *Node) *Node {
 				ParamNormalization)
 		}
 		return norm.BatchNorm(scope, input, -1).Done()
+	case NormalizationDyT:
+		return norm.DynamicTanh(scope, input).Done()
 	default:
-		Panicf("invalid normalization type %q given in scope parameter %q -- valid values are 'none', 'layer' or 'batch'",
+		Panicf("invalid normalization type %q given in scope parameter %q -- valid values are 'none', 'layer', 'rms', 'batch', or 'dyt'",
 			normType, ParamNormalization)
 	}
 	return input

--- a/ml/zoo/transformer/transformer.go
+++ b/ml/zoo/transformer/transformer.go
@@ -41,6 +41,7 @@ const (
 	ParamArchitecture          = "transformer_architecture"
 	ParamNormalization         = "transformer_normalization"
 	ParamNormEpsilon           = "transformer_norm_epsilon"
+	ParamDyTAlpha              = "transformer_dyt_alpha"
 	ParamActivation            = "transformer_activation"
 	ParamNumKVHeads            = "transformer_num_kv_heads"
 	ParamGlobalHeadDim         = "transformer_global_head_dim"
@@ -123,8 +124,9 @@ type Model struct {
 	Architecture         Architecture    // e.g. ArchitectureStandard, ArchitectureGemma
 	EmbedNormalization   string          // e.g. "layer", "rms", "none" or ""
 	TokenTypeEmbedSize   int             // e.g. Number of token types, 2 for BERT. See WithTokenTypeEmbedding.
-	Normalization        string          // e.g. "layer", "rms", "batch", "none" or "" (see layers.Normalization*)
+	Normalization        string          // e.g. "layer", "rms", "batch", "dyt", "none" or "" (see layers.Normalization*)
 	NormEpsilon          float64         // Epsilon for normalization
+	DyTAlpha             float64         // Initial alpha for Dynamic Tanh
 	Activation           activation.Type // e.g. "gelu", "silu", "gelu_approximate"
 	NumKVHeads           int             // For Grouped Query Attention (GQA), 0 means equal to NumHeads
 
@@ -176,6 +178,7 @@ func New(scope *model.Scope) *Model {
 		Architecture:                 ArchitectureStandard,
 		Normalization:                layers.NormalizationLayerNorm,
 		NormEpsilon:                  1e-5,
+		DyTAlpha:                     0.5,
 		Activation:                   activation.TypeGelu,
 		NumKVHeads:                   0,
 		posEncoder:                   nil,
@@ -216,6 +219,7 @@ func New(scope *model.Scope) *Model {
 			exceptions.Panicf("invalid architecture name %q: options are %v", archStr, ArchitectureValues())
 		}
 		m.NormEpsilon = model.GetParamOr(scope, ParamNormEpsilon, m.NormEpsilon)
+		m.DyTAlpha = model.GetParamOr(scope, ParamDyTAlpha, m.DyTAlpha)
 		m.Activation = activation.FromName(model.GetParamOr(scope, ParamActivation, m.Activation.String()))
 		m.NumKVHeads = model.GetParamOr(scope, ParamNumKVHeads, m.NumKVHeads)
 		m.GlobalHeadDim = model.GetParamOr(scope, ParamGlobalHeadDim, m.GlobalHeadDim)
@@ -461,11 +465,13 @@ func (m *Model) WithArchitecture(arch Architecture) *Model {
 	return m
 }
 
-// WithNormalization sets the normalization type ("layer", "rms", "batch", "none" or "").
+// WithNormalization sets the normalization type used inside transformer layers.
 //
+// Valid values are "layer", "rms", "dyt", "batch", "none" or "".
 // The values "none" or "" mean no normalization.
 //
-// See constants layers.NormalizationLayerNorm ("layer"), layers.NormalizationRMSNorm ("rms"), layers.NormalizationBatchNorm ("batch")
+// See constants layers.NormalizationLayerNorm ("layer"), layers.NormalizationRMSNorm ("rms"),
+// layers.NormalizationDyT ("dyt"), layers.NormalizationBatchNorm ("batch")
 // and layers.NormalizationNone ("none").
 func (m *Model) WithNormalization(norm string) *Model {
 	if norm == "" {
@@ -478,6 +484,12 @@ func (m *Model) WithNormalization(norm string) *Model {
 // WithNormEpsilon sets the epsilon value used for normalization layers.
 func (m *Model) WithNormEpsilon(eps float64) *Model {
 	m.NormEpsilon = eps
+	return m
+}
+
+// WithDyTAlpha sets the initial value for the learnable alpha parameter when using Dynamic Tanh.
+func (m *Model) WithDyTAlpha(alpha float64) *Model {
+	m.DyTAlpha = alpha
 	return m
 }
 
@@ -1092,6 +1104,8 @@ func (m *Model) normalize(scope *model.Scope, operand *Node, normType string) *N
 		return builder.Done()
 	case layers.NormalizationLayerNorm:
 		return norm.LayerNorm(scope, operand, -1).Epsilon(m.NormEpsilon).Done()
+	case layers.NormalizationDyT:
+		return norm.DynamicTanh(scope, operand).WithAlpha(m.DyTAlpha).Done()
 	default:
 		exceptions.Panicf("unsupported normalization type: %q", normType)
 		return nil

--- a/ml/zoo/transformer/transformer_test.go
+++ b/ml/zoo/transformer/transformer_test.go
@@ -301,6 +301,28 @@ func TestTransformerVariants(t *testing.T) {
 		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
 	})
 
+	t.Run("WithDyTNormalization", func(t *testing.T) {
+		backend := testutil.BuildTestBackend()
+		store := model.NewStore()
+		scope := store.RootScope()
+		m := New(scope).
+			WithVocabSize(100).
+			WithEmbedDim(64).
+			WithNumLayers(2).
+			WithNumHeads(4).
+			WithHeadDim(16).
+			WithFFNDim(128).
+			WithMaxPosEmbed(128).
+			WithNormalization(layers.NormalizationDyT).
+			WithDyTAlpha(0.75)
+		g := NewGraph(backend, "WithDyTNormalization")
+		tokens := IotaFull(g, shapes.Make(dtypes.Int32, 2, 8))
+		tokens = Mod(tokens, Const(g, int32(m.VocabSize)))
+		logits := m.Logits(tokens, CallOptions{})
+		require.NotNil(t, logits)
+		assert.Equal(t, []int{2, 8, 100}, logits.Shape().Dimensions)
+	})
+
 	t.Run("WithoutBias", func(t *testing.T) {
 		backend := testutil.BuildTestBackend()
 		store := model.NewStore()


### PR DESCRIPTION
## Summary
- Add `norm.DynamicTanh` implementing DyT from [Transformers without Normalization](https://arxiv.org/abs/2503.10622): `tanh(alpha * x) * gamma + beta` with learnable scalar `alpha`, and per-feature `gamma`/`beta`.
- Register `"dyt"` in `layers.KnownNormalizers` and `MaskedNormalizeFromScope`.
- Wire into `ml/zoo/transformer` via `WithNormalization("dyt")` and `WithDyTAlpha`.

## Test plan
- [x] `go test ./ml/layers/norm/ -run TestDynamicTanh`
- [x] `go test ./ml/zoo/transformer/ -run TestTransformerVariants/WithDyTNormalization`


Made with [Cursor](https://cursor.com)