### PR TITLE
Re-download cached files when checksum validation fails

### DIFF
--- a/examples/downloader/downloader.go
+++ b/examples/downloader/downloader.go
@@ -134,14 +134,23 @@ func DownloadIfMissing(url, filePath, checkHash string) error {
 		}
 	}
 
+	partPath := filePath + ".part"
+
 	// Download the compressed file.
 	fmt.Printf("Downloading %s ...\n", url)
-	_, err := Download(url, filePath, true)
-	if err != nil {
+	if _, err := Download(url, partPath, true); err != nil {
+		os.Remove(partPath)
 		return err
 	}
-
-	return fsutil.ValidateChecksum(filePath, checkHash)
+	if err := fsutil.ValidateChecksum(partPath, checkHash); err != nil {
+		os.Remove(partPath)
+		return err
+	}
+	if err := os.Rename(partPath, filePath); err != nil {
+		os.Remove(partPath)
+		return err
+	}
+	return nil
 }
 
 // Untar file, using decompression flags according to suffix: .gz for gzip, bz2 for bzip2.

--- a/examples/downloader/downloader.go
+++ b/examples/downloader/downloader.go
@@ -90,6 +90,12 @@ func Download(url, filePath string, showProgressBar bool) (size int64, err error
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed creating file %q", filePath)
 	}
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			size = 0
+			err = errors.Wrapf(cerr, "failed closing %q", filePath)
+		}
+	}()
 	client := http.Client{
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			r.URL.Opaque = r.URL.Path
@@ -101,6 +107,12 @@ func Download(url, filePath string, showProgressBar bool) (size int64, err error
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed downloading %q", url)
 	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil && err == nil {
+			size = 0
+			err = errors.Wrapf(cerr, "failed closing connection to %q", url)
+		}
+	}()
 
 	if showProgressBar {
 		size, err = CopyWithProgressBar(file, resp.Body, resp.ContentLength)
@@ -109,14 +121,6 @@ func Download(url, filePath string, showProgressBar bool) (size int64, err error
 	}
 	if err != nil {
 		return 0, errors.Wrapf(err, "downloading %q to %q", url, filePath)
-	}
-	err = file.Close()
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed closing %q", filePath)
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed closing connection to %q", url)
 	}
 	return size, nil
 }

--- a/examples/downloader/downloader.go
+++ b/examples/downloader/downloader.go
@@ -125,10 +125,10 @@ func Download(url, filePath string, showProgressBar bool) (size int64, err error
 	return size, nil
 }
 
-// DownloadIfMissing will check if the path exists already, and if not it will download the file
-// from the given URL.
+// DownloadIfMissing will check if the path exists already and has a valid checksum, and if not it will download the file
+// from the given URL to a .part file, validate the checksum, and rename it to the final path.
 //
-// If checkHash is provided, it checks that the file has the hash or fail.
+// If checkHash is provided, it checks that the file has the hash or returns an error.
 func DownloadIfMissing(url, filePath, checkHash string) error {
 	filePath = fsutil.MustReplaceTildeInDir(filePath)
 

--- a/examples/downloader/downloader.go
+++ b/examples/downloader/downloader.go
@@ -127,17 +127,20 @@ func Download(url, filePath string, showProgressBar bool) (size int64, err error
 // If checkHash is provided, it checks that the file has the hash or fail.
 func DownloadIfMissing(url, filePath, checkHash string) error {
 	filePath = fsutil.MustReplaceTildeInDir(filePath)
-	if !fsutil.MustFileExists(filePath) {
-		// Download the compressed file first.
-		fmt.Printf("Downloading %s ...\n", url)
-		_, err := Download(url, filePath, true)
-		if err != nil {
-			return err
+
+	if fsutil.MustFileExists(filePath) {
+		if err := fsutil.ValidateChecksum(filePath, checkHash); err == nil {
+			return nil
 		}
 	}
-	if checkHash == "" {
-		return nil
+
+	// Download the compressed file.
+	fmt.Printf("Downloading %s ...\n", url)
+	_, err := Download(url, filePath, true)
+	if err != nil {
+		return err
 	}
+
 	return fsutil.ValidateChecksum(filePath, checkHash)
 }
 

--- a/examples/downloader/downloader_test.go
+++ b/examples/downloader/downloader_test.go
@@ -1,0 +1,98 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package downloader
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testBody = []byte("fake dataset content for downloader test")
+
+func testHash(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeTestFile(t *testing.T, path string, body []byte) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, body, 0666))
+}
+
+func testServer(t *testing.T, body []byte) (url string, hits *int) {
+	t.Helper()
+	count := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, &count
+}
+
+func TestDownloadIfMissing_GoodFinal(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "data.bin")
+	writeTestFile(t, final, testBody)
+	url, hits := testServer(t, testBody)
+	err := DownloadIfMissing(url, final, testHash(testBody))
+
+	require.NoError(t, err)
+	require.Equal(t, 0, *hits)
+	require.NoFileExists(t, final+".part")
+	require.FileExists(t, final)
+}
+
+func TestDownloadIfMissing_BadFinal(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "data.bin")
+	writeTestFile(t, final, []byte("corrupt"))
+	url, hits := testServer(t, testBody)
+	err := DownloadIfMissing(url, final, testHash(testBody))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, *hits)
+	require.FileExists(t, final)
+	require.NoFileExists(t, final+".part")
+}
+
+func TestDownloadIfMissing_NoFinal(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "data.bin")
+	url, hits := testServer(t, testBody)
+	err := DownloadIfMissing(url, final, testHash(testBody))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, *hits)
+	require.FileExists(t, final)
+	require.NoFileExists(t, final+".part")
+}
+
+func TestDownloadIfMissing_BadChecksum(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "data.bin")
+	url, hits := testServer(t, []byte("wrong bytes"))
+	err := DownloadIfMissing(url, final, testHash(testBody))
+
+	require.Error(t, err)
+	require.Equal(t, 1, *hits)
+	require.NoFileExists(t, final)
+	require.NoFileExists(t, final+".part")
+}
+
+func TestDownloadIfMissing_DownloadFails(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "data.bin")
+	err := DownloadIfMissing("http://127.0.0.1:1", final, testHash(testBody))
+
+	require.Error(t, err)
+	require.NoFileExists(t, final)
+	require.NoFileExists(t, final+".part")
+}

--- a/support/fsutil/fsutil.go
+++ b/support/fsutil/fsutil.go
@@ -140,7 +140,11 @@ func ReportedClose(closer io.Closer, name string, reportErrPtr *error) {
 
 // ValidateChecksum verifies that the checksum of the file in the given path matches the checksum
 // given. If it fails, it will remove the file (!) and return and error.
+// If checkHash is empty, this is a no-op.
 func ValidateChecksum(path, checkHash string) error {
+	if checkHash == "" {
+		return nil
+	}
 	hasher := sha256.New()
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `DownloadIfMissing` downloads when a file isn't cached, or it doesn't pass SHA256 validation.
- Downloads go to a `.part` file first; checksum is validated before renaming to the final path.
- `ValidateChecksum()` with empty checkHash is a no-op so callers don't need a separate empty-hash branch.
- Fixed `Download()` to close file handles on error paths (Windows CI).

## Context
Hit this running the CIFAR demo: a partial `cifar-10-binary.tar.gz` failed checksum, got deleted, and the process died. Re-running worked only because the bad file was already gone.

## Test plan
- [x] `cd examples && go test ./downloader/ -v`
- [x] Interrupted a CIFAR download mid-way, re-ran — re-downloaded successfully instead of fatal checksum error