### PR TITLE
cmd/gomlx_checkpoints: replace go-plotly with vizb for --plot, add sidebar legend and fix rendering bugs

### DIFF
--- a/cmd/gomlx_checkpoints/README.md
+++ b/cmd/gomlx_checkpoints/README.md
@@ -56,7 +56,15 @@ go install github.com/goptics/vizb@latest
 
 One HTML file is generated (a temp file by default, or `-plot_output <path>` for a fixed location), with
 one chart panel per metric type (e.g. "loss", "accuracy") and one line per metric within it (e.g. train
-vs. eval). It opens in your default browser unless `-browser=false`.
+vs. eval) — all metrics of the same type share a panel, so you can see e.g. train and validation loss
+diverge on the same chart. It opens in your default browser unless `-browser=false`.
+
+Pass more than one `<checkpoint_path>` to compare models side by side: each metric line is prefixed with
+`#1`, `#2`, ... and a persistent sidebar on the left lists the models being compared and every metric's
+short label (e.g. `T/~loss`) next to its full name (e.g. "Train: Moving Average Loss") — each entry gets
+a color-coded dot matching its model, so it's easy to tell at a glance which sidebar entries belong to
+which run. Add `-plot_title "<text>"` to title the page — handy when sharing the generated HTML file
+with others.
 
 Narrow down what gets plotted (or listed with `-metrics`) with `-metrics_names <regex>` (matches metric
 name or short name) and `-metrics_types <type1,type2,...>`.

--- a/cmd/gomlx_checkpoints/main.go
+++ b/cmd/gomlx_checkpoints/main.go
@@ -87,7 +87,7 @@ func main() {
 	// Constructed once, regardless of -loop: PlotBuilder's session state (output path, whether
 	// the browser tab has been opened yet, last-render time) needs to survive across every
 	// Reports call below, not just be created fresh on each one.
-	plotBuilder := NewPlotBuilder(*flagBrowser, *flagPlotOutput, *flagLoop)
+	plotBuilder := NewPlotBuilder(*flagBrowser, *flagPlotOutput, *flagLoop, *flagPlotTitle)
 
 	if *flagLoop > 0 {
 		for {

--- a/cmd/gomlx_checkpoints/plots.go
+++ b/cmd/gomlx_checkpoints/plots.go
@@ -41,14 +41,9 @@ var (
 )
 
 // PlotBuilder renders training metrics to a self-contained HTML file using the `vizb` CLI tool,
-// across possibly many calls to Plot within one process (e.g. once per -loop iteration).
-//
-// It exists (rather than a handful of package-level variables) so that: (1) every test can
-// construct its own PlotBuilder and run in parallel, with no risk of one test's state leaking
-// into another's; (2) the session state it carries -- has a plot ever been rendered yet, has the
-// browser tab already been opened, what output path and last-render time are we using -- is
-// visible in one place instead of scattered across the package; and (3) nothing stops two
-// PlotBuilders (say, one per session in some future server-like use) from existing side by side.
+// across possibly many calls to Plot within one process (e.g. once per -loop iteration). Holds
+// session state as fields rather than package-level variables, so tests can construct their own
+// instance and run in parallel without leaking state into each other.
 //
 // Construct one with NewPlotBuilder and call Plot as many times as needed.
 type PlotBuilder struct {
@@ -93,19 +88,28 @@ func createSortedMetricTypes(metricsOrder map[ModelNameAndMetric]int) []string {
 	return metricTypes
 }
 
+// modelIndexMarker returns a compact marker ("❶", "❷", ...) for the 1-based position of a
+// compared model -- not "#1"/"#2", since "#" already means something else in these metric names.
+// Falls back to "[N]" brackets past 10 (the circled-digit block doesn't continue further).
+func modelIndexMarker(oneBasedIdx int) string {
+	if oneBasedIdx >= 1 && oneBasedIdx <= 10 {
+		return string(rune('❶' + oneBasedIdx - 1))
+	}
+	return fmt.Sprintf("[%d]", oneBasedIdx)
+}
+
 // plotLineInfo contains the information for a single line in a plot.
 //
-// short becomes the line's series label passed to vizb (`--select step,colN{short}`) -- vizb
-// groups series by this label, so it must be unique among the lines of one metric type (see
-// disambiguateShortLabels). desc is the long-form description shown in the legend box (e.g.
-// "Train: Moving Average Loss" or "Mean Loss on train for model \"model-a\"") -- unlike short, it
-// doesn't need to be unique. modelIdx (0-based index into the Plot call's modelNames) is used to
-// color-code this line's legend entry so lines belonging to the same model are easy to spot in
-// the sidebar at a glance -- see modelColor.
+// short is the series label passed to vizb, unique per metric type (see disambiguateShortLabels)
+// and model-prefixed in multi-model mode. coreShort is the same label without the model prefix,
+// used to collapse duplicate sidebar entries across models (see buildDescriptionEntries). desc is
+// the long-form description shown in the sidebar. metricType is which chart this line belongs to.
+// modelIdx is which compared model produced it.
 type plotLineInfo struct {
-	short, desc   string
-	modelIdx      int
-	steps, values []float64
+	metricType             string
+	short, coreShort, desc string
+	modelIdx               int
+	steps, values          []float64
 }
 
 // createPlotLines for the given metric type.
@@ -119,7 +123,6 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 		modelName := modelNames[modelIdx]
 		modelNum := modelNamesToIndex[modelName]
 
-		// Group points by metric name.
 		metricPoints := make(map[string]*plotLineInfo)
 		for _, pt := range modelPoints {
 			if pt.MetricType != metricType {
@@ -131,18 +134,15 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 				MetricType: pt.MetricType,
 			}
 			if _, ok := metricsOrder[metricKey]; !ok {
-				// Metric was not selected, skip.
 				continue
 			}
 			info, exists := metricPoints[pt.MetricName]
 			if !exists {
-				info = &plotLineInfo{modelIdx: modelIdx}
+				info = &plotLineInfo{metricType: metricType, modelIdx: modelIdx, coreShort: pt.Short, desc: pt.MetricName}
 				if len(modelNames) == 1 {
 					info.short = pt.Short
-					info.desc = pt.MetricName
 				} else {
-					info.short = fmt.Sprintf("#%d %s", modelNum, pt.Short)
-					info.desc = fmt.Sprintf("%s for model %q", pt.MetricName, modelName)
+					info.short = fmt.Sprintf("%s %s", modelIndexMarker(modelNum), pt.Short)
 				}
 			}
 			info.steps = append(info.steps, pt.Step)
@@ -150,11 +150,8 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 			metricPoints[pt.MetricName] = info
 		}
 
-		// Sort points by steps.
 		for _, info := range metricPoints {
-			// Create the indices array.
 			indices := xslices.Iota(0, len(info.steps))
-			// Sort indices.
 			slices.SortFunc(indices, func(i, j int) int {
 				if info.steps[i] < info.steps[j] {
 					return -1
@@ -164,7 +161,6 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 				}
 				return 0
 			})
-			// Apply sorted order.
 			steps := make([]float64, len(info.steps))
 			values := make([]float64, len(info.values))
 			for ii, idx := range indices {
@@ -175,7 +171,6 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 			info.values = values
 		}
 
-		// Collect all lines.
 		for _, info := range metricPoints {
 			lines = append(lines, info)
 		}
@@ -183,26 +178,114 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 	return lines
 }
 
-// disambiguateShortLabels ensures every line's short is unique within one metric type's line
-// set -- vizb's chart renderer groups series by this label (the "type" field in its DataSet
-// JSON), so two different metrics sharing an identical Short (e.g. when a training script's eval
-// dataset doesn't provide a distinguishing ShortName -- confirmed to happen in practice) would
-// otherwise silently collide into what the user perceives as one series instead of two, which is
-// exactly what makes it look like same-metric-type lines (e.g. train vs validation loss) aren't
-// being plotted together correctly.
+// disambiguationSuffix derives a human-readable disambiguation suffix from a line's long
+// description, e.g. " (train)" or " (validation)". Exploits the known shape of eval-metric
+// descriptions built by ui/plot.AddTrainAndEvalMetrics: "<name> on <dataset>" (e.g. "Mean Loss on
+// train" -- see ui/plot/plot.go). Returns "" if desc doesn't end in " on <something>", signaling
+// the caller to fall back to a plain numeric suffix instead.
+func disambiguationSuffix(desc string) string {
+	const marker = " on "
+	idx := strings.LastIndex(desc, marker)
+	if idx < 0 {
+		return ""
+	}
+	dataset := strings.TrimSpace(desc[idx+len(marker):])
+	if dataset == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", dataset)
+}
+
+// disambiguateShortLabels ensures every line's short (and coreShort) is unique within one metric
+// type's line set -- vizb's chart renderer groups series by short, so two different metrics
+// sharing an identical Short would otherwise silently collide into one series.
+//
+// Prefers a suffix derived from desc (see disambiguationSuffix), e.g. "#loss() (train)" vs
+// "#loss() (validation)", over a bare numeric counter, which reads too easily as a per-model
+// marker next to the ❶/❷ markers used elsewhere. Falls back to a numeric counter when desc doesn't
+// fit that shape, or when two colliding lines would otherwise derive the same suffix.
+//
+// Sorts lines by desc first: createPlotLines builds `lines` from a Go map, whose iteration order
+// is randomized per run, so without a deterministic sort two models' independent collisions on the
+// same underlying metric could get mismatched suffixes purely by chance -- silently breaking
+// buildDescriptionEntries' cross-model dedup, which merges by exact (coreShort, desc) match.
 func disambiguateShortLabels(lines []*plotLineInfo) {
+	slices.SortFunc(lines, func(a, b *plotLineInfo) int { return strings.Compare(a.desc, b.desc) })
+
 	counts := make(map[string]int, len(lines))
 	for _, line := range lines {
 		counts[line.short]++
 	}
-	seen := make(map[string]int, len(lines))
+	seen := make(map[string]int, len(lines))                     // base short -> numeric fallback counter
+	usedSuffixes := make(map[string]map[string]bool, len(lines)) // base short -> suffixes already assigned
 	for _, line := range lines {
-		if counts[line.short] <= 1 {
+		base := line.short
+		if counts[base] <= 1 {
 			continue // No collision: leave the common case untouched.
 		}
-		seen[line.short]++
-		line.short = fmt.Sprintf("%s (%d)", line.short, seen[line.short])
+		suffix := disambiguationSuffix(line.desc)
+		if suffix == "" || usedSuffixes[base][suffix] {
+			seen[base]++
+			suffix = fmt.Sprintf(" (%d)", seen[base])
+		}
+		if usedSuffixes[base] == nil {
+			usedSuffixes[base] = make(map[string]bool)
+		}
+		usedSuffixes[base][suffix] = true
+		line.short += suffix
+		line.coreShort += suffix
 	}
+}
+
+// buildMetricTypeSection collects one legendEntry per distinct (coreShort, desc) pair among a
+// single metric type's lines, deduplicating entries that describe the same metric across multiple
+// models, sorted by term then detail. Factored out of buildDescriptionEntries so Plot can compute
+// the same ordered list before calling runVizbLine, to assign matching swatch/chart colors (§Plot).
+func buildMetricTypeSection(lines []*plotLineInfo) []legendEntry {
+	type entry struct {
+		term, detail string
+	}
+	byKey := make(map[string]*entry, len(lines))
+	var order []string
+	for _, line := range lines {
+		key := line.coreShort + "\x00" + line.desc
+		if _, exists := byKey[key]; exists {
+			continue
+		}
+		byKey[key] = &entry{term: line.coreShort, detail: line.desc}
+		order = append(order, key)
+	}
+	entries := make([]legendEntry, len(order))
+	for i, key := range order {
+		e := byKey[key]
+		entries[i] = legendEntry{term: e.term, detail: e.detail}
+	}
+	slices.SortFunc(entries, func(a, b legendEntry) int {
+		if c := strings.Compare(a.term, b.term); c != 0 {
+			return c
+		}
+		return strings.Compare(a.detail, b.detail)
+	})
+	return entries
+}
+
+// buildDescriptionEntries groups the "Metric labels" sidebar entries (see buildMetricTypeSection)
+// into one legendSection per metric type, in first-encountered order -- so a reader looking at one
+// chart finds only that chart's labels under its own heading.
+func buildDescriptionEntries(allLines []*plotLineInfo) []legendSection {
+	var metricTypeOrder []string
+	byMetricType := make(map[string][]*plotLineInfo, len(allLines))
+	for _, line := range allLines {
+		if _, ok := byMetricType[line.metricType]; !ok {
+			metricTypeOrder = append(metricTypeOrder, line.metricType)
+		}
+		byMetricType[line.metricType] = append(byMetricType[line.metricType], line)
+	}
+	sections := make([]legendSection, len(metricTypeOrder))
+	for i, metricType := range metricTypeOrder {
+		sections[i] = legendSection{heading: metricType, entries: buildMetricTypeSection(byMetricType[metricType])}
+	}
+	return sections
 }
 
 // Plot the models' metrics points, using the `vizb` CLI tool: one dataset per metric type,
@@ -236,26 +319,34 @@ func (pb *PlotBuilder) Plot(checkpointPaths []string, modelNames []string, metri
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// One vizb DataSet JSON per metric type (e.g. "loss", "accuracy"). Also collect a short ->
-	// long description entry per line, for the legend box (see buildPageSidebarHTML).
+	// One vizb DataSet JSON per metric type. Also collect every line across every type, to build
+	// the sidebar from once the loop is done (see buildDescriptionEntries).
 	jsonPaths := make([]string, 0, len(metricTypes))
-	var descriptionEntries []legendEntry
+	var allLines []*plotLineInfo
 	for _, metricType := range metricTypes {
 		lines := createPlotLines(metricType, modelNames, metricsOrder, points, modelNamesToIndex)
 		disambiguateShortLabels(lines)
-		for _, line := range lines {
-			descriptionEntries = append(descriptionEntries, legendEntry{
-				modelIdx: line.modelIdx,
-				text:     fmt.Sprintf("%s: %s", line.short, line.desc),
-			})
+		allLines = append(allLines, lines...)
+
+		// Assign each distinct metric a swatch color (matching the order it'll appear in the
+		// sidebar, see buildMetricTypeSection), then look each line's color up by coreShort, so
+		// lines for the same metric (e.g. one per model) share a color.
+		colorByCoreShort := make(map[string]string, len(lines))
+		for i, entry := range buildMetricTypeSection(lines) {
+			colorByCoreShort[entry.term] = swatchColorHex(i)
 		}
-		jsonPath, err := runVizbLine(tmpDir, metricType, lines)
+		lineColors := make([]string, len(lines))
+		for i, line := range lines {
+			lineColors[i] = colorByCoreShort[line.coreShort]
+		}
+
+		jsonPath, err := runVizbLine(tmpDir, metricType, lines, lineColors)
 		if err != nil {
 			panic(errors.Wrapf(err, "failed to build vizb dataset for metric type %q", metricType))
 		}
 		jsonPaths = append(jsonPaths, jsonPath)
 	}
-	slices.SortFunc(descriptionEntries, func(a, b legendEntry) int { return strings.Compare(a.text, b.text) })
+	descriptionEntries := buildDescriptionEntries(allLines)
 
 	if err := mergeAndRenderVizb(tmpDir, jsonPaths, outputFilePath); err != nil {
 		panic(errors.Wrap(err, "failed to render plots with vizb"))
@@ -265,8 +356,8 @@ func (pb *PlotBuilder) Plot(checkpointPaths []string, modelNames []string, metri
 	if len(modelNames) > 1 {
 		for idx, name := range modelNames {
 			modelEntries = append(modelEntries, legendEntry{
-				modelIdx: idx,
-				text:     fmt.Sprintf("#%d %s (%s)", idx+1, name, checkpointPaths[idx]),
+				term:   fmt.Sprintf("%s %s", modelIndexMarker(idx+1), name),
+				detail: checkpointPaths[idx],
 			})
 		}
 	}
@@ -373,108 +464,159 @@ func injectAutoRefresh(htmlPath string, period time.Duration) error {
 // overlap it.
 const pageSidebarWidth = "300px"
 
-// pageSidebarCSS styles the sidebar purely through the id="gomlx-sidebar" selector (chosen to
-// not collide with anything vizb itself generates) plus a margin on #app -- vizb owns everything
-// inside #app itself (see injectPageExtras), so this never needs to know anything about its
-// internal structure, only that the id="app" element exists, which is stable across vizb
-// versions. It's a fixed, independently-scrolling column so a long metric-labels list never
-// pushes the actual charts below the fold -- collapses to a normal top block on narrow viewports.
+// pageSidebarCSS styles the sidebar purely through the id="gomlx-sidebar" selector plus a margin
+// on #app -- never anything about vizb's internal DOM, only that id="app" exists. A fixed,
+// independently-scrolling column so a long metric-labels list never pushes the charts below the
+// fold. Colors are the dataviz skill's validated colorblind-safe 8-hue palette, as custom
+// properties so light/dark mode switches automatically.
 const pageSidebarCSS = `
-#gomlx-sidebar{position:fixed;top:0;left:0;width:` + pageSidebarWidth + `;height:100vh;overflow-y:auto;
-box-sizing:border-box;padding:1em;font-family:sans-serif;font-size:0.85em;
-border-right:1px solid #ccc;background:#fafafa;z-index:1000}
-#gomlx-sidebar h1{font-size:1.1em;margin:0 0 0.6em 0}
-#gomlx-sidebar h2{font-size:0.95em;margin:1em 0 0.3em 0}
-#gomlx-sidebar ul{margin:0;padding-left:1.1em}
-#gomlx-sidebar li{margin-bottom:0.2em;word-break:break-word}
+#gomlx-sidebar{
+--gomlx-surface:#fcfcfb;--gomlx-text:#0b0b0b;--gomlx-text-secondary:#52514e;--gomlx-text-muted:#898781;
+--gomlx-border:rgba(11,11,11,0.10);
+--gomlx-series-1:#2a78d6;--gomlx-series-2:#eb6834;--gomlx-series-3:#1baf7a;--gomlx-series-4:#eda100;
+--gomlx-series-5:#e87ba4;--gomlx-series-6:#008300;--gomlx-series-7:#4a3aa7;--gomlx-series-8:#e34948;
+position:fixed;top:0;left:0;width:` + pageSidebarWidth + `;height:100vh;overflow-y:auto;box-sizing:border-box;
+padding:1.5em 1.25em;background:var(--gomlx-surface);color:var(--gomlx-text);
+font-family:system-ui,-apple-system,"Segoe UI",sans-serif;font-size:13px;line-height:1.45;
+border-right:1px solid var(--gomlx-border);z-index:1000}
+#gomlx-sidebar h1{font-size:1.05em;font-weight:600;margin:0 0 1em;letter-spacing:-0.01em}
+#gomlx-sidebar h2{font-size:0.72em;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;
+color:var(--gomlx-text-muted);margin:1.5em 0 0.7em;padding-top:1.1em;border-top:1px solid var(--gomlx-border)}
+#gomlx-sidebar h2:first-of-type{margin-top:0;padding-top:0;border-top:none}
+#gomlx-sidebar dl{margin:0}
+#gomlx-sidebar .gomlx-row{margin-bottom:0.9em}
+#gomlx-sidebar .gomlx-row:last-child{margin-bottom:0}
+#gomlx-sidebar dt{display:flex;align-items:center;gap:0.5em;font-weight:500;word-break:break-word}
+#gomlx-sidebar dt code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.92em}
+#gomlx-sidebar dd{margin:0.2em 0 0 1.15em;color:var(--gomlx-text-secondary);font-size:0.93em;word-break:break-word}
+#gomlx-sidebar dd code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.92em}
+#gomlx-sidebar .gomlx-swatch{flex:0 0 auto;width:0.6em;height:0.6em;border-radius:50%}
 #app{margin-left:` + pageSidebarWidth + `}
 @media (max-width:900px){
-#gomlx-sidebar{position:static;width:auto;height:auto;border-right:none;border-bottom:1px solid #ccc}
+#gomlx-sidebar{position:static;width:auto;height:auto;border-right:none;border-bottom:1px solid var(--gomlx-border)}
 #app{margin-left:0}
 }
 @media (prefers-color-scheme:dark){
-#gomlx-sidebar{background:#1e1e1e;border-color:#444;color:#eee}
+#gomlx-sidebar{
+--gomlx-surface:#1a1a19;--gomlx-text:#ffffff;--gomlx-text-secondary:#c3c2b7;--gomlx-text-muted:#898781;
+--gomlx-border:rgba(255,255,255,0.10);
+--gomlx-series-1:#3987e5;--gomlx-series-2:#d95926;--gomlx-series-3:#199e70;--gomlx-series-4:#c98500;
+--gomlx-series-5:#d55181;--gomlx-series-6:#008300;--gomlx-series-7:#9085e9;--gomlx-series-8:#e66767}
 }
 `
 
-// legendEntry is one row in a sidebar list. modelIdx (0-based index into the Plot call's
-// modelNames) selects which color swatch to show next to it -- see modelColor -- so entries
-// belonging to the same model are easy to spot at a glance; it's meaningless (ignored) in
-// single-model mode, where there's nothing to color-code against.
+// legendEntry is one row in a sidebar list: term is the short, scannable label (a model name, or
+// a metric's short code); detail is the longer text underneath it (a checkpoint path, or a
+// metric's full description).
 type legendEntry struct {
-	modelIdx int
-	text     string
+	term, detail string
 }
 
-// modelColorPalette assigns each compared model its own consistent color, shown as a swatch next
-// to every one of its entries in the sidebar (both "Models compared" and "Metric labels") -- the
-// Okabe-Ito colorblind-safe categorical palette. This intentionally does NOT try to match vizb's
-// own chart line colors: vizb's charts have their own live, in-browser theme switcher, so any
-// color we set at generation time could be changed by the viewer at any moment -- the sidebar
-// swatches are a self-contained, always-correct way to group entries by model, independent of
-// whatever chart colors/theme the viewer currently has selected.
-var modelColorPalette = []string{
-	"#0072B2", // blue
-	"#E69F00", // orange
-	"#009E73", // green
-	"#D55E00", // vermillion
-	"#CC79A7", // purple
-	"#56B4E9", // sky blue
+// legendSection is one heading plus its rows in the sidebar -- e.g. one metric type's ("loss",
+// "img_loss", ...) glossary group within "Metric labels" (see buildDescriptionEntries), so a
+// reader looking at one chart finds only that chart's labels under their own heading.
+type legendSection struct {
+	heading string
+	entries []legendEntry
 }
 
-// modelColor returns a stable, distinct color for modelIdx (0-based), cycling through
-// modelColorPalette if there are more models than palette entries.
-func modelColor(modelIdx int) string {
-	return modelColorPalette[modelIdx%len(modelColorPalette)]
+// swatchPalette is the fixed, colorblind-safe 8-hue categorical order (validated via the dataviz
+// skill) used to color every "Metric labels" row -- each row gets its own color, matching vizb's
+// own chart line for that metric (see swatchColorHex and Plot), not a color tied to model identity.
+var swatchPalette = []string{
+	"blue", "orange", "aqua", "yellow", "magenta", "green", "violet", "red",
 }
 
-// buildPageSidebarHTML renders the optional visible title heading and, when there's anything to
-// show, the models-compared list and the metric short-label -> long-description list, as one
-// <div id="gomlx-sidebar"> fragment (styled by pageSidebarCSS). Returns "" if there's nothing to
-// show at all -- the caller should skip injecting both this and pageSidebarCSS in that case.
+// swatchPaletteHex holds swatchPalette's literal light-step hex values, in the same order -- for
+// contexts needing a raw hex string instead of a CSS custom property (e.g. vizb's --theme flag).
+// Must stay in sync with the light-mode "--gomlx-series-N" values in pageSidebarCSS.
+var swatchPaletteHex = []string{
+	"#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4", "#008300", "#4a3aa7", "#e34948",
+}
+
+// swatchColor returns the CSS custom property (see pageSidebarCSS) holding rowIdx's (0-based)
+// color slot, cycling through swatchPalette if there are more rows than slots.
+func swatchColor(rowIdx int) string {
+	return fmt.Sprintf("var(--gomlx-series-%d)", rowIdx%len(swatchPalette)+1)
+}
+
+// swatchColorHex returns the literal hex color (see swatchPaletteHex) for rowIdx's (0-based) slot,
+// cycling if there are more rows than slots -- the hex-string counterpart of swatchColor, for
+// contexts (like vizb's --theme flag) that need a raw color rather than a CSS custom property.
+func swatchColorHex(rowIdx int) string {
+	return swatchPaletteHex[rowIdx%len(swatchPaletteHex)]
+}
+
+// buildPageSidebarHTML renders the optional title heading, the models-compared list, and one
+// "Metric labels — <type>" section per metric type (see buildDescriptionEntries), as one
+// <div id="gomlx-sidebar"> fragment. Returns "" if there's nothing to show.
 //
-// Each entry gets a color swatch matching its model (see modelColor), but only when modelEntries
-// is non-empty -- i.e. only in multi-model mode, where there's actually something to distinguish;
-// single-model mode shows plain entries, matching today's simpler common case.
-func buildPageSidebarHTML(title string, modelEntries, descriptionEntries []legendEntry) string {
-	if title == "" && len(modelEntries) == 0 && len(descriptionEntries) == 0 {
+// Each list is a <dl>: term (model name, or a metric's short code, code-formatted) paired with
+// detail underneath (checkpoint path, or the metric's long description). "Metric labels" rows get
+// a color swatch matching vizb's chart line for that metric (see Plot); "Models compared" rows
+// deliberately don't, since the ❶/❷ marker already identifies each model and reusing the palette
+// there would coincidentally match an unrelated metric's color.
+func buildPageSidebarHTML(title string, modelEntries []legendEntry, descriptionSections []legendSection) string {
+	hasDescriptions := false
+	for _, section := range descriptionSections {
+		if len(section.entries) > 0 {
+			hasDescriptions = true
+			break
+		}
+	}
+	if title == "" && len(modelEntries) == 0 && !hasDescriptions {
 		return ""
 	}
-	showSwatches := len(modelEntries) > 0
 	var b strings.Builder
 	b.WriteString(`<div id="gomlx-sidebar">`)
 	if title != "" {
 		fmt.Fprintf(&b, `<h1>%s</h1>`, html.EscapeString(title))
 	}
-	writeList := func(heading string, entries []legendEntry) {
+	wrap := func(s string, asCode bool) string {
+		escaped := html.EscapeString(s)
+		if asCode {
+			return "<code>" + escaped + "</code>"
+		}
+		return escaped
+	}
+	writeList := func(heading string, entries []legendEntry, codeTerm, codeDetail, showSwatch bool) {
 		if len(entries) == 0 {
 			return
 		}
-		fmt.Fprintf(&b, `<h2>%s</h2><ul>`, html.EscapeString(heading))
-		for _, entry := range entries {
-			if showSwatches {
-				fmt.Fprintf(&b, `<li><span style="display:inline-block;width:0.8em;height:0.8em;`+
-					`border-radius:50%%;background:%s;margin-right:0.4em;vertical-align:middle"></span>%s</li>`,
-					modelColor(entry.modelIdx), html.EscapeString(entry.text))
-			} else {
-				fmt.Fprintf(&b, `<li>%s</li>`, html.EscapeString(entry.text))
+		fmt.Fprintf(&b, `<h2>%s</h2><dl>`, html.EscapeString(heading))
+		for i, entry := range entries {
+			b.WriteString(`<div class="gomlx-row"><dt>`)
+			if showSwatch {
+				fmt.Fprintf(&b, `<span class="gomlx-swatch" style="background:%s"></span>`, swatchColor(i))
 			}
+			b.WriteString(wrap(entry.term, codeTerm))
+			b.WriteString(`</dt>`)
+			if entry.detail != "" {
+				b.WriteString(`<dd>`)
+				b.WriteString(wrap(entry.detail, codeDetail))
+				b.WriteString(`</dd>`)
+			}
+			b.WriteString(`</div>`)
 		}
-		b.WriteString(`</ul>`)
+		b.WriteString(`</dl>`)
 	}
-	writeList("Models compared", modelEntries)
-	writeList("Metric labels", descriptionEntries)
+	writeList("Models compared", modelEntries, false, true, false) // no swatch, see doc comment above.
+	for _, section := range descriptionSections {
+		writeList("Metric labels — "+section.heading, section.entries, true, false, true)
+	}
 	b.WriteString(`</div>`)
 	return b.String()
 }
 
-// injectPageExtras adds an optional page <title> and, if there's anything to show, a sidebar
-// (see buildPageSidebarHTML/pageSidebarCSS) alongside vizb's own charts -- the sidebar is
-// inserted right after <body>, before vizb's own <div id="app">, which its client-side JS fully
-// owns and replaces on load (confirmed by inspecting the page's skeleton markup), so it survives
-// untouched once the page hydrates; the CSS goes in <head>, styling #app purely by id so it never
-// needs to know anything about vizb's internal DOM structure.
-func injectPageExtras(htmlPath, title string, modelEntries, descriptionEntries []legendEntry) error {
+// injectPageExtras adds an optional page <title> and, if there's anything to show, a sidebar (see
+// buildPageSidebarHTML/pageSidebarCSS) right after <body>, before vizb's own <div id="app">, which
+// its client-side JS fully owns and replaces on load -- so the sidebar survives untouched once the
+// page hydrates.
+//
+// Note: a hover-tooltip on vizb's own chart legend was investigated and deliberately not built --
+// vizb's legend renders onto a <canvas>, not real DOM, so a title-attribute tooltip can never fire
+// on it. The sidebar's "Metric labels" list is the answer to "see the full name" instead.
+func injectPageExtras(htmlPath, title string, modelEntries []legendEntry, descriptionSections []legendSection) error {
 	content, err := os.ReadFile(htmlPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read %q", htmlPath)
@@ -487,7 +629,7 @@ func injectPageExtras(htmlPath, title string, modelEntries, descriptionEntries [
 		content = bytes.Replace(content, []byte("<title>Vizb</title>"), []byte("<title>"+html.EscapeString(title)+"</title>"), 1)
 	}
 
-	sidebar := buildPageSidebarHTML(title, modelEntries, descriptionEntries)
+	sidebar := buildPageSidebarHTML(title, modelEntries, descriptionSections)
 	if sidebar == "" {
 		return os.WriteFile(htmlPath, content, 0644)
 	}

--- a/cmd/gomlx_checkpoints/plots.go
+++ b/cmd/gomlx_checkpoints/plots.go
@@ -6,12 +6,14 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"html"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gomlx/compute/support/xslices"
@@ -33,6 +35,9 @@ var (
 		"If empty (the default), a random path in the OS temp dir is picked once and reused for the "+
 		"rest of the session -- so repeated runs (e.g. under -loop) overwrite the same file instead "+
 		"of accumulating a new one each time.")
+	flagPlotTitle = flag.String("plot_title", "", "Optional title for the generated plots page: "+
+		"shown in the browser tab and as a heading atop the page. Handy when sharing the plot file "+
+		"with others.")
 )
 
 // PlotBuilder renders training metrics to a self-contained HTML file using the `vizb` CLI tool,
@@ -51,6 +56,7 @@ type PlotBuilder struct {
 	openBrowser    bool
 	outputOverride string        // corresponds to -plot_output; if empty, a random path is picked once (see cachedOutputPath) and reused.
 	loopPeriod     time.Duration // corresponds to -loop; > 0 enables the auto-refresh <meta> tag.
+	plotTitle      string        // corresponds to -plot_title; if empty, no title is added.
 
 	// Session state, mutated across repeated Plot calls.
 	browserOpenedOnce bool
@@ -63,11 +69,12 @@ type PlotBuilder struct {
 // Plot is called on it -- e.g. once per -loop iteration, in which case the resulting PlotBuilder
 // must be created once and reused for every iteration, not recreated each time, since that's what
 // makes the output path stable and the browser tab open only once.
-func NewPlotBuilder(openBrowser bool, outputOverride string, loopPeriod time.Duration) *PlotBuilder {
+func NewPlotBuilder(openBrowser bool, outputOverride string, loopPeriod time.Duration, plotTitle string) *PlotBuilder {
 	return &PlotBuilder{
 		openBrowser:    openBrowser,
 		outputOverride: outputOverride,
 		loopPeriod:     loopPeriod,
+		plotTitle:      plotTitle,
 	}
 }
 
@@ -87,8 +94,17 @@ func createSortedMetricTypes(metricsOrder map[ModelNameAndMetric]int) []string {
 }
 
 // plotLineInfo contains the information for a single line in a plot.
+//
+// short becomes the line's series label passed to vizb (`--select step,colN{short}`) -- vizb
+// groups series by this label, so it must be unique among the lines of one metric type (see
+// disambiguateShortLabels). desc is the long-form description shown in the legend box (e.g.
+// "Train: Moving Average Loss" or "Mean Loss on train for model \"model-a\"") -- unlike short, it
+// doesn't need to be unique. modelIdx (0-based index into the Plot call's modelNames) is used to
+// color-code this line's legend entry so lines belonging to the same model are easy to spot in
+// the sidebar at a glance -- see modelColor.
 type plotLineInfo struct {
 	short, desc   string
+	modelIdx      int
 	steps, values []float64
 }
 
@@ -120,13 +136,13 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 			}
 			info, exists := metricPoints[pt.MetricName]
 			if !exists {
-				info = &plotLineInfo{}
+				info = &plotLineInfo{modelIdx: modelIdx}
 				if len(modelNames) == 1 {
 					info.short = pt.Short
-					info.desc = fmt.Sprintf("%s: %s", pt.Short, pt.MetricName)
+					info.desc = pt.MetricName
 				} else {
 					info.short = fmt.Sprintf("#%d %s", modelNum, pt.Short)
-					info.desc = fmt.Sprintf("%s: %s for model %q", info.short, pt.MetricName, modelName)
+					info.desc = fmt.Sprintf("%s for model %q", pt.MetricName, modelName)
 				}
 			}
 			info.steps = append(info.steps, pt.Step)
@@ -167,6 +183,28 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 	return lines
 }
 
+// disambiguateShortLabels ensures every line's short is unique within one metric type's line
+// set -- vizb's chart renderer groups series by this label (the "type" field in its DataSet
+// JSON), so two different metrics sharing an identical Short (e.g. when a training script's eval
+// dataset doesn't provide a distinguishing ShortName -- confirmed to happen in practice) would
+// otherwise silently collide into what the user perceives as one series instead of two, which is
+// exactly what makes it look like same-metric-type lines (e.g. train vs validation loss) aren't
+// being plotted together correctly.
+func disambiguateShortLabels(lines []*plotLineInfo) {
+	counts := make(map[string]int, len(lines))
+	for _, line := range lines {
+		counts[line.short]++
+	}
+	seen := make(map[string]int, len(lines))
+	for _, line := range lines {
+		if counts[line.short] <= 1 {
+			continue // No collision: leave the common case untouched.
+		}
+		seen[line.short]++
+		line.short = fmt.Sprintf("%s (%d)", line.short, seen[line.short])
+	}
+}
+
 // Plot the models' metrics points, using the `vizb` CLI tool: one dataset per metric type,
 // combined into a single self-contained HTML file. Safe to call repeatedly on the same
 // PlotBuilder (e.g. once per -loop iteration) -- see PlotBuilder's doc comment.
@@ -198,19 +236,44 @@ func (pb *PlotBuilder) Plot(checkpointPaths []string, modelNames []string, metri
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// One vizb DataSet JSON per metric type (e.g. "loss", "accuracy").
+	// One vizb DataSet JSON per metric type (e.g. "loss", "accuracy"). Also collect a short ->
+	// long description entry per line, for the legend box (see buildPageSidebarHTML).
 	jsonPaths := make([]string, 0, len(metricTypes))
+	var descriptionEntries []legendEntry
 	for _, metricType := range metricTypes {
 		lines := createPlotLines(metricType, modelNames, metricsOrder, points, modelNamesToIndex)
+		disambiguateShortLabels(lines)
+		for _, line := range lines {
+			descriptionEntries = append(descriptionEntries, legendEntry{
+				modelIdx: line.modelIdx,
+				text:     fmt.Sprintf("%s: %s", line.short, line.desc),
+			})
+		}
 		jsonPath, err := runVizbLine(tmpDir, metricType, lines)
 		if err != nil {
 			panic(errors.Wrapf(err, "failed to build vizb dataset for metric type %q", metricType))
 		}
 		jsonPaths = append(jsonPaths, jsonPath)
 	}
+	slices.SortFunc(descriptionEntries, func(a, b legendEntry) int { return strings.Compare(a.text, b.text) })
 
 	if err := mergeAndRenderVizb(tmpDir, jsonPaths, outputFilePath); err != nil {
 		panic(errors.Wrap(err, "failed to render plots with vizb"))
+	}
+
+	var modelEntries []legendEntry
+	if len(modelNames) > 1 {
+		for idx, name := range modelNames {
+			modelEntries = append(modelEntries, legendEntry{
+				modelIdx: idx,
+				text:     fmt.Sprintf("#%d %s (%s)", idx+1, name, checkpointPaths[idx]),
+			})
+		}
+	}
+	if err := injectPageExtras(outputFilePath, pb.plotTitle, modelEntries, descriptionEntries); err != nil {
+		// Not fatal: the plots are still written and viewable, just without the title/legend
+		// boxes -- the underlying chart data is unaffected.
+		klog.Warningf("Failed to inject title/legend into %s: %v", outputFilePath, err)
 	}
 	pb.hasRenderedOnce = true
 	pb.lastRenderModTime = currentModTime
@@ -301,6 +364,141 @@ func injectAutoRefresh(htmlPath string, period time.Duration) error {
 	updated := bytes.Replace(content, []byte("<head>"), []byte("<head>"+metaTag), 1)
 	if bytes.Equal(updated, content) {
 		return errors.Errorf("could not find a <head> tag to inject auto-refresh into")
+	}
+	return os.WriteFile(htmlPath, updated, 0644)
+}
+
+// pageSidebarWidth is how much horizontal space the injected sidebar (see buildPageSidebarHTML)
+// reserves for itself; vizb's own content (#app) gets an equal left margin so the sidebar doesn't
+// overlap it.
+const pageSidebarWidth = "300px"
+
+// pageSidebarCSS styles the sidebar purely through the id="gomlx-sidebar" selector (chosen to
+// not collide with anything vizb itself generates) plus a margin on #app -- vizb owns everything
+// inside #app itself (see injectPageExtras), so this never needs to know anything about its
+// internal structure, only that the id="app" element exists, which is stable across vizb
+// versions. It's a fixed, independently-scrolling column so a long metric-labels list never
+// pushes the actual charts below the fold -- collapses to a normal top block on narrow viewports.
+const pageSidebarCSS = `
+#gomlx-sidebar{position:fixed;top:0;left:0;width:` + pageSidebarWidth + `;height:100vh;overflow-y:auto;
+box-sizing:border-box;padding:1em;font-family:sans-serif;font-size:0.85em;
+border-right:1px solid #ccc;background:#fafafa;z-index:1000}
+#gomlx-sidebar h1{font-size:1.1em;margin:0 0 0.6em 0}
+#gomlx-sidebar h2{font-size:0.95em;margin:1em 0 0.3em 0}
+#gomlx-sidebar ul{margin:0;padding-left:1.1em}
+#gomlx-sidebar li{margin-bottom:0.2em;word-break:break-word}
+#app{margin-left:` + pageSidebarWidth + `}
+@media (max-width:900px){
+#gomlx-sidebar{position:static;width:auto;height:auto;border-right:none;border-bottom:1px solid #ccc}
+#app{margin-left:0}
+}
+@media (prefers-color-scheme:dark){
+#gomlx-sidebar{background:#1e1e1e;border-color:#444;color:#eee}
+}
+`
+
+// legendEntry is one row in a sidebar list. modelIdx (0-based index into the Plot call's
+// modelNames) selects which color swatch to show next to it -- see modelColor -- so entries
+// belonging to the same model are easy to spot at a glance; it's meaningless (ignored) in
+// single-model mode, where there's nothing to color-code against.
+type legendEntry struct {
+	modelIdx int
+	text     string
+}
+
+// modelColorPalette assigns each compared model its own consistent color, shown as a swatch next
+// to every one of its entries in the sidebar (both "Models compared" and "Metric labels") -- the
+// Okabe-Ito colorblind-safe categorical palette. This intentionally does NOT try to match vizb's
+// own chart line colors: vizb's charts have their own live, in-browser theme switcher, so any
+// color we set at generation time could be changed by the viewer at any moment -- the sidebar
+// swatches are a self-contained, always-correct way to group entries by model, independent of
+// whatever chart colors/theme the viewer currently has selected.
+var modelColorPalette = []string{
+	"#0072B2", // blue
+	"#E69F00", // orange
+	"#009E73", // green
+	"#D55E00", // vermillion
+	"#CC79A7", // purple
+	"#56B4E9", // sky blue
+}
+
+// modelColor returns a stable, distinct color for modelIdx (0-based), cycling through
+// modelColorPalette if there are more models than palette entries.
+func modelColor(modelIdx int) string {
+	return modelColorPalette[modelIdx%len(modelColorPalette)]
+}
+
+// buildPageSidebarHTML renders the optional visible title heading and, when there's anything to
+// show, the models-compared list and the metric short-label -> long-description list, as one
+// <div id="gomlx-sidebar"> fragment (styled by pageSidebarCSS). Returns "" if there's nothing to
+// show at all -- the caller should skip injecting both this and pageSidebarCSS in that case.
+//
+// Each entry gets a color swatch matching its model (see modelColor), but only when modelEntries
+// is non-empty -- i.e. only in multi-model mode, where there's actually something to distinguish;
+// single-model mode shows plain entries, matching today's simpler common case.
+func buildPageSidebarHTML(title string, modelEntries, descriptionEntries []legendEntry) string {
+	if title == "" && len(modelEntries) == 0 && len(descriptionEntries) == 0 {
+		return ""
+	}
+	showSwatches := len(modelEntries) > 0
+	var b strings.Builder
+	b.WriteString(`<div id="gomlx-sidebar">`)
+	if title != "" {
+		fmt.Fprintf(&b, `<h1>%s</h1>`, html.EscapeString(title))
+	}
+	writeList := func(heading string, entries []legendEntry) {
+		if len(entries) == 0 {
+			return
+		}
+		fmt.Fprintf(&b, `<h2>%s</h2><ul>`, html.EscapeString(heading))
+		for _, entry := range entries {
+			if showSwatches {
+				fmt.Fprintf(&b, `<li><span style="display:inline-block;width:0.8em;height:0.8em;`+
+					`border-radius:50%%;background:%s;margin-right:0.4em;vertical-align:middle"></span>%s</li>`,
+					modelColor(entry.modelIdx), html.EscapeString(entry.text))
+			} else {
+				fmt.Fprintf(&b, `<li>%s</li>`, html.EscapeString(entry.text))
+			}
+		}
+		b.WriteString(`</ul>`)
+	}
+	writeList("Models compared", modelEntries)
+	writeList("Metric labels", descriptionEntries)
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// injectPageExtras adds an optional page <title> and, if there's anything to show, a sidebar
+// (see buildPageSidebarHTML/pageSidebarCSS) alongside vizb's own charts -- the sidebar is
+// inserted right after <body>, before vizb's own <div id="app">, which its client-side JS fully
+// owns and replaces on load (confirmed by inspecting the page's skeleton markup), so it survives
+// untouched once the page hydrates; the CSS goes in <head>, styling #app purely by id so it never
+// needs to know anything about vizb's internal DOM structure.
+func injectPageExtras(htmlPath, title string, modelEntries, descriptionEntries []legendEntry) error {
+	content, err := os.ReadFile(htmlPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %q", htmlPath)
+	}
+
+	if title != "" {
+		// Best-effort: if vizb's default <title> text ever changes, just skip updating the
+		// browser tab's title -- the visible <h1> heading in the sidebar is what matters most,
+		// and doesn't depend on this succeeding.
+		content = bytes.Replace(content, []byte("<title>Vizb</title>"), []byte("<title>"+html.EscapeString(title)+"</title>"), 1)
+	}
+
+	sidebar := buildPageSidebarHTML(title, modelEntries, descriptionEntries)
+	if sidebar == "" {
+		return os.WriteFile(htmlPath, content, 0644)
+	}
+
+	withCSS := bytes.Replace(content, []byte("<head>"), []byte("<head><style>"+pageSidebarCSS+"</style>"), 1)
+	if bytes.Equal(withCSS, content) {
+		return errors.Errorf("could not find a <head> tag to inject the sidebar's CSS into")
+	}
+	updated := bytes.Replace(withCSS, []byte("<body>"), []byte("<body>"+sidebar), 1)
+	if bytes.Equal(updated, withCSS) {
+		return errors.Errorf("could not find a <body> tag to inject the sidebar into")
 	}
 	return os.WriteFile(htmlPath, updated, 0644)
 }

--- a/cmd/gomlx_checkpoints/plots.go
+++ b/cmd/gomlx_checkpoints/plots.go
@@ -41,9 +41,14 @@ var (
 )
 
 // PlotBuilder renders training metrics to a self-contained HTML file using the `vizb` CLI tool,
-// across possibly many calls to Plot within one process (e.g. once per -loop iteration). Holds
-// session state as fields rather than package-level variables, so tests can construct their own
-// instance and run in parallel without leaking state into each other.
+// across possibly many calls to Plot within one process (e.g. once per -loop iteration).
+//
+// It exists (rather than a handful of package-level variables) so that: (1) every test can
+// construct its own PlotBuilder and run in parallel, with no risk of one test's state leaking
+// into another's; (2) the session state it carries -- has a plot ever been rendered yet, has the
+// browser tab already been opened, what output path and last-render time are we using -- is
+// visible in one place instead of scattered across the package; and (3) nothing stops two
+// PlotBuilders (say, one per session in some future server-like use) from existing side by side.
 //
 // Construct one with NewPlotBuilder and call Plot as many times as needed.
 type PlotBuilder struct {
@@ -122,7 +127,7 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 	for modelIdx, modelPoints := range points {
 		modelName := modelNames[modelIdx]
 		modelNum := modelNamesToIndex[modelName]
-
+		// Group points by metric name.
 		metricPoints := make(map[string]*plotLineInfo)
 		for _, pt := range modelPoints {
 			if pt.MetricType != metricType {
@@ -134,6 +139,7 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 				MetricType: pt.MetricType,
 			}
 			if _, ok := metricsOrder[metricKey]; !ok {
+				// Metric was not selected, skip.
 				continue
 			}
 			info, exists := metricPoints[pt.MetricName]
@@ -150,8 +156,11 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 			metricPoints[pt.MetricName] = info
 		}
 
+		// Sort points by steps.
 		for _, info := range metricPoints {
+			// Create the indices array.
 			indices := xslices.Iota(0, len(info.steps))
+			// Sort indices.
 			slices.SortFunc(indices, func(i, j int) int {
 				if info.steps[i] < info.steps[j] {
 					return -1
@@ -161,6 +170,7 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 				}
 				return 0
 			})
+			// Apply sorted order.
 			steps := make([]float64, len(info.steps))
 			values := make([]float64, len(info.values))
 			for ii, idx := range indices {
@@ -171,6 +181,7 @@ func createPlotLines(metricType string, modelNames []string, metricsOrder map[Mo
 			info.values = values
 		}
 
+		// Collect all lines.
 		for _, info := range metricPoints {
 			lines = append(lines, info)
 		}
@@ -319,8 +330,8 @@ func (pb *PlotBuilder) Plot(checkpointPaths []string, modelNames []string, metri
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// One vizb DataSet JSON per metric type. Also collect every line across every type, to build
-	// the sidebar from once the loop is done (see buildDescriptionEntries).
+	// One vizb DataSet JSON per metric type (e.g. "loss", "accuracy"). Also collect every line
+	// across every type, to build the sidebar from once the loop is done (see buildDescriptionEntries).
 	jsonPaths := make([]string, 0, len(metricTypes))
 	var allLines []*plotLineInfo
 	for _, metricType := range metricTypes {

--- a/cmd/gomlx_checkpoints/plots_test.go
+++ b/cmd/gomlx_checkpoints/plots_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestResolveOutputFilePath_DefaultIsStableWithinASession(t *testing.T) {
 	t.Parallel()
-	pb := NewPlotBuilder(false, "", 0)
+	pb := NewPlotBuilder(false, "", 0, "")
 	checkpointPaths := []string{"/home/user/mnist_data/checkpoint"}
 
 	// Calling it twice must return the exact same path -- that's the whole
@@ -30,7 +30,7 @@ func TestResolveOutputFilePath_DefaultIsStableWithinASession(t *testing.T) {
 
 func TestResolveOutputFilePath_CacheIgnoresCheckpointPathsArgument(t *testing.T) {
 	t.Parallel()
-	pb := NewPlotBuilder(false, "", 0)
+	pb := NewPlotBuilder(false, "", 0, "")
 
 	// Once cached, the *same PlotBuilder* reuses the same path regardless of
 	// what checkpointPaths is passed on a later call -- correct, because in
@@ -44,7 +44,7 @@ func TestResolveOutputFilePath_CacheIgnoresCheckpointPathsArgument(t *testing.T)
 
 func TestResolveOutputFilePath_ExplicitRelativePath(t *testing.T) {
 	t.Parallel()
-	pb := NewPlotBuilder(false, "plot.html", 0)
+	pb := NewPlotBuilder(false, "plot.html", 0, "")
 	got := pb.resolveOutputFilePath([]string{"/checkpoints/model-a"})
 	require.Equal(t, "/checkpoints/model-a/plot.html", got)
 }
@@ -57,7 +57,7 @@ func TestResolveOutputFilePath_ExplicitAbsolutePath(t *testing.T) {
 	// Windows CI runner -- t.TempDir() is a real absolute path on whichever OS
 	// the test is running on.
 	absPath := filepath.Join(t.TempDir(), "my-plot.html")
-	pb := NewPlotBuilder(false, absPath, 0)
+	pb := NewPlotBuilder(false, absPath, 0, "")
 	got := pb.resolveOutputFilePath([]string{"/checkpoints/model-a"})
 	require.Equal(t, absPath, got)
 }
@@ -135,5 +135,183 @@ func TestInjectAutoRefresh_NoHeadTagReturnsError(t *testing.T) {
 	require.NoError(t, os.WriteFile(htmlPath, []byte("<html><body>no head here</body></html>"), 0644))
 
 	err := injectAutoRefresh(htmlPath, 30*time.Second)
+	require.Error(t, err)
+}
+
+// TestDisambiguateShortLabels_NoCollision characterizes the common case: when every line's
+// short is already unique within the metric type, nothing changes.
+func TestDisambiguateShortLabels_NoCollision(t *testing.T) {
+	t.Parallel()
+	lines := []*plotLineInfo{
+		{short: "T/loss"},
+		{short: "T/~loss"},
+	}
+	disambiguateShortLabels(lines)
+	require.Equal(t, "T/loss", lines[0].short)
+	require.Equal(t, "T/~loss", lines[1].short)
+}
+
+// TestDisambiguateShortLabels_Collision reproduces the real bug found in the maintainer's
+// FlowMatching fixture: "Mean Loss on train" and "Mean Loss on validation" both produce the
+// Short "#loss()" (their eval dataset's ShortName came out empty), so without disambiguation
+// they'd collide into a single series in vizb's chart (vizb groups by this label). Every line
+// must end up with a distinct short after the call.
+func TestDisambiguateShortLabels_Collision(t *testing.T) {
+	t.Parallel()
+	lines := []*plotLineInfo{
+		{short: "#loss()", desc: "Mean Loss on train"},
+		{short: "#loss()", desc: "Mean Loss on validation"},
+		{short: "T/loss", desc: "Train: Loss"}, // Unrelated, must be untouched.
+	}
+	disambiguateShortLabels(lines)
+
+	seen := make(map[string]bool)
+	for _, line := range lines {
+		require.False(t, seen[line.short], "short %q is not unique after disambiguation", line.short)
+		seen[line.short] = true
+	}
+	require.Equal(t, "T/loss", lines[2].short, "non-colliding line must be left untouched")
+	require.Contains(t, lines[0].short, "#loss()")
+	require.Contains(t, lines[1].short, "#loss()")
+}
+
+// TestDisambiguateShortLabels_ThreeWayCollision checks the disambiguation counter handles more
+// than two lines sharing the same short.
+func TestDisambiguateShortLabels_ThreeWayCollision(t *testing.T) {
+	t.Parallel()
+	lines := []*plotLineInfo{
+		{short: "x"}, {short: "x"}, {short: "x"},
+	}
+	disambiguateShortLabels(lines)
+	seen := make(map[string]bool)
+	for _, line := range lines {
+		require.False(t, seen[line.short])
+		seen[line.short] = true
+	}
+}
+
+func TestBuildPageSidebarHTML_EmptyWhenNothingToShow(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, buildPageSidebarHTML("", nil, nil))
+}
+
+func TestBuildPageSidebarHTML_TitleOnly(t *testing.T) {
+	t.Parallel()
+	got := buildPageSidebarHTML("My Title", nil, nil)
+	require.Contains(t, got, `id="gomlx-sidebar"`)
+	require.Contains(t, got, "<h1")
+	require.Contains(t, got, "My Title")
+	require.NotContains(t, got, "Models compared")
+}
+
+func TestBuildPageSidebarHTML_EscapesUserContent(t *testing.T) {
+	t.Parallel()
+	got := buildPageSidebarHTML(`<script>alert(1)</script>`, []legendEntry{{text: `<b>evil</b>`}}, nil)
+	require.NotContains(t, got, "<script>")
+	require.NotContains(t, got, "<b>evil</b>")
+	require.Contains(t, got, "&lt;script&gt;")
+}
+
+func TestBuildPageSidebarHTML_ModelsAndDescriptions(t *testing.T) {
+	t.Parallel()
+	got := buildPageSidebarHTML("",
+		[]legendEntry{{modelIdx: 0, text: "#1 model-a (path/a)"}, {modelIdx: 1, text: "#2 model-b (path/b)"}},
+		[]legendEntry{{modelIdx: 0, text: "T/loss: Train: Loss"}})
+	require.Contains(t, got, "Models compared")
+	require.Contains(t, got, "#1 model-a (path/a)")
+	require.Contains(t, got, "Metric labels")
+	require.Contains(t, got, "T/loss: Train: Loss")
+}
+
+// TestBuildPageSidebarHTML_SwatchesOnlyInMultiModelMode characterizes that color swatches (a
+// small colored <span>) only appear when modelEntries is non-empty -- single-model mode has
+// nothing to color-code against, so entries stay plain, matching today's simpler common case.
+func TestBuildPageSidebarHTML_SwatchesOnlyInMultiModelMode(t *testing.T) {
+	t.Parallel()
+	singleModel := buildPageSidebarHTML("", nil, []legendEntry{{text: "T/loss: Train: Loss"}})
+	require.NotContains(t, singleModel, "border-radius:50%")
+
+	multiModel := buildPageSidebarHTML("",
+		[]legendEntry{{modelIdx: 0, text: "#1 model-a"}},
+		[]legendEntry{{modelIdx: 0, text: "T/loss: Train: Loss"}})
+	require.Contains(t, multiModel, "border-radius:50%")
+	require.Contains(t, multiModel, modelColor(0))
+}
+
+func TestModelColor_DistinctAndStable(t *testing.T) {
+	t.Parallel()
+	require.NotEqual(t, modelColor(0), modelColor(1))
+	require.Equal(t, modelColor(0), modelColor(0))
+	// Cycles once we run out of palette entries, rather than panicking.
+	require.NotPanics(t, func() { modelColor(len(modelColorPalette) + 3) })
+}
+
+func TestInjectPageExtras_NoOpWhenNothingToInject(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "plot.html")
+	original := "<html><head><title>Vizb</title></head><body><div id=\"app\"></div></body></html>"
+	require.NoError(t, os.WriteFile(htmlPath, []byte(original), 0644))
+
+	require.NoError(t, injectPageExtras(htmlPath, "", nil, nil))
+
+	content, err := os.ReadFile(htmlPath)
+	require.NoError(t, err)
+	require.Equal(t, original, string(content))
+}
+
+func TestInjectPageExtras_TitleUpdatesTagAndInjectsHeading(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "plot.html")
+	require.NoError(t, os.WriteFile(htmlPath,
+		[]byte(`<html><head><title>Vizb</title></head><body><div id="app"></div></body></html>`), 0644))
+
+	require.NoError(t, injectPageExtras(htmlPath, "FlowMatching results", nil, nil))
+
+	content, err := os.ReadFile(htmlPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "<title>FlowMatching results</title>")
+	require.Contains(t, string(content), "#gomlx-sidebar")
+	// The sidebar must land before vizb's own <div id="app">, which its JS fully replaces, and
+	// the CSS giving #app room for the sidebar must land in <head>.
+	require.Regexp(t, `(?s)<style>.*#app\{margin-left:300px\}.*</style>.*<div id="gomlx-sidebar"><h1>FlowMatching results</h1>.*<div id="app">`,
+		string(content))
+}
+
+func TestInjectPageExtras_ModelsAndDescriptionsSurviveInBody(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "plot.html")
+	require.NoError(t, os.WriteFile(htmlPath,
+		[]byte(`<html><head><title>Vizb</title></head><body><div id="app"></div></body></html>`), 0644))
+
+	require.NoError(t, injectPageExtras(htmlPath, "",
+		[]legendEntry{{modelIdx: 0, text: "#1 model-a (dir-a)"}},
+		[]legendEntry{{modelIdx: 0, text: "T/loss: Train: Loss"}}))
+
+	content, err := os.ReadFile(htmlPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "#1 model-a (dir-a)")
+	require.Contains(t, string(content), "T/loss: Train: Loss")
+}
+
+func TestInjectPageExtras_NoHeadTagReturnsError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "plot.html")
+	require.NoError(t, os.WriteFile(htmlPath, []byte("<html>no head here<body><div id=\"app\"></div></body></html>"), 0644))
+
+	err := injectPageExtras(htmlPath, "", []legendEntry{{text: "#1 model-a (dir-a)"}}, nil)
+	require.Error(t, err)
+}
+
+func TestInjectPageExtras_NoBodyTagReturnsError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "plot.html")
+	require.NoError(t, os.WriteFile(htmlPath, []byte("<html><head><title>Vizb</title></head>no body here</html>"), 0644))
+
+	err := injectPageExtras(htmlPath, "", []legendEntry{{text: "#1 model-a (dir-a)"}}, nil)
 	require.Error(t, err)
 }

--- a/cmd/gomlx_checkpoints/plots_test.go
+++ b/cmd/gomlx_checkpoints/plots_test.go
@@ -5,9 +5,11 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gomlx/gomlx/ui/plot"
 	"github.com/stretchr/testify/require"
 )
 
@@ -138,6 +140,67 @@ func TestInjectAutoRefresh_NoHeadTagReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestPlot_SidebarReflectsCurrentMetricsAcrossRepeatedCalls characterizes the sidebar as dynamic
+// across repeated Plot calls on the same PlotBuilder (the -loop use case: one PlotBuilder, called
+// again each time training produces new metrics) -- it is NOT a live, in-browser element that
+// reacts to which chart the viewer currently has selected (investigated separately; not currently
+// built, see buildDescriptionEntries' per-metric-type grouping instead). What "dynamic" means
+// here specifically: each call to Plot regenerates the sidebar from that call's own metricsOrder
+// and points, so a metric type that only starts appearing partway through training (e.g. "loss"
+// alone at first, "img_loss" joining later) shows up in the very next render -- the sidebar never
+// gets stuck showing only what was true the first time Plot ran.
+func TestPlot_SidebarReflectsCurrentMetricsAcrossRepeatedCalls(t *testing.T) {
+	if err := checkVizbAvailable(); err != nil {
+		t.Skip("vizb not installed, skipping integration test:", err)
+	}
+	dir := t.TempDir()
+	metricsFile := filepath.Join(dir, plot.TrainingPlotFileName)
+	older := time.Now().Add(-time.Hour)
+	require.NoError(t, os.WriteFile(metricsFile, []byte("{}\n"), 0644))
+	require.NoError(t, os.Chtimes(metricsFile, older, older))
+
+	outPath := filepath.Join(dir, "plot.html")
+	pb := NewPlotBuilder(false, outPath, 0, "")
+	checkpointPaths := []string{dir}
+	modelNames := []string{"model"}
+
+	// First render: only "loss" has been logged so far (simulates early training).
+	lossOrder := map[ModelNameAndMetric]int{
+		{ModelName: "model", MetricName: "T/loss", MetricType: "loss"}: 0,
+	}
+	lossPoints := [][]plot.Point{{
+		{MetricName: "Train: Loss", Short: "T/loss", MetricType: "loss", Step: 0, Value: 0.9},
+	}}
+	pb.Plot(checkpointPaths, modelNames, lossOrder, lossPoints)
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "Metric labels — loss")
+	require.NotContains(t, string(content), "Metric labels — img_loss")
+
+	// The metrics file changes (a new metric type starts appearing) -- bump its mtime so Plot's
+	// caching guard (see PlotBuilder's doc comment) doesn't skip regenerating.
+	newer := time.Now()
+	require.NoError(t, os.Chtimes(metricsFile, newer, newer))
+
+	// Second render: "img_loss" has now joined "loss" (simulates training progressing).
+	allOrder := map[ModelNameAndMetric]int{
+		{ModelName: "model", MetricName: "T/loss", MetricType: "loss"}:         0,
+		{ModelName: "model", MetricName: "T/img_loss", MetricType: "img_loss"}: 1,
+	}
+	allPoints := [][]plot.Point{{
+		{MetricName: "Train: Loss", Short: "T/loss", MetricType: "loss", Step: 0, Value: 0.9},
+		{MetricName: "Train: Images Loss", Short: "T/img_loss", MetricType: "img_loss", Step: 0, Value: 0.5},
+	}}
+	pb.Plot(checkpointPaths, modelNames, allOrder, allPoints)
+
+	content, err = os.ReadFile(outPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "Metric labels — loss")
+	require.Contains(t, string(content), "Metric labels — img_loss",
+		"sidebar must pick up the newly-appeared metric type on the next render, not stay stuck with the first render's content")
+}
+
 // TestDisambiguateShortLabels_NoCollision characterizes the common case: when every line's
 // short is already unique within the metric type, nothing changes.
 func TestDisambiguateShortLabels_NoCollision(t *testing.T) {
@@ -151,17 +214,34 @@ func TestDisambiguateShortLabels_NoCollision(t *testing.T) {
 	require.Equal(t, "T/~loss", lines[1].short)
 }
 
+// findLineByDesc returns the line whose desc matches, failing the test if there isn't exactly
+// one -- disambiguateShortLabels sorts lines in place, so tests can't rely on index position to
+// identify a particular line after calling it.
+func findLineByDesc(t *testing.T, lines []*plotLineInfo, desc string) *plotLineInfo {
+	t.Helper()
+	var found *plotLineInfo
+	for _, line := range lines {
+		if line.desc == desc {
+			require.Nil(t, found, "more than one line with desc %q", desc)
+			found = line
+		}
+	}
+	require.NotNil(t, found, "no line with desc %q", desc)
+	return found
+}
+
 // TestDisambiguateShortLabels_Collision reproduces the real bug found in the maintainer's
 // FlowMatching fixture: "Mean Loss on train" and "Mean Loss on validation" both produce the
 // Short "#loss()" (their eval dataset's ShortName came out empty), so without disambiguation
 // they'd collide into a single series in vizb's chart (vizb groups by this label). Every line
-// must end up with a distinct short after the call.
+// must end up with a distinct short after the call, and coreShort must get the same suffix (used
+// later to dedupe the sidebar glossary across models -- see buildDescriptionEntries).
 func TestDisambiguateShortLabels_Collision(t *testing.T) {
 	t.Parallel()
 	lines := []*plotLineInfo{
-		{short: "#loss()", desc: "Mean Loss on train"},
-		{short: "#loss()", desc: "Mean Loss on validation"},
-		{short: "T/loss", desc: "Train: Loss"}, // Unrelated, must be untouched.
+		{short: "#loss()", coreShort: "#loss()", desc: "Mean Loss on train"},
+		{short: "#loss()", coreShort: "#loss()", desc: "Mean Loss on validation"},
+		{short: "T/loss", coreShort: "T/loss", desc: "Train: Loss"}, // Unrelated, must be untouched.
 	}
 	disambiguateShortLabels(lines)
 
@@ -169,10 +249,73 @@ func TestDisambiguateShortLabels_Collision(t *testing.T) {
 	for _, line := range lines {
 		require.False(t, seen[line.short], "short %q is not unique after disambiguation", line.short)
 		seen[line.short] = true
+		require.Equal(t, line.short, line.coreShort, "coreShort must get the same suffix as short")
 	}
-	require.Equal(t, "T/loss", lines[2].short, "non-colliding line must be left untouched")
-	require.Contains(t, lines[0].short, "#loss()")
-	require.Contains(t, lines[1].short, "#loss()")
+	require.Equal(t, "T/loss", findLineByDesc(t, lines, "Train: Loss").short, "non-colliding line must be left untouched")
+	// Prefers the desc-derived "(train)"/"(validation)" suffix over a bare numeric counter, since a
+	// bare "(1)"/"(2)" reads too easily as a per-model marker next to the ❶/❷ model-index markers
+	// used elsewhere in the sidebar.
+	require.Equal(t, "#loss() (train)", findLineByDesc(t, lines, "Mean Loss on train").short)
+	require.Equal(t, "#loss() (validation)", findLineByDesc(t, lines, "Mean Loss on validation").short)
+}
+
+// TestDisambiguateShortLabels_FallsBackToNumericWhenDescHasNoDataset covers descs that don't fit
+// the "<name> on <dataset>" shape disambiguationSuffix expects -- disambiguation must still make
+// every short unique, just via a plain numeric counter instead.
+func TestDisambiguateShortLabels_FallsBackToNumericWhenDescHasNoDataset(t *testing.T) {
+	t.Parallel()
+	lines := []*plotLineInfo{
+		{short: "x", coreShort: "x", desc: "Batch Accuracy"},
+		{short: "x", coreShort: "x", desc: "Moving Average Accuracy"},
+	}
+	disambiguateShortLabels(lines)
+
+	seen := make(map[string]bool)
+	for _, line := range lines {
+		require.False(t, seen[line.short], "short %q is not unique after disambiguation", line.short)
+		seen[line.short] = true
+		require.Regexp(t, `^x \(\d+\)$`, line.short)
+	}
+}
+
+// TestDisambiguateShortLabels_ConsistentAcrossModels is the regression test for the ordering bug
+// found while implementing cross-model glossary deduplication: two "models" (❶/❷-prefixed short,
+// simulating createPlotLines' output) each have their own train/validation collision on the same
+// underlying metric. Without a deterministic sort first, Go's randomized map iteration order in
+// createPlotLines could assign mismatched suffixes (e.g. model ❶'s train getting one suffix while
+// model ❷'s train gets another), which would silently break buildDescriptionEntries' (coreShort,
+// desc) matching. The same desc must always get the same suffix, regardless of model.
+func TestDisambiguateShortLabels_ConsistentAcrossModels(t *testing.T) {
+	t.Parallel()
+	// Deliberately in a shuffled order that doesn't match desc's alphabetical order, to exercise
+	// the internal sort rather than accidentally pass due to already-sorted input.
+	lines := []*plotLineInfo{
+		{short: "❷ #loss()", coreShort: "#loss()", desc: "Mean Loss on validation", modelIdx: 1},
+		{short: "❶ #loss()", coreShort: "#loss()", desc: "Mean Loss on train", modelIdx: 0},
+		{short: "❷ #loss()", coreShort: "#loss()", desc: "Mean Loss on train", modelIdx: 1},
+		{short: "❶ #loss()", coreShort: "#loss()", desc: "Mean Loss on validation", modelIdx: 0},
+	}
+	disambiguateShortLabels(lines)
+
+	findByModelAndDesc := func(modelIdx int, desc string) *plotLineInfo {
+		for _, line := range lines {
+			if line.modelIdx == modelIdx && line.desc == desc {
+				return line
+			}
+		}
+		t.Fatalf("no line with modelIdx=%d desc=%q", modelIdx, desc)
+		return nil
+	}
+
+	trainModel0 := findByModelAndDesc(0, "Mean Loss on train")
+	trainModel1 := findByModelAndDesc(1, "Mean Loss on train")
+	require.Equal(t, trainModel0.coreShort, trainModel1.coreShort, "the same metric (train) must get the same suffix regardless of model")
+	require.Equal(t, "#loss() (train)", trainModel0.coreShort)
+
+	validationModel0 := findByModelAndDesc(0, "Mean Loss on validation")
+	validationModel1 := findByModelAndDesc(1, "Mean Loss on validation")
+	require.Equal(t, validationModel0.coreShort, validationModel1.coreShort, "the same metric (validation) must get the same suffix regardless of model")
+	require.Equal(t, "#loss() (validation)", validationModel0.coreShort)
 }
 
 // TestDisambiguateShortLabels_ThreeWayCollision checks the disambiguation counter handles more
@@ -206,7 +349,8 @@ func TestBuildPageSidebarHTML_TitleOnly(t *testing.T) {
 
 func TestBuildPageSidebarHTML_EscapesUserContent(t *testing.T) {
 	t.Parallel()
-	got := buildPageSidebarHTML(`<script>alert(1)</script>`, []legendEntry{{text: `<b>evil</b>`}}, nil)
+	got := buildPageSidebarHTML(`<script>alert(1)</script>`,
+		[]legendEntry{{term: `<b>evil</b>`, detail: "d"}}, nil)
 	require.NotContains(t, got, "<script>")
 	require.NotContains(t, got, "<b>evil</b>")
 	require.Contains(t, got, "&lt;script&gt;")
@@ -215,35 +359,142 @@ func TestBuildPageSidebarHTML_EscapesUserContent(t *testing.T) {
 func TestBuildPageSidebarHTML_ModelsAndDescriptions(t *testing.T) {
 	t.Parallel()
 	got := buildPageSidebarHTML("",
-		[]legendEntry{{modelIdx: 0, text: "#1 model-a (path/a)"}, {modelIdx: 1, text: "#2 model-b (path/b)"}},
-		[]legendEntry{{modelIdx: 0, text: "T/loss: Train: Loss"}})
+		[]legendEntry{{term: "❶ model-a", detail: "path/a"}, {term: "❷ model-b", detail: "path/b"}},
+		[]legendSection{{heading: "loss", entries: []legendEntry{{term: "T/loss", detail: "Train: Loss"}}}})
 	require.Contains(t, got, "Models compared")
-	require.Contains(t, got, "#1 model-a (path/a)")
-	require.Contains(t, got, "Metric labels")
-	require.Contains(t, got, "T/loss: Train: Loss")
+	require.Contains(t, got, "❶ model-a")
+	require.Contains(t, got, "path/a")
+	require.Contains(t, got, "Metric labels — loss")
+	require.Contains(t, got, "T/loss")
+	require.Contains(t, got, "Train: Loss")
 }
 
-// TestBuildPageSidebarHTML_SwatchesOnlyInMultiModelMode characterizes that color swatches (a
-// small colored <span>) only appear when modelEntries is non-empty -- single-model mode has
-// nothing to color-code against, so entries stay plain, matching today's simpler common case.
-func TestBuildPageSidebarHTML_SwatchesOnlyInMultiModelMode(t *testing.T) {
+// TestBuildPageSidebarHTML_GroupsDescriptionsByMetricType characterizes that each legendSection
+// renders under its own "Metric labels — <heading>" heading, rather than one flat list -- so a
+// reader looking at one chart isn't scrolling through every other chart's labels to find the ones
+// that matter.
+func TestBuildPageSidebarHTML_GroupsDescriptionsByMetricType(t *testing.T) {
 	t.Parallel()
-	singleModel := buildPageSidebarHTML("", nil, []legendEntry{{text: "T/loss: Train: Loss"}})
-	require.NotContains(t, singleModel, "border-radius:50%")
+	got := buildPageSidebarHTML("", nil, []legendSection{
+		{heading: "loss", entries: []legendEntry{{term: "T/loss", detail: "Train: Loss"}}},
+		{heading: "img_loss", entries: []legendEntry{{term: "T/~img_loss", detail: "Train: Moving Images Loss"}}},
+	})
+	require.Contains(t, got, "Metric labels — loss")
+	require.Contains(t, got, "Metric labels — img_loss")
+	// The "loss" section's heading must come before its own entry, which must come before the
+	// "img_loss" section's heading -- i.e. genuinely grouped, not just both headings present
+	// anywhere in the output.
+	lossHeading := strings.Index(got, "Metric labels — loss")
+	lossEntry := strings.Index(got, "T/loss<")
+	imgLossHeading := strings.Index(got, "Metric labels — img_loss")
+	require.True(t, lossHeading < lossEntry && lossEntry < imgLossHeading)
+}
+
+// TestBuildPageSidebarHTML_EveryRowGetsASwatch characterizes the current swatch policy for
+// "Metric labels": every row gets its own color, cycling by position -- including in single-model
+// mode, since the swatch's job is telling metrics apart (mirroring vizb's own chart legend, which
+// colors every series distinctly, and now actually uses the same colors -- see Plot), not
+// indicating which model a row belongs to.
+func TestBuildPageSidebarHTML_EveryRowGetsASwatch(t *testing.T) {
+	t.Parallel()
+	singleModel := buildPageSidebarHTML("", nil,
+		[]legendSection{{heading: "loss", entries: []legendEntry{{term: "T/loss", detail: "Train: Loss"}}}})
+	require.Contains(t, singleModel, "gomlx-swatch")
 
 	multiModel := buildPageSidebarHTML("",
-		[]legendEntry{{modelIdx: 0, text: "#1 model-a"}},
-		[]legendEntry{{modelIdx: 0, text: "T/loss: Train: Loss"}})
-	require.Contains(t, multiModel, "border-radius:50%")
-	require.Contains(t, multiModel, modelColor(0))
+		[]legendEntry{{term: "❶ model-a"}, {term: "❷ model-b"}},
+		[]legendSection{{heading: "loss", entries: []legendEntry{
+			{term: "T/loss", detail: "Train: Loss"},
+			{term: "T/~loss", detail: "Train: Moving Average Loss"},
+		}}})
+	require.Contains(t, multiModel, "gomlx-swatch")
+	require.Contains(t, multiModel, swatchColor(0))
+	require.Contains(t, multiModel, swatchColor(1))
 }
 
-func TestModelColor_DistinctAndStable(t *testing.T) {
+// TestBuildPageSidebarHTML_ModelsHaveNoSwatch characterizes that "Models compared" rows never get
+// a color swatch, unlike "Metric labels" rows -- swatchColor's cycling is scoped per list, so
+// reusing it for models would make a model's dot coincidentally match an unrelated metric's color
+// elsewhere on the page (metric colors now mirror the chart's own line colors, see Plot), implying
+// a connection that doesn't exist. The ❶/❷ marker already uniquely identifies each model.
+func TestBuildPageSidebarHTML_ModelsHaveNoSwatch(t *testing.T) {
 	t.Parallel()
-	require.NotEqual(t, modelColor(0), modelColor(1))
-	require.Equal(t, modelColor(0), modelColor(0))
+	got := buildPageSidebarHTML("",
+		[]legendEntry{{term: "❶ model-a", detail: "path/a"}, {term: "❷ model-b", detail: "path/b"}},
+		nil)
+	require.NotContains(t, got, "gomlx-swatch")
+}
+
+func TestSwatchColor_DistinctAndStable(t *testing.T) {
+	t.Parallel()
+	require.NotEqual(t, swatchColor(0), swatchColor(1))
+	require.Equal(t, swatchColor(0), swatchColor(0))
 	// Cycles once we run out of palette entries, rather than panicking.
-	require.NotPanics(t, func() { modelColor(len(modelColorPalette) + 3) })
+	require.NotPanics(t, func() { swatchColor(len(swatchPalette) + 3) })
+}
+
+// TestModelIndexMarker_CircledDigits characterizes the maintainer-requested "❶"/"❷" markers
+// (instead of "#1"/"#2", which was ambiguous next to "#" already meaning "average" in these
+// metric names) for the 1-10 range the circled-digit Unicode block covers.
+func TestModelIndexMarker_CircledDigits(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "❶", modelIndexMarker(1))
+	require.Equal(t, "❷", modelIndexMarker(2))
+	require.Equal(t, "❿", modelIndexMarker(10))
+}
+
+// TestModelIndexMarker_FallsBackPastTen checks the bracket fallback beyond the circled-digit
+// block's range, rather than an invalid/out-of-range character.
+func TestModelIndexMarker_FallsBackPastTen(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "[11]", modelIndexMarker(11))
+}
+
+func TestBuildDescriptionEntries_DedupesAcrossModels(t *testing.T) {
+	t.Parallel()
+	// Same metric ("T/~loss": "Train: Moving Average Loss"), measured on two different models --
+	// must collapse to one glossary entry, not one per model, per the maintainer's request.
+	lines := []*plotLineInfo{
+		{metricType: "loss", modelIdx: 0, coreShort: "T/~loss", desc: "Train: Moving Average Loss"},
+		{metricType: "loss", modelIdx: 1, coreShort: "T/~loss", desc: "Train: Moving Average Loss"},
+	}
+	sections := buildDescriptionEntries(lines)
+	require.Len(t, sections, 1)
+	require.Equal(t, "loss", sections[0].heading)
+	require.Len(t, sections[0].entries, 1)
+	require.Equal(t, "T/~loss", sections[0].entries[0].term)
+	require.Equal(t, "Train: Moving Average Loss", sections[0].entries[0].detail)
+}
+
+// TestBuildDescriptionEntries_GroupsByMetricType checks that lines from different metric types
+// (e.g. "loss" vs "img_loss") land in separate sections, in first-encountered order, rather than
+// one flat list -- Plot always calls createPlotLines/appends to allLines in
+// createSortedMetricTypes' order, so that's also the sections' order.
+func TestBuildDescriptionEntries_GroupsByMetricType(t *testing.T) {
+	t.Parallel()
+	lines := []*plotLineInfo{
+		{metricType: "loss", coreShort: "T/loss", desc: "Train: Loss"},
+		{metricType: "img_loss", coreShort: "T/~img_loss", desc: "Train: Moving Images Loss"},
+		{metricType: "loss", coreShort: "T/~loss", desc: "Train: Moving Average Loss"},
+	}
+	sections := buildDescriptionEntries(lines)
+	require.Len(t, sections, 2)
+	require.Equal(t, "loss", sections[0].heading)
+	require.Len(t, sections[0].entries, 2)
+	require.Equal(t, "img_loss", sections[1].heading)
+	require.Len(t, sections[1].entries, 1)
+}
+
+func TestBuildDescriptionEntries_DistinctMetricsStayDistinct(t *testing.T) {
+	t.Parallel()
+	// Different coreShort/desc pairs (even from the same model) must never collapse together.
+	lines := []*plotLineInfo{
+		{metricType: "loss", modelIdx: 0, coreShort: "#loss() (1)", desc: "Mean Loss on train"},
+		{metricType: "loss", modelIdx: 0, coreShort: "#loss() (2)", desc: "Mean Loss on validation"},
+	}
+	sections := buildDescriptionEntries(lines)
+	require.Len(t, sections, 1)
+	require.Len(t, sections[0].entries, 2)
 }
 
 func TestInjectPageExtras_NoOpWhenNothingToInject(t *testing.T) {
@@ -287,13 +538,15 @@ func TestInjectPageExtras_ModelsAndDescriptionsSurviveInBody(t *testing.T) {
 		[]byte(`<html><head><title>Vizb</title></head><body><div id="app"></div></body></html>`), 0644))
 
 	require.NoError(t, injectPageExtras(htmlPath, "",
-		[]legendEntry{{modelIdx: 0, text: "#1 model-a (dir-a)"}},
-		[]legendEntry{{modelIdx: 0, text: "T/loss: Train: Loss"}}))
+		[]legendEntry{{term: "❶ model-a", detail: "dir-a"}},
+		[]legendSection{{heading: "loss", entries: []legendEntry{{term: "T/loss", detail: "Train: Loss"}}}}))
 
 	content, err := os.ReadFile(htmlPath)
 	require.NoError(t, err)
-	require.Contains(t, string(content), "#1 model-a (dir-a)")
-	require.Contains(t, string(content), "T/loss: Train: Loss")
+	require.Contains(t, string(content), "❶ model-a")
+	require.Contains(t, string(content), "dir-a")
+	require.Contains(t, string(content), "T/loss")
+	require.Contains(t, string(content), "Train: Loss")
 }
 
 func TestInjectPageExtras_NoHeadTagReturnsError(t *testing.T) {
@@ -302,7 +555,7 @@ func TestInjectPageExtras_NoHeadTagReturnsError(t *testing.T) {
 	htmlPath := filepath.Join(dir, "plot.html")
 	require.NoError(t, os.WriteFile(htmlPath, []byte("<html>no head here<body><div id=\"app\"></div></body></html>"), 0644))
 
-	err := injectPageExtras(htmlPath, "", []legendEntry{{text: "#1 model-a (dir-a)"}}, nil)
+	err := injectPageExtras(htmlPath, "", []legendEntry{{term: "❶ model-a", detail: "dir-a"}}, nil)
 	require.Error(t, err)
 }
 
@@ -312,6 +565,6 @@ func TestInjectPageExtras_NoBodyTagReturnsError(t *testing.T) {
 	htmlPath := filepath.Join(dir, "plot.html")
 	require.NoError(t, os.WriteFile(htmlPath, []byte("<html><head><title>Vizb</title></head>no body here</html>"), 0644))
 
-	err := injectPageExtras(htmlPath, "", []legendEntry{{text: "#1 model-a (dir-a)"}}, nil)
+	err := injectPageExtras(htmlPath, "", []legendEntry{{term: "❶ model-a", detail: "dir-a"}}, nil)
 	require.Error(t, err)
 }

--- a/cmd/gomlx_checkpoints/vizb.go
+++ b/cmd/gomlx_checkpoints/vizb.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -87,10 +88,13 @@ func writeLinesAsCSV(w io.Writer, lines []*plotLineInfo) error {
 	return nil
 }
 
-// runVizbLine shapes one metric type's lines into a CSV, invokes
-// `vizb line ... --select ...`, and returns the path to the resulting
-// DataSet JSON file (written inside tmpDir).
-func runVizbLine(tmpDir, metricType string, lines []*plotLineInfo) (jsonPath string, err error) {
+// runVizbLine shapes one metric type's lines into a CSV, invokes `vizb line`, and returns the
+// path to the resulting DataSet JSON file (written inside tmpDir).
+//
+// Uses vizb's "group" mode (-g/-p put step on the X axis, --col-axis y puts column names on Y) so
+// every line for a metric type overlays on one chart with a shared, clickable legend -- vizb's
+// "solo" mode (repeated --select step,colN{label} flags) instead renders one chart per series.
+func runVizbLine(tmpDir, metricType string, lines []*plotLineInfo, lineColors []string) (jsonPath string, err error) {
 	csvPath := filepath.Join(tmpDir, metricType+".csv")
 	f, err := os.Create(csvPath)
 	if err != nil {
@@ -106,9 +110,18 @@ func runVizbLine(tmpDir, metricType string, lines []*plotLineInfo) (jsonPath str
 	}
 
 	jsonPath = filepath.Join(tmpDir, metricType+".json")
-	args := []string{"line", csvPath, "-o", jsonPath, "-n", metricType}
+	selectCols := make([]string, len(lines))
 	for i, line := range lines {
-		args = append(args, "--select", fmt.Sprintf("step,col%d{%s}", i, line.short))
+		selectCols[i] = fmt.Sprintf("col%d{%s}", i, line.short)
+	}
+	args := []string{
+		"line", csvPath, "-o", jsonPath, "-n", metricType,
+		"-g", "step", "-p", "x", "--col-axis", "y",
+		"--select", strings.Join(selectCols, ","),
+		"--smooth", // curve-smoothed lines rather than piecewise-linear segments between points.
+	}
+	if len(lineColors) > 0 {
+		args = append(args, "--theme", strings.Join(lineColors, ","))
 	}
 
 	cmd := exec.Command("vizb", args...)

--- a/cmd/gomlx_checkpoints/vizb_test.go
+++ b/cmd/gomlx_checkpoints/vizb_test.go
@@ -5,8 +5,10 @@ package main
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -100,6 +102,41 @@ func TestWriteLinesAsCSV_StepsOutOfOrderInSource(t *testing.T) {
 // These skip cleanly (not fail) if vizb isn't installed, e.g. in CI -- --plot
 // is a soft dependency, and these tests reflect that.
 
+// TestRunVizbLine_AppliesLineColorsAsTheme locks in the --theme wiring (see Plot): confirmed by
+// hand that vizb embeds a bare comma-separated hex list into the DataSet JSON's "themes" field,
+// in the exact order given, including repeating the same hex at two positions when two lines
+// should share a color -- this is what lets the chart's own line colors match the sidebar's
+// per-metric swatches instead of being an unrelated, internally-assigned palette.
+func TestRunVizbLine_AppliesLineColorsAsTheme(t *testing.T) {
+	if err := checkVizbAvailable(); err != nil {
+		t.Skip("vizb not installed, skipping integration test:", err)
+	}
+	tmpDir := t.TempDir()
+	lines := []*plotLineInfo{
+		{short: "Alpha", steps: []float64{0, 1}, values: []float64{0.1, 0.2}},
+		{short: "Beta", steps: []float64{0, 1}, values: []float64{0.3, 0.4}},
+		{short: "Gamma", steps: []float64{0, 1}, values: []float64{0.5, 0.6}},
+	}
+	// Alpha and Gamma deliberately share a color, Beta gets a different one -- exercises both the
+	// "two lines, one color" case (e.g. one metric shared by two models) and a genuinely distinct
+	// color in the same call.
+	colors := []string{"#2a78d6", "#eb6834", "#2a78d6"}
+
+	jsonPath, err := runVizbLine(tmpDir, "loss", lines, colors)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(jsonPath)
+	require.NoError(t, err)
+	var doc struct {
+		Themes []struct {
+			Colors []string `json:"colors"`
+		} `json:"themes"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	require.Len(t, doc.Themes, 1)
+	require.Equal(t, colors, doc.Themes[0].Colors)
+}
+
 func TestRunVizbLine_RealVizb(t *testing.T) {
 	if err := checkVizbAvailable(); err != nil {
 		t.Skip("vizb not installed, skipping integration test:", err)
@@ -110,7 +147,7 @@ func TestRunVizbLine_RealVizb(t *testing.T) {
 		{short: "Eval", steps: []float64{0, 100, 200}, values: []float64{0.85, 0.45, 0.25}},
 	}
 
-	jsonPath, err := runVizbLine(tmpDir, "loss", lines)
+	jsonPath, err := runVizbLine(tmpDir, "loss", lines, nil)
 	require.NoError(t, err)
 	require.FileExists(t, jsonPath)
 
@@ -119,11 +156,137 @@ func TestRunVizbLine_RealVizb(t *testing.T) {
 	content := string(data)
 	require.Contains(t, content, "Train")
 	require.Contains(t, content, "Eval")
-	// All 3 steps must be present -- i.e. not aggregated away (the exact
-	// failure mode of vizb's --group mode, which this recipe deliberately avoids).
+	// All 3 steps must be present -- i.e. not aggregated away. Group mode's
+	// aggregation only sums rows sharing the same key; since each (step,
+	// series) pair is unique here, there's nothing to sum, so nothing is lost.
 	require.Contains(t, content, `"xAxis":"0"`)
 	require.Contains(t, content, `"xAxis":"100"`)
 	require.Contains(t, content, `"xAxis":"200"`)
+}
+
+// dataSetEntry mirrors the shape of one entry in vizb's group-mode DataSet JSON "data" array
+// (--col-axis y): {"xAxis":"<step>","yAxis":"<series>","stats":[{"value":<v>}]}.
+type dataSetEntry struct {
+	XAxis string `json:"xAxis"`
+	YAxis string `json:"yAxis"`
+}
+
+func parseDataSetEntries(t *testing.T, jsonPath string) []dataSetEntry {
+	t.Helper()
+	data, err := os.ReadFile(jsonPath)
+	require.NoError(t, err)
+	var doc struct {
+		Data []dataSetEntry `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	return doc.Data
+}
+
+// TestRunVizbLine_SeriesOnYAxis characterizes the group-mode shape (-g step -p x --col-axis y)
+// runVizbLine uses: every line's name lands on "yAxis", not as a per-series "type" key the way
+// solo mode did. This is what lets vizb's chart renderer overlay every series of one metric type
+// on a single chart with a shared, clickable legend -- solo mode's DataSet JSON also grouped
+// every line under one dataset, but vizb's `-c line` chart type rendered that as one chart *per
+// series* instead (confirmed both by asking vizb's maintainers directly and by hands-on browser
+// testing against real multi-series data).
+func TestRunVizbLine_SeriesOnYAxis(t *testing.T) {
+	if err := checkVizbAvailable(); err != nil {
+		t.Skip("vizb not installed, skipping integration test:", err)
+	}
+	tmpDir := t.TempDir()
+	lines := []*plotLineInfo{
+		{short: "Train", steps: []float64{0, 100}, values: []float64{0.9, 0.5}},
+		{short: "Eval", steps: []float64{0, 100}, values: []float64{0.85, 0.45}},
+	}
+
+	jsonPath, err := runVizbLine(tmpDir, "loss", lines, nil)
+	require.NoError(t, err)
+	entries := parseDataSetEntries(t, jsonPath)
+
+	seriesNames := make(map[string]bool)
+	for _, e := range entries {
+		seriesNames[e.YAxis] = true
+	}
+	require.Equal(t, map[string]bool{"Train": true, "Eval": true}, seriesNames)
+	require.Len(t, entries, 4) // 2 series x 2 steps, none missing.
+}
+
+// TestRunVizbLine_MisalignedStepsOmitMissingSeries verifies, against the real vizb binary (not
+// just writeLinesAsCSV's own unit tests), that a step where one series has no value (a blank CSV
+// cell -- see writeLinesAsCSV) is correctly omitted from that series' data rather than being
+// turned into a zero or causing an error. This was verified by hand first, against the real
+// fixture data that originally motivated the group-mode switch, before being locked in here.
+func TestRunVizbLine_MisalignedStepsOmitMissingSeries(t *testing.T) {
+	if err := checkVizbAvailable(); err != nil {
+		t.Skip("vizb not installed, skipping integration test:", err)
+	}
+	tmpDir := t.TempDir()
+	// Train logged every step, Eval only at step 100 -- step 50's cell for Eval is blank.
+	lines := []*plotLineInfo{
+		{short: "Train", steps: []float64{50, 100}, values: []float64{0.7, 0.5}},
+		{short: "Eval", steps: []float64{100}, values: []float64{0.45}},
+	}
+
+	jsonPath, err := runVizbLine(tmpDir, "loss", lines, nil)
+	require.NoError(t, err)
+	entries := parseDataSetEntries(t, jsonPath)
+
+	var step50Series []string
+	for _, e := range entries {
+		if e.XAxis == "50" {
+			step50Series = append(step50Series, e.YAxis)
+		}
+	}
+	require.Equal(t, []string{"Train"}, step50Series)
+}
+
+// TestRunVizbLine_PreservesNarrowRangePrecision guards against a `vizb line` regression: older
+// versions (< v0.18.0) rounded every value to a fixed 2 decimal places during CSV->JSON
+// conversion, silently collapsing genuinely different, closely-spaced values -- e.g. a converging
+// loss curve -- into an identical, flat-looking value. Fixed upstream, confirmed in
+// https://github.com/goptics/vizb/issues/336#issuecomment-5191941764. Uses the exact values that
+// first exposed the bug (all 5 used to round to 0.91).
+func TestRunVizbLine_PreservesNarrowRangePrecision(t *testing.T) {
+	if err := checkVizbAvailable(); err != nil {
+		t.Skip("vizb not installed, skipping integration test:", err)
+	}
+	tmpDir := t.TempDir()
+	values := []float64{0.914273581, 0.913891247, 0.912456839, 0.910128475, 0.909983221}
+	lines := []*plotLineInfo{
+		{short: "Train", steps: []float64{1, 2, 3, 4, 5}, values: values},
+	}
+
+	jsonPath, err := runVizbLine(tmpDir, "loss", lines, nil)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(jsonPath)
+	require.NoError(t, err)
+	var doc struct {
+		Data []struct {
+			XAxis string `json:"xAxis"`
+			Stats []struct {
+				Value float64 `json:"value"`
+			} `json:"stats"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	require.Len(t, doc.Data, 5)
+
+	seen := make(map[float64]bool)
+	for _, entry := range doc.Data {
+		require.Len(t, entry.Stats, 1)
+		seen[entry.Stats[0].Value] = true
+	}
+	// On the buggy version, all 5 collapse to the single rounded value 0.91.
+	require.Greaterf(t, len(seen), 1, "all 5 distinct values collapsed to the same rounded value: %v", seen)
+
+	// Values should pass through essentially untouched (full float64 round-trip via CSV text).
+	for i, entry := range doc.Data {
+		step, err := strconv.Atoi(entry.XAxis)
+		require.NoError(t, err)
+		want := values[step-1]
+		require.InDelta(t, want, entry.Stats[0].Value, 1e-9, "point %d", i)
+	}
 }
 
 func TestMergeAndRenderVizb_MultipleTypes(t *testing.T) {
@@ -133,11 +296,11 @@ func TestMergeAndRenderVizb_MultipleTypes(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	lossJSON, err := runVizbLine(tmpDir, "loss",
-		[]*plotLineInfo{{short: "Train", steps: []float64{0, 100}, values: []float64{0.9, 0.5}}})
+		[]*plotLineInfo{{short: "Train", steps: []float64{0, 100}, values: []float64{0.9, 0.5}}}, nil)
 	require.NoError(t, err)
 
 	accJSON, err := runVizbLine(tmpDir, "accuracy",
-		[]*plotLineInfo{{short: "Train", steps: []float64{0, 100}, values: []float64{0.5, 0.9}}})
+		[]*plotLineInfo{{short: "Train", steps: []float64{0, 100}, values: []float64{0.5, 0.9}}}, nil)
 	require.NoError(t, err)
 
 	outPath := filepath.Join(tmpDir, "final.html")
@@ -157,7 +320,7 @@ func TestMergeAndRenderVizb_SingleType(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	lossJSON, err := runVizbLine(tmpDir, "loss",
-		[]*plotLineInfo{{short: "Train", steps: []float64{0, 100}, values: []float64{0.9, 0.5}}})
+		[]*plotLineInfo{{short: "Train", steps: []float64{0, 100}, values: []float64{0.9, 0.5}}}, nil)
 	require.NoError(t, err)
 
 	outPath := filepath.Join(tmpDir, "final.html")


### PR DESCRIPTION
This is a continuation of #452 (closed). Addresses review feedback:
restores inline comments that were removed during the AI-assisted rewrite.
