### PR TITLE
Fix variable handling in graphs for backends preferring constants

### DIFF
--- a/ml/model/store.go
+++ b/ml/model/store.go
@@ -571,12 +571,17 @@ const GraphParamIsTraining = "training"
 
 // IsTraining returns whether current Store (and thus this Scope) is being used for training.
 func (s *Store) IsTraining(g *Graph) bool {
-	return GetGraphParamOr(s.RootScope(), g, GraphParamIsTraining, false)
+	val, found := GetGraphParam(g, ScopeSeparator+GraphParamIsTraining)
+	if !found || val == nil {
+		return false
+	}
+	isTraining, _ := val.(bool)
+	return isTraining
 }
 
 // SetTraining marks the current Store (and thus this Scope) for the given graph as training.
 func (s *Store) SetTraining(g *Graph, value bool) {
-	s.RootScope().SetGraphParam(g, GraphParamIsTraining, value)
+	SetGraphParam(g, ScopeSeparator+GraphParamIsTraining, value)
 }
 
 // SetParams sets a collection of parameters in the current scope.

--- a/ml/model/variable.go
+++ b/ml/model/variable.go
@@ -541,9 +541,21 @@ func (v *Variable) paramNode(g *Graph) (*Node, error) {
 		return nodes.paramNode, nil
 	}
 
-	if v.store != nil && v.store.variablesAsConst {
+	useConst := false
+	if v.store != nil {
+		if v.store.variablesAsConst {
+			useConst = true
+		} else if backend := g.Backend(); backend != nil && backend.Capabilities().PreferConstantsForVariables {
+			// If backend prefers constants for variables, only embed as constant if NOT in training mode and variable is non-trainable.
+			if !v.store.IsTraining(g) && !v.Trainable {
+				useConst = true
+			}
+		}
+	}
+
+	if useConst {
 		if !v.HasValue() {
-			return nil, errors.Errorf("variable %q has no value initialized when Store.WithVariableAsConst is set to true", v.Path())
+			return nil, errors.Errorf("variable %q has no value initialized when embedding as constant graph node", v.Path())
 		}
 		val, err := v.Value()
 		if err != nil {


### PR DESCRIPTION
## Summary

Refactors variable graph node handling and training flag lookup in `ml/model`.

### Key Changes

1. **Selective Constant Embedding for Backends**:
   - In `ml/model/variable.go` (`paramNode`), when a backend specifies `Capabilities().PreferConstantsForVariables`, variables are now embedded as constants only when **not** in training mode (`!store.IsTraining(g)`) and the variable is non-trainable (`!v.Trainable`).
   - Improved the error message when a variable value is uninitialized when attempting to embed as a constant graph node.

2. **Store Training Flag Lookup**:
   - In `ml/model/store.go`, updated `Store.IsTraining` and `Store.SetTraining` to access graph parameters directly via the root scope parameter path (`ScopeSeparator + GraphParamIsTraining`) using `GetGraphParam` and `SetGraphParam`.